### PR TITLE
fix(traceql): change identifier names

### DIFF
--- a/internal/traceql/attribute.go
+++ b/internal/traceql/attribute.go
@@ -62,7 +62,7 @@ func (s Attribute) String() string {
 	case SpanID:
 		return "span:id"
 	case ParentID:
-		return "span:parentId"
+		return "span:parentID"
 	case TraceID:
 		return "trace:id"
 	case EventName:
@@ -70,9 +70,9 @@ func (s Attribute) String() string {
 	case EventTimeSinceStart:
 		return "event:timeSinceStart"
 	case LinkTraceID:
-		return "link:traceId"
+		return "link:traceID"
 	case LinkSpanID:
-		return "link:spanId"
+		return "link:spanID"
 	case InstrumentationName:
 		return "instrumentation:name"
 	case InstrumentationVersion:

--- a/internal/traceql/lexer/token.go
+++ b/internal/traceql/lexer/token.go
@@ -163,9 +163,9 @@ var tokens = map[string]TokenType{
 	"nestedSetRight":  NestedSetRight,
 	"nestedSetParent": NestedSetParent,
 	"id":              ID,
-	"traceId":         TraceID,
-	"spanId":          SpanID,
-	"parentId":        ParentID,
+	"traceID":         TraceID,
+	"spanID":          SpanID,
+	"parentID":        ParentID,
 	"timeSinceStart":  TimeSinceStart,
 	"version":         Version,
 }

--- a/internal/traceql/parser_test.go
+++ b/internal/traceql/parser_test.go
@@ -998,7 +998,7 @@ var tests = []TestCase{
 		false,
 	},
 	{
-		`{ span:parentId = "def" }`,
+		`{ span:parentID = "def" }`,
 		testBinFieldExpr(
 			&Attribute{Prop: ParentID},
 			OpEq,
@@ -1036,7 +1036,7 @@ var tests = []TestCase{
 	},
 	// Scoped intrinsics: link:
 	{
-		`{ link:traceId = "abc" }`,
+		`{ link:traceID = "abc" }`,
 		testBinFieldExpr(
 			&Attribute{Prop: LinkTraceID},
 			OpEq,
@@ -1045,7 +1045,7 @@ var tests = []TestCase{
 		false,
 	},
 	{
-		`{ link:spanId = "def" }`,
+		`{ link:spanID = "def" }`,
 		testBinFieldExpr(
 			&Attribute{Prop: LinkSpanID},
 			OpEq,

--- a/internal/traceql/traceqlengine/evaluater_test.go
+++ b/internal/traceql/traceqlengine/evaluater_test.go
@@ -182,8 +182,8 @@ func TestEvaluater(t *testing.T) {
 		{fmt.Sprintf(`{ span:id = %q }`, testSpanID.Hex()), true},
 		{fmt.Sprintf(`{ span:id != %q }`, otelstorage.SpanID{}.Hex()), true},
 		// ParentID intrinsic.
-		{fmt.Sprintf(`{ span:parentId = %q }`, testParentSpanID.Hex()), true},
-		{fmt.Sprintf(`{ span:parentId != %q }`, testSpanID.Hex()), true},
+		{fmt.Sprintf(`{ span:parentID = %q }`, testParentSpanID.Hex()), true},
+		{fmt.Sprintf(`{ span:parentID != %q }`, testSpanID.Hex()), true},
 		// TraceID intrinsic.
 		{fmt.Sprintf(`{ trace:id = %q }`, testTraceID.Hex()), true},
 		// Instrumentation intrinsics.
@@ -195,8 +195,8 @@ func TestEvaluater(t *testing.T) {
 		{`{ event:timeSinceStart >= 1s }`, true},
 		{`{ event:timeSinceStart < 2s }`, true},
 		// Link intrinsics.
-		{fmt.Sprintf(`{ link:traceId = %q }`, testLinkTraceID.Hex()), true},
-		{fmt.Sprintf(`{ link:spanId = %q }`, testLinkSpanID.Hex()), true},
+		{fmt.Sprintf(`{ link:traceID = %q }`, testLinkTraceID.Hex()), true},
+		{fmt.Sprintf(`{ link:spanID = %q }`, testLinkSpanID.Hex()), true},
 		// Scoped attribute selectors.
 		{`{ event.custom = "eventValue" }`, true},
 		{`{ event.custom != "other" }`, true},


### PR DESCRIPTION
Fixes some traceql identifier names to be in line with vanilla tempo, it's `link:traceID`, `link:spanID`, `span:parentID`
https://grafana.com/docs/tempo/latest/traceql/construct-traceql-queries/#intrinsic-fields