### PR TITLE
perf(logqlengine): use simple prefix tree to match JSON paths

### DIFF
--- a/internal/logql/logqlengine/jsonexpr/eval.go
+++ b/internal/logql/logqlengine/jsonexpr/eval.go
@@ -70,8 +70,8 @@ func (e *extractor) walkObj(n *selectorNode, d *jx.Decoder) error {
 		return err
 	}
 
-	return d.Obj(func(d *jx.Decoder, key string) error {
-		child, ok := n.sub[KeySel(key)]
+	return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+		child, ok := n.key[string(key)]
 		if !ok {
 			return d.Skip()
 		}
@@ -90,7 +90,7 @@ func (e *extractor) walkArr(n *selectorNode, d *jx.Decoder) error {
 
 	c := 0
 	return d.Arr(func(d *jx.Decoder) error {
-		child, ok := n.sub[IndexSel(c)]
+		child, ok := n.index[c]
 		if !ok {
 			return d.Skip()
 		}

--- a/internal/logql/logqlengine/jsonexpr/eval.go
+++ b/internal/logql/logqlengine/jsonexpr/eval.go
@@ -11,125 +11,128 @@ import (
 // Extract extracts values from given paths using extract callback.
 func Extract(
 	d *jx.Decoder,
-	paths map[logql.Label]Path,
+	paths SelectorTree,
 	extract func(logql.Label, string),
 ) error {
 	e := extractor{
-		// TODO(tdakkota): re-use slice?
-		current: make(Path, 0, 16),
 		paths:   paths,
 		extract: extract,
 	}
-	return e.walk(d)
+	return e.walk(e.paths.root, d)
 }
 
 // extractor extracts values from JSON value.
 type extractor struct {
-	current Path
-	paths   map[logql.Label]Path
+	paths   SelectorTree
 	extract func(logql.Label, string)
 }
 
-func (e *extractor) walk(d *jx.Decoder) error {
+func (e *extractor) walk(n *selectorNode, d *jx.Decoder) error {
 	switch d.Next() {
 	case jx.String:
 		val, err := d.Str()
 		if err != nil {
 			return err
 		}
-		e.matchLiteral(val)
+		e.matchLiteral(n, val)
 		return nil
 	case jx.Number:
 		num, err := d.Num()
 		if err != nil {
 			return err
 		}
-		e.matchLiteral(string(num))
+		e.matchLiteral(n, string(num))
 		return nil
 	case jx.Null:
 		if err := d.Null(); err != nil {
 			return err
 		}
-		e.matchLiteral("")
+		e.matchLiteral(n, "")
 		return nil
 	case jx.Bool:
 		val, err := d.Bool()
 		if err != nil {
 			return err
 		}
-		e.matchLiteral(strconv.FormatBool(val))
+		e.matchLiteral(n, strconv.FormatBool(val))
 		return nil
 	case jx.Array:
-		return e.walkArr(d)
+		return e.walkArr(n, d)
 	case jx.Object:
-		return e.walkObj(d)
+		return e.walkObj(n, d)
 	default:
 		return d.Skip()
 	}
 }
 
-func (e *extractor) walkObj(d *jx.Decoder) error {
-	if err := e.tryMatchRaw(d); err != nil {
+func (e *extractor) walkObj(n *selectorNode, d *jx.Decoder) error {
+	if err := e.tryMatchRaw(n, d); err != nil {
 		return err
 	}
 
 	return d.Obj(func(d *jx.Decoder, key string) error {
-		e.current = append(e.current, KeySel(key))
-		if err := e.walk(d); err != nil {
+		child, ok := n.sub[KeySel(key)]
+		if !ok {
+			return d.Skip()
+		}
+
+		if err := e.walk(child, d); err != nil {
 			return err
 		}
-		e.current = e.current[:len(e.current)-1]
 		return nil
 	})
 }
 
-func (e *extractor) walkArr(d *jx.Decoder) error {
-	if err := e.tryMatchRaw(d); err != nil {
+func (e *extractor) walkArr(n *selectorNode, d *jx.Decoder) error {
+	if err := e.tryMatchRaw(n, d); err != nil {
 		return err
 	}
 
-	n := 0
+	c := 0
 	return d.Arr(func(d *jx.Decoder) error {
-		e.current = append(e.current, IndexSel(n))
-		if err := e.walk(d); err != nil {
+		child, ok := n.sub[IndexSel(c)]
+		if !ok {
+			return d.Skip()
+		}
+
+		if err := e.walk(child, d); err != nil {
 			return err
 		}
-		e.current = e.current[:len(e.current)-1]
-		n++
+		c++
 		return nil
 	})
 }
 
-func (e *extractor) matchLiteral(val string) {
-	for label, p := range e.paths {
-		if e.current.Equal(p) {
-			e.extract(label, val)
-		}
+func (e *extractor) matchLiteral(n *selectorNode, val string) {
+	for _, label := range n.labels {
+		e.extract(label, val)
 	}
 }
 
-func (e *extractor) tryMatchRaw(d *jx.Decoder) error {
-	var raw string
-	for label, p := range e.paths {
-		if !e.current.Equal(p) {
-			// No match.
-			continue
-		}
+func (e *extractor) tryMatchRaw(n *selectorNode, d *jx.Decoder) error {
+	if len(n.labels) == 0 {
+		return nil
+	}
 
-		if raw == "" {
-			if err := d.Capture(func(d *jx.Decoder) error {
-				data, err := d.Raw()
-				if err != nil {
-					return err
-				}
-				raw = string(data)
-				return nil
-			}); err != nil {
-				return err
-			}
+	var (
+		raw string
+		got bool
+	)
+	if err := d.Capture(func(d *jx.Decoder) error {
+		data, err := d.Raw()
+		if err != nil {
+			return err
 		}
-
-		e.extract(label, raw)
+		raw = string(data)
+		got = true
+		return nil
+	}); err != nil {
+		return err
+	}
+	if got {
+		for _, label := range n.labels {
+			e.extract(label, raw)
+		}
 	}
 	return nil
 }

--- a/internal/logql/logqlengine/jsonexpr/eval_test.go
+++ b/internal/logql/logqlengine/jsonexpr/eval_test.go
@@ -86,6 +86,33 @@ func TestExtract(t *testing.T) {
 			},
 			false,
 		},
+		{
+			`{
+				"a": {"b": "correct"},
+				"a.b": "wrong"
+			}`,
+			parseExprs(t,
+				"a.b",
+			),
+			map[logql.Label]string{
+				"a.b": "correct",
+			},
+			false,
+		},
+		{
+			`{
+				"a": ["correct", "wrong"],
+				"a.0": "wrong",
+				"a[0]": "wrong"
+			}`,
+			parseExprs(t,
+				"a[0]",
+			),
+			map[logql.Label]string{
+				"a[0]": "correct",
+			},
+			false,
+		},
 
 		// Invalid JSON.
 		{
@@ -151,7 +178,7 @@ func TestExtract(t *testing.T) {
 
 			err := Extract(
 				d,
-				tt.paths,
+				MakeSelectorTree(tt.paths),
 				func(l logql.Label, s string) {
 					got[l] = s
 				},
@@ -192,9 +219,9 @@ func FuzzExtract(f *testing.F) {
 
 		_ = Extract(
 			jx.DecodeBytes(input),
-			map[logql.Label]Path{
+			MakeSelectorTree(map[logql.Label]Path{
 				"fuzz": sel,
-			},
+			}),
 			func(l logql.Label, s string) {},
 		)
 	})

--- a/internal/logql/logqlengine/jsonexpr/jsonexpr.go
+++ b/internal/logql/logqlengine/jsonexpr/jsonexpr.go
@@ -3,7 +3,6 @@ package jsonexpr
 
 import (
 	"io"
-	"slices"
 	"strconv"
 	"text/scanner"
 	"unicode/utf8"
@@ -15,11 +14,6 @@ import (
 
 // Path is a list of selectors.
 type Path []Selector
-
-// Equal compares p to other.
-func (p Path) Equal(other Path) bool {
-	return slices.Equal(p, other)
-}
 
 // SelectorType is a [Selector] type.
 type SelectorType int

--- a/internal/logql/logqlengine/jsonexpr/selector_tree.go
+++ b/internal/logql/logqlengine/jsonexpr/selector_tree.go
@@ -1,0 +1,55 @@
+package jsonexpr
+
+import (
+	"slices"
+
+	"github.com/go-faster/oteldb/internal/logql"
+)
+
+// SelectorTree is a simple prefix tree of selectors. Efficient for matching multiple JSON paths.
+type SelectorTree struct {
+	root *selectorNode
+}
+
+// IsEmpty returns true if the tree is empty.
+func (p SelectorTree) IsEmpty() bool {
+	return p.root == nil || len(p.root.sub) == 0
+}
+
+type selectorNode struct {
+	labels []logql.Label
+	sub    map[Selector]*selectorNode
+}
+
+// MakeSelectorTree creates a new SelectorTree from the given paths.
+func MakeSelectorTree(paths map[logql.Label]Path) SelectorTree {
+	if len(paths) == 0 {
+		return SelectorTree{}
+	}
+
+	root := &selectorNode{}
+	for label, p := range paths {
+		n := root
+		for i, s := range p {
+			nn, ok := n.sub[s]
+			if !ok {
+				nn = &selectorNode{}
+			}
+
+			if i == len(p)-1 {
+				if !slices.Contains(nn.labels, label) {
+					nn.labels = append(nn.labels, label)
+				}
+			}
+
+			if n.sub == nil {
+				n.sub = map[Selector]*selectorNode{}
+			}
+			n.sub[s] = nn
+			n = nn
+		}
+	}
+	return SelectorTree{
+		root: root,
+	}
+}

--- a/internal/logql/logqlengine/jsonexpr/selector_tree_test.go
+++ b/internal/logql/logqlengine/jsonexpr/selector_tree_test.go
@@ -1,0 +1,11 @@
+package jsonexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectorTree(t *testing.T) {
+	require.True(t, MakeSelectorTree(nil).IsEmpty())
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/go-faster/oteldb/internal/logql/logqlengine
cpu: AMD Ryzen 9 5950X 16-Core Processor            
                           │   old.txt    │               new.txt               │
                           │    sec/op    │   sec/op     vs base                │
JSONExtractor/JMESPaths-32   2122.0n ± 1%   810.1n ± 1%  -61.82% (p=0.000 n=15)

                           │   old.txt    │                new.txt                │
                           │     B/s      │     B/s       vs base                 │
JSONExtractor/JMESPaths-32   151.9Mi ± 1%   397.9Mi ± 1%  +161.94% (p=0.000 n=15)

                           │  old.txt   │              new.txt               │
                           │    B/op    │    B/op     vs base                │
JSONExtractor/JMESPaths-32   888.0 ± 0%   170.0 ± 0%  -80.86% (p=0.000 n=15)

                           │   old.txt   │              new.txt               │
                           │  allocs/op  │ allocs/op   vs base                │
JSONExtractor/JMESPaths-32   36.000 ± 0%   9.000 ± 0%  -75.00% (p=0.000 n=15)
```