### PR TITLE
perf(otelstorage): optimize allocations in `Hash`

### DIFF
--- a/internal/otelstorage/hash.go
+++ b/internal/otelstorage/hash.go
@@ -25,13 +25,6 @@ func AttrHash(m pcommon.Map) Hash {
 	return h.Sum128().Bytes()
 }
 
-// StrHash computes string hash.
-func StrHash(s string) Hash {
-	h := xxh3.New()
-	_, _ = h.WriteString(s)
-	return h.Sum128().Bytes()
-}
-
 func hashValue(h *xxh3.Hasher, val pcommon.Value) {
 	var buf [8]byte
 
@@ -76,7 +69,12 @@ func hashMap(h *xxh3.Hasher, m pcommon.Map) {
 		key   string
 		value pcommon.Value
 	}
-	pairs := make([]pair, 0, m.Len())
+	var pairs []pair
+	if l := m.Len(); l < 16 {
+		pairs = make([]pair, 0, 16)
+	} else {
+		pairs = make([]pair, 0, m.Len())
+	}
 	m.Range(func(k string, v pcommon.Value) bool {
 		pairs = append(pairs, pair{
 			key:   k,

--- a/internal/otelstorage/hash_test.go
+++ b/internal/otelstorage/hash_test.go
@@ -11,5 +11,32 @@ func TestHash(t *testing.T) {
 	m := pcommon.NewMap()
 	m.PutStr("foo", "bar")
 	require.NotEqual(t, AttrHash(m), Hash{})
-	require.NotEqual(t, StrHash("foo"), Hash{})
+}
+
+func BenchmarkHash(b *testing.B) {
+	m := pcommon.NewMap()
+	m.PutStr("net.transport", "ip_tcp")
+	m.PutStr("net.sock.family", "inet")
+	m.PutStr("net.sock.host.addr", "192.168.210.83")
+	m.PutStr("net.host.name", "shop-backend.local")
+	m.PutStr("http.flavor", "1.1")
+	m.PutStr("http.method", "PUT")
+	m.PutInt("http.status_code", 204)
+	m.PutStr("http.url", "https://shop-backend.local:8409/article-to-cart")
+	m.PutStr("http.scheme", "https")
+	m.PutStr("http.target", "/article-to-cart")
+	m.PutInt("http.response_content_length", 937939)
+	m.PutInt("http.request_content_length", 39543)
+
+	var sink Hash
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sink = AttrHash(m)
+	}
+
+	if sink == (Hash{}) {
+		b.Fatal("hash is zero")
+	}
 }


### PR DESCRIPTION
For #293.

```
                 │   old.txt   │               new.txt               │
                 │   sec/op    │   sec/op     vs base                │
_metricsBatch-32   1.257m ± 0%   1.095m ± 1%  -12.83% (p=0.000 n=15)

                 │   old.txt    │               new.txt                │
                 │     B/op     │     B/op      vs base                │
_metricsBatch-32   511.2Ki ± 0%   290.8Ki ± 0%  -43.11% (p=0.000 n=15)

                 │   old.txt   │               new.txt               │
                 │  allocs/op  │  allocs/op   vs base                │
_metricsBatch-32   7.894k ± 0%   6.280k ± 0%  -20.45% (p=0.000 n=15)
```