### PR TITLE
feat(otelbench): add dashboard benchmark command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage.txt
 /requests.rwq
 /report.yml
 /otelbench
+
+.gemini/
+gha-creds-*.json

--- a/cmd/otelbench/dashboard.go
+++ b/cmd/otelbench/dashboard.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newDashboardCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Suite for dashboard benchmarks",
+	}
+	cmd.AddCommand(
+		newDashboardBenchmarkCommand(),
+	)
+	return cmd
+}

--- a/cmd/otelbench/dashboard_bench.go
+++ b/cmd/otelbench/dashboard_bench.go
@@ -1,0 +1,490 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/schollz/progressbar/v3"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-faster/oteldb/internal/lokiapi"
+	"github.com/go-faster/oteldb/internal/promapi"
+	"github.com/go-faster/oteldb/internal/tempoapi"
+)
+
+type DashboardBenchmark struct {
+	Input  string
+	Output string
+
+	PromAddr  string
+	LokiAddr  string
+	TempoAddr string
+
+	Count  int
+	Warmup int
+
+	StartTime string
+	EndTime   string
+	Step      string
+
+	Variables []string
+
+	promClient  *promapi.Client
+	lokiClient  *lokiapi.Client
+	tempoClient *tempoapi.Client
+
+	start time.Time
+	end   time.Time
+
+	vars map[string]string
+}
+
+func (b *DashboardBenchmark) Run(ctx context.Context) error {
+	if err := b.setup(ctx); err != nil {
+		return errors.Wrap(err, "setup")
+	}
+
+	dashboard, err := b.loadDashboard()
+	if err != nil {
+		return errors.Wrap(err, "load dashboard")
+	}
+
+	queries := b.extractQueries(dashboard)
+	if len(queries) == 0 {
+		return errors.New("no queries found in dashboard")
+	}
+
+	fmt.Printf("found %d queries in %d panels\n", len(queries), len(dashboard.Panels))
+
+	total := len(queries) * (b.Count + b.Warmup)
+	pb := progressbar.Default(int64(total))
+
+	var results []queryResult
+	for _, q := range queries {
+		res := queryResult{
+			Query: q,
+		}
+
+		// Warmup
+		for i := 0; i < b.Warmup; i++ {
+			start := time.Now()
+			isEmpty, n, err := b.execute(ctx, q)
+			if err != nil {
+				return errors.Wrapf(err, "warmup query %q", q.Expr)
+			}
+			res.Empty = isEmpty
+			res.N = n
+			dur := time.Since(start)
+			if i == 0 {
+				res.First = dur
+			}
+			_ = pb.Add(1)
+		}
+
+		// Benchmark
+		var durations []time.Duration
+		for i := 0; i < b.Count; i++ {
+			start := time.Now()
+			isEmpty, n, err := b.execute(ctx, q)
+			if err != nil {
+				return errors.Wrapf(err, "execute query %q", q.Expr)
+			}
+			res.Empty = isEmpty
+			res.N = n
+			dur := time.Since(start)
+			if i == 0 && b.Warmup == 0 {
+				res.First = dur
+			}
+			durations = append(durations, dur)
+			_ = pb.Add(1)
+		}
+
+		if len(durations) > 0 {
+			var totalDur time.Duration
+			min := durations[0]
+			max := durations[0]
+			for _, d := range durations {
+				totalDur += d
+				if d < min {
+					min = d
+				}
+				if d > max {
+					max = d
+				}
+			}
+			res.Avg = totalDur / time.Duration(len(durations))
+			res.Min = min
+			res.Max = max
+
+			slices.Sort(durations)
+			res.P99 = durations[len(durations)*99/100]
+		}
+
+		results = append(results, res)
+	}
+	_ = pb.Finish()
+
+	return b.report(results)
+}
+
+func (b *DashboardBenchmark) setup(_ context.Context) (err error) {
+	if b.promClient, err = promapi.NewClient(b.PromAddr); err != nil {
+		return errors.Wrap(err, "setup prometheus client")
+	}
+	if b.lokiClient, err = lokiapi.NewClient(b.LokiAddr); err != nil {
+		return errors.Wrap(err, "setup loki client")
+	}
+	if b.tempoClient, err = tempoapi.NewClient(b.TempoAddr); err != nil {
+		return errors.Wrap(err, "setup tempo client")
+	}
+
+	if b.start, err = parseTime(b.StartTime); err != nil {
+		return errors.Wrap(err, "parse start time")
+	}
+	if b.end, err = parseTime(b.EndTime); err != nil {
+		return errors.Wrap(err, "parse end time")
+	}
+
+	b.vars = map[string]string{
+		"__interval":      "15s",
+		"__rate_interval": "5m",
+		"__range":         "1h",
+	}
+	for _, v := range b.Variables {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return errors.Errorf("invalid variable %q", v)
+		}
+		b.vars[parts[0]] = parts[1]
+	}
+
+	return nil
+}
+
+type queryType string
+
+const (
+	promQL  queryType = "promql"
+	logQL   queryType = "logql"
+	traceQL queryType = "traceql"
+)
+
+type extractedQuery struct {
+	Panel string
+	Expr  string
+	Type  queryType
+}
+
+type queryResult struct {
+	Query extractedQuery
+	Empty bool
+	N     int
+	First time.Duration
+	Avg   time.Duration
+	Min   time.Duration
+	Max   time.Duration
+	P99   time.Duration
+}
+
+func (b *DashboardBenchmark) loadDashboard() (*grafanaDashboard, error) {
+	f, err := os.Open(b.Input)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var d grafanaDashboard
+	if err := json.NewDecoder(f).Decode(&d); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (b *DashboardBenchmark) extractQueries(d *grafanaDashboard) []extractedQuery {
+	var queries []extractedQuery
+	for _, p := range d.Panels {
+		for _, t := range p.Targets {
+			typ := b.identifyType(t)
+			if typ == "" {
+				continue
+			}
+			expr := t.Expr
+			if expr == "" {
+				expr = t.Query
+			}
+			if expr == "" {
+				continue
+			}
+
+			expr = b.interpolate(expr)
+			queries = append(queries, extractedQuery{
+				Panel: p.Title,
+				Expr:  expr,
+				Type:  typ,
+			})
+		}
+	}
+	return queries
+}
+
+func (b *DashboardBenchmark) identifyType(t grafanaTarget) queryType {
+	dsType := strings.ToLower(t.Datasource.Type)
+	if dsType == "" {
+		dsType = strings.ToLower(fmt.Sprint(t.Datasource))
+	}
+
+	switch {
+	case strings.Contains(dsType, "prometheus"):
+		return promQL
+	case strings.Contains(dsType, "loki"):
+		return logQL
+	case strings.Contains(dsType, "tempo"):
+		return traceQL
+	default:
+		return ""
+	}
+}
+
+func (b *DashboardBenchmark) interpolate(s string) string {
+	for k, v := range b.vars {
+		s = strings.ReplaceAll(s, "$"+k, v)
+		s = strings.ReplaceAll(s, "${"+k+"}", v)
+	}
+	return s
+}
+
+func (b *DashboardBenchmark) execute(ctx context.Context, q extractedQuery) (bool, int, error) {
+	switch q.Type {
+	case promQL:
+		return b.executePromQL(ctx, q)
+	case logQL:
+		return b.executeLogQL(ctx, q)
+	case traceQL:
+		return b.executeTraceQL(ctx, q)
+	default:
+		return false, 0, errors.Errorf("unknown query type %q", q.Type)
+	}
+}
+
+func (b *DashboardBenchmark) executePromQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+	if b.start.IsZero() || b.end.IsZero() {
+		resp, err := b.promClient.GetQuery(ctx, promapi.GetQueryParams{
+			Query: q.Expr,
+		})
+		if err != nil {
+			return false, 0, err
+		}
+		n := 0
+		switch resp.Data.Type {
+		case promapi.MatrixData:
+			n = len(resp.Data.Matrix.Result)
+		case promapi.VectorData:
+			n = len(resp.Data.Vector.Result)
+		}
+		return n == 0, n, nil
+	}
+	resp, err := b.promClient.GetQueryRange(ctx, promapi.GetQueryRangeParams{
+		Query: q.Expr,
+		Start: toPrometheusTimestamp(b.start),
+		End:   toPrometheusTimestamp(b.end),
+		Step:  promapi.NewOptString(b.Step),
+	})
+	if err != nil {
+		return false, 0, err
+	}
+	n := 0
+	switch resp.Data.Type {
+	case promapi.MatrixData:
+		n = len(resp.Data.Matrix.Result)
+	case promapi.VectorData:
+		n = len(resp.Data.Vector.Result)
+	}
+	return n == 0, n, nil
+}
+
+func (b *DashboardBenchmark) executeLogQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+	if b.start.IsZero() || b.end.IsZero() {
+		resp, err := b.lokiClient.Query(ctx, lokiapi.QueryParams{
+			Query: q.Expr,
+		})
+		if err != nil {
+			return false, 0, err
+		}
+		n := 0
+		switch resp.Data.Type {
+		case lokiapi.StreamsResultQueryResponseData:
+			n = len(resp.Data.StreamsResult.Result)
+		case lokiapi.MatrixResultQueryResponseData:
+			n = len(resp.Data.MatrixResult.Result)
+		case lokiapi.VectorResultQueryResponseData:
+			n = len(resp.Data.VectorResult.Result)
+		}
+		return n == 0, n, nil
+	}
+	resp, err := b.lokiClient.QueryRange(ctx, lokiapi.QueryRangeParams{
+		Query: q.Expr,
+		Start: lokiapi.NewOptLokiTime(lokiapi.LokiTime(b.start.Format(time.RFC3339Nano))),
+		End:   lokiapi.NewOptLokiTime(lokiapi.LokiTime(b.end.Format(time.RFC3339Nano))),
+		Step:  lokiapi.NewOptPrometheusDuration(lokiapi.PrometheusDuration(b.Step)),
+	})
+	if err != nil {
+		return false, 0, err
+	}
+	n := 0
+	switch resp.Data.Type {
+	case lokiapi.StreamsResultQueryResponseData:
+		n = len(resp.Data.StreamsResult.Result)
+	case lokiapi.MatrixResultQueryResponseData:
+		n = len(resp.Data.MatrixResult.Result)
+	case lokiapi.VectorResultQueryResponseData:
+		n = len(resp.Data.VectorResult.Result)
+	}
+	return n == 0, n, nil
+}
+
+func (b *DashboardBenchmark) executeTraceQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+	resp, err := b.tempoClient.Search(ctx, tempoapi.SearchParams{
+		Q:     tempoapi.NewOptString(q.Expr),
+		Start: tempoapi.NewOptTempoTime(tempoapi.TempoTime(b.start.Format(time.RFC3339Nano))),
+		End:   tempoapi.NewOptTempoTime(tempoapi.TempoTime(b.end.Format(time.RFC3339Nano))),
+	})
+	if err != nil {
+		return false, 0, err
+	}
+	n := len(resp.Traces)
+	return n == 0, n, nil
+}
+
+func (b *DashboardBenchmark) report(results []queryResult) error {
+	fmt.Println("\nBenchmark results:")
+	slices.SortFunc(results, func(a, b queryResult) int {
+		if a.Avg > b.Avg {
+			return -1
+		}
+		if a.Avg < b.Avg {
+			return 1
+		}
+		return 0
+	})
+
+	for i, res := range results {
+		if i >= 10 {
+			break
+		}
+		empty := ""
+		if res.Empty {
+			empty = " [EMPTY]"
+		} else {
+			empty = fmt.Sprintf(" [N=%d]", res.N)
+		}
+		fmt.Printf("%d. %s: %s (avg: %v, p99: %v, first: %v)%s\n", i+1, res.Query.Panel, res.Query.Expr, res.Avg, res.P99, res.First, empty)
+	}
+
+	type reportEntry struct {
+		Panel string        `yaml:"panel"`
+		Query string        `yaml:"query"`
+		Type  string        `yaml:"type"`
+		Empty bool          `yaml:"empty"`
+		N     int           `yaml:"n"`
+		First time.Duration `yaml:"first"`
+		Avg   time.Duration `yaml:"avg"`
+		Min   time.Duration `yaml:"min"`
+		Max   time.Duration `yaml:"max"`
+		P99   time.Duration `yaml:"p99"`
+	}
+
+	var report []reportEntry
+	for _, res := range results {
+		report = append(report, reportEntry{
+			Panel: res.Query.Panel,
+			Query: res.Query.Expr,
+			Type:  string(res.Query.Type),
+			Empty: res.Empty,
+			N:     res.N,
+			First: res.First,
+			Avg:   res.Avg,
+			Min:   res.Min,
+			Max:   res.Max,
+			P99:   res.P99,
+		})
+	}
+
+	out, err := yaml.Marshal(report)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(b.Output, out, 0644)
+}
+
+type grafanaDashboard struct {
+	Panels []grafanaPanel `json:"panels"`
+}
+
+type grafanaPanel struct {
+	Title   string          `json:"title"`
+	Targets []grafanaTarget `json:"targets"`
+}
+
+type grafanaTarget struct {
+	Datasource grafanaDatasource `json:"datasource"`
+	Expr       string            `json:"expr"`
+	Query      string            `json:"query"`
+	RefId      string            `json:"refId"`
+}
+
+type grafanaDatasource struct {
+	Type string `json:"type"`
+	Uid  string `json:"uid"`
+}
+
+func (d *grafanaDatasource) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		d.Type = s
+		return nil
+	}
+	type alias grafanaDatasource
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*d = grafanaDatasource(a)
+	return nil
+}
+
+func newDashboardBenchmarkCommand() *cobra.Command {
+	b := &DashboardBenchmark{}
+	cmd := &cobra.Command{
+		Use:   "bench",
+		Short: "Run dashboard benchmarks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return b.Run(cmd.Context())
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&b.Input, "input", "i", "dashboard.json", "Input dashboard JSON file")
+	f.StringVarP(&b.Output, "output", "o", "report.yml", "Output report file")
+	f.StringVar(&b.PromAddr, "prom-addr", "http://localhost:9090", "Prometheus address")
+	f.StringVar(&b.LokiAddr, "loki-addr", "http://localhost:3100", "Loki address")
+	f.StringVar(&b.TempoAddr, "tempo-addr", "http://localhost:3200", "Tempo address")
+	f.IntVar(&b.Count, "count", 1, "Number of times to run each query")
+	f.IntVar(&b.Warmup, "warmup", 0, "Number of warmup runs")
+	f.StringVar(&b.StartTime, "start", "", "Start time override")
+	f.StringVar(&b.EndTime, "end", "", "End time override")
+	f.StringVar(&b.Step, "step", "15s", "Step override")
+	f.StringSliceVar(&b.Variables, "template-var", nil, "Template variables (key=value)")
+
+	return cmd
+}

--- a/cmd/otelbench/dashboard_bench.go
+++ b/cmd/otelbench/dashboard_bench.go
@@ -1,18 +1,20 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
+	"github.com/go-faster/yaml"
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-faster/oteldb/internal/lokiapi"
 	"github.com/go-faster/oteldb/internal/promapi"
@@ -33,6 +35,10 @@ type DashboardBenchmark struct {
 	StartTime string
 	EndTime   string
 	Step      string
+
+	Interval     string
+	RateInterval string
+	Range        string
 
 	Variables []string
 
@@ -153,9 +159,9 @@ func (b *DashboardBenchmark) setup(_ context.Context) (err error) {
 	}
 
 	b.vars = map[string]string{
-		"__interval":      "15s",
-		"__rate_interval": "5m",
-		"__range":         "1h",
+		"__interval":      b.Interval,
+		"__rate_interval": b.RateInterval,
+		"__range":         b.Range,
 	}
 	for _, v := range b.Variables {
 		parts := strings.SplitN(v, "=", 2)
@@ -254,10 +260,15 @@ func (b *DashboardBenchmark) identifyType(t grafanaTarget) queryType {
 	}
 }
 
+var varRegex = regexp.MustCompile(`\$[a-zA-Z_][a-zA-Z0-9_]*|\$\{[a-zA-Z0-9_:]+\}`)
+
 func (b *DashboardBenchmark) interpolate(s string) string {
 	for k, v := range b.vars {
 		s = strings.ReplaceAll(s, "$"+k, v)
 		s = strings.ReplaceAll(s, "${"+k+"}", v)
+	}
+	if varRegex.MatchString(s) {
+		fmt.Printf("warning: query %q contains unreplaced variables\n", s)
 	}
 	return s
 }
@@ -367,13 +378,7 @@ func (b *DashboardBenchmark) executeTraceQL(ctx context.Context, q extractedQuer
 func (b *DashboardBenchmark) report(results []queryResult) error {
 	fmt.Println("\nBenchmark results:")
 	slices.SortFunc(results, func(a, b queryResult) int {
-		if a.Avg > b.Avg {
-			return -1
-		}
-		if a.Avg < b.Avg {
-			return 1
-		}
-		return 0
+		return cmp.Compare(b.Avg, a.Avg)
 	})
 
 	for i, res := range results {
@@ -486,6 +491,9 @@ func newDashboardBenchmarkCommand() *cobra.Command {
 	f.StringVar(&b.StartTime, "start", "", "Start time override")
 	f.StringVar(&b.EndTime, "end", "", "End time override")
 	f.StringVar(&b.Step, "step", "15s", "Step override")
+	f.StringVar(&b.Interval, "interval", "15s", "Default $__interval variable")
+	f.StringVar(&b.RateInterval, "rate-interval", "5m", "Default $__rate_interval variable")
+	f.StringVar(&b.Range, "range", "1h", "Default $__range variable")
 	f.StringSliceVar(&b.Variables, "template-var", nil, "Template variables (key=value)")
 
 	return cmd

--- a/cmd/otelbench/dashboard_bench.go
+++ b/cmd/otelbench/dashboard_bench.go
@@ -108,20 +108,20 @@ func (b *DashboardBenchmark) Run(ctx context.Context) error {
 
 		if len(durations) > 0 {
 			var totalDur time.Duration
-			min := durations[0]
-			max := durations[0]
+			minDur := durations[0]
+			maxDur := durations[0]
 			for _, d := range durations {
 				totalDur += d
-				if d < min {
-					min = d
+				if d < minDur {
+					minDur = d
 				}
-				if d > max {
-					max = d
+				if d > maxDur {
+					maxDur = d
 				}
 			}
 			res.Avg = totalDur / time.Duration(len(durations))
-			res.Min = min
-			res.Max = max
+			res.Min = minDur
+			res.Max = maxDur
 
 			slices.Sort(durations)
 			res.P99 = durations[len(durations)*99/100]
@@ -198,7 +198,9 @@ func (b *DashboardBenchmark) loadDashboard() (*grafanaDashboard, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	var d grafanaDashboard
 	if err := json.NewDecoder(f).Decode(&d); err != nil {
@@ -260,7 +262,7 @@ func (b *DashboardBenchmark) interpolate(s string) string {
 	return s
 }
 
-func (b *DashboardBenchmark) execute(ctx context.Context, q extractedQuery) (bool, int, error) {
+func (b *DashboardBenchmark) execute(ctx context.Context, q extractedQuery) (isEmpty bool, n int, err error) {
 	switch q.Type {
 	case promQL:
 		return b.executePromQL(ctx, q)
@@ -273,7 +275,7 @@ func (b *DashboardBenchmark) execute(ctx context.Context, q extractedQuery) (boo
 	}
 }
 
-func (b *DashboardBenchmark) executePromQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+func (b *DashboardBenchmark) executePromQL(ctx context.Context, q extractedQuery) (isEmpty bool, n int, err error) {
 	if b.start.IsZero() || b.end.IsZero() {
 		resp, err := b.promClient.GetQuery(ctx, promapi.GetQueryParams{
 			Query: q.Expr,
@@ -299,7 +301,7 @@ func (b *DashboardBenchmark) executePromQL(ctx context.Context, q extractedQuery
 	if err != nil {
 		return false, 0, err
 	}
-	n := 0
+	n = 0
 	switch resp.Data.Type {
 	case promapi.MatrixData:
 		n = len(resp.Data.Matrix.Result)
@@ -309,7 +311,7 @@ func (b *DashboardBenchmark) executePromQL(ctx context.Context, q extractedQuery
 	return n == 0, n, nil
 }
 
-func (b *DashboardBenchmark) executeLogQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+func (b *DashboardBenchmark) executeLogQL(ctx context.Context, q extractedQuery) (isEmpty bool, n int, err error) {
 	if b.start.IsZero() || b.end.IsZero() {
 		resp, err := b.lokiClient.Query(ctx, lokiapi.QueryParams{
 			Query: q.Expr,
@@ -337,7 +339,7 @@ func (b *DashboardBenchmark) executeLogQL(ctx context.Context, q extractedQuery)
 	if err != nil {
 		return false, 0, err
 	}
-	n := 0
+	n = 0
 	switch resp.Data.Type {
 	case lokiapi.StreamsResultQueryResponseData:
 		n = len(resp.Data.StreamsResult.Result)
@@ -349,7 +351,7 @@ func (b *DashboardBenchmark) executeLogQL(ctx context.Context, q extractedQuery)
 	return n == 0, n, nil
 }
 
-func (b *DashboardBenchmark) executeTraceQL(ctx context.Context, q extractedQuery) (bool, int, error) {
+func (b *DashboardBenchmark) executeTraceQL(ctx context.Context, q extractedQuery) (isEmpty bool, n int, err error) {
 	resp, err := b.tempoClient.Search(ctx, tempoapi.SearchParams{
 		Q:     tempoapi.NewOptString(q.Expr),
 		Start: tempoapi.NewOptTempoTime(tempoapi.TempoTime(b.start.Format(time.RFC3339Nano))),
@@ -358,7 +360,7 @@ func (b *DashboardBenchmark) executeTraceQL(ctx context.Context, q extractedQuer
 	if err != nil {
 		return false, 0, err
 	}
-	n := len(resp.Traces)
+	n = len(resp.Traces)
 	return n == 0, n, nil
 }
 
@@ -421,7 +423,7 @@ func (b *DashboardBenchmark) report(results []queryResult) error {
 		return err
 	}
 
-	return os.WriteFile(b.Output, out, 0644)
+	return os.WriteFile(b.Output, out, 0o644)
 }
 
 type grafanaDashboard struct {
@@ -437,12 +439,12 @@ type grafanaTarget struct {
 	Datasource grafanaDatasource `json:"datasource"`
 	Expr       string            `json:"expr"`
 	Query      string            `json:"query"`
-	RefId      string            `json:"refId"`
+	RefID      string            `json:"refId"`
 }
 
 type grafanaDatasource struct {
 	Type string `json:"type"`
-	Uid  string `json:"uid"`
+	UID  string `json:"uid"`
 }
 
 func (d *grafanaDatasource) UnmarshalJSON(data []byte) error {
@@ -468,7 +470,7 @@ func newDashboardBenchmarkCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bench",
 		Short: "Run dashboard benchmarks",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return b.Run(cmd.Context())
 		},
 	}

--- a/cmd/otelbench/main.go
+++ b/cmd/otelbench/main.go
@@ -25,6 +25,7 @@ func main() {
 		newPrometheusRemoteWriteCommand(),
 		newOtelCommand(),
 		newDumpCommand(),
+		newDashboardCommand(),
 	)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,6 @@ require (
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -358,6 +357,7 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	mvdan.cc/xurls/v2 v2.6.0 // indirect
 	pluginrpc.com/pluginrpc v0.5.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -357,7 +358,6 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	mvdan.cc/xurls/v2 v2.6.0 // indirect
 	pluginrpc.com/pluginrpc v0.5.0 // indirect
 )


### PR DESCRIPTION
This PR adds a new `dashboard bench` subcommand to `otelbench` for benchmarking queries extracted from Grafana dashboards.

Features:
- Extracts PromQL, LogQL, and TraceQL queries from Dashboard JSON.
- Supports variable interpolation (including custom variables via `--template-var`).
- Captures "cold start" (first run) stats along with average, P99, min, and max.
- Validates query results (reports if query returns no data).