### PR TITLE
perf(chstorage): do not make an unnecessary copy of encoded attributes

### DIFF
--- a/internal/chstorage/attributes.go
+++ b/internal/chstorage/attributes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 	"github.com/go-faster/errors"
+	"github.com/go-faster/jx"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"golang.org/x/exp/maps"
 
@@ -68,7 +69,13 @@ func (a *attributeCol) Append(v otelstorage.Attrs) {
 	if !ok {
 		idx = len(a.hashes)
 		a.hashes[h] = idx
-		a.index.Append(encodeAttributes(v.AsMap()))
+
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+		encodeMap(e, v.AsMap())
+
+		// Append will copy passed bytes.
+		a.index.Append(e.Bytes())
 	}
 	a.col.AppendKey(idx)
 }

--- a/internal/chstorage/attributes_json.go
+++ b/internal/chstorage/attributes_json.go
@@ -9,8 +9,6 @@ import (
 
 type lazyAttributes struct {
 	orig pcommon.Map
-
-	encoded []byte
 }
 
 func (l *lazyAttributes) Attributes(additional ...[2]string) otelstorage.Attrs {
@@ -23,18 +21,6 @@ func (l *lazyAttributes) Attributes(additional ...[2]string) otelstorage.Attrs {
 		return otelstorage.Attrs(target)
 	}
 	return otelstorage.Attrs(l.orig)
-}
-
-func (l *lazyAttributes) Encode(additional ...[2]string) []byte {
-	switch {
-	case len(additional) > 0:
-		return encodeAttributes(l.orig, additional...)
-	case len(l.encoded) > 0:
-		return l.encoded
-	default:
-		l.encoded = encodeAttributes(l.orig)
-		return l.encoded
-	}
 }
 
 func encodeAttributes(attrs pcommon.Map, additional ...[2]string) []byte {


### PR DESCRIPTION
For #293.

```          
                 │   old.txt    │               new.txt               │
                 │    sec/op    │   sec/op     vs base                │
_metricsBatch-32   1059.2µ ± 0%   824.0µ ± 1%  -22.21% (p=0.000 n=15)

                 │    old.txt     │               new.txt                │
                 │      B/op      │     B/op      vs base                │
_metricsBatch-32   290.716Ki ± 0%   4.317Ki ± 0%  -98.51% (p=0.000 n=15)

                 │   old.txt    │              new.txt               │
                 │  allocs/op   │ allocs/op   vs base                │
_metricsBatch-32   6280.00 ± 0%   16.00 ± 0%  -99.75% (p=0.000 n=15)
```