### PR TITLE
feat: serve traces/logs/profiles from the embedded storage backend (storage v0.3.0)

### DIFF
--- a/cmd/oteldb/app.go
+++ b/cmd/oteldb/app.go
@@ -50,9 +50,12 @@ type App struct {
 	shutdown func()
 	otelStorage
 
-	// metricsSink, when set, routes metrics ingestion to the embedded storage engine
-	// instead of ClickHouse (see [MetricsBackendStorage]).
-	metricsSink otelreceiver.MetricsSink
+	// metricsSink/tracesSink/logsSink, when set, route the corresponding signal's ingestion to
+	// the embedded storage engine instead of ClickHouse (see [MetricsBackendStorage]).
+	metricsSink  otelreceiver.MetricsSink
+	tracesSink   otelreceiver.TracesSink
+	logsSink     otelreceiver.LogsSink
+	profilesSink otelreceiver.ProfilesSink
 
 	lg        *zap.Logger
 	telemetry *sdkapp.Telemetry
@@ -101,15 +104,31 @@ func newApp(ctx context.Context, cfg Config, m *sdkapp.Telemetry) (_ *App, err e
 		app.otelStorage = store
 	}
 
-	// Optionally swap the metrics signal onto the embedded storage engine. Logs and traces
-	// stay on ClickHouse; only the metrics querier and ingestion sink are replaced.
-	if cfg.MetricsBackend == MetricsBackendStorage {
+	// Optionally swap one or more signals onto the embedded storage engine. A single shared
+	// engine instance backs every signal selected via the *_backend config; the rest stay on
+	// ClickHouse. For each swapped signal both the query side (the API handler's querier) and
+	// the ingestion side (the collector exporter's sink) are replaced.
+	if cfg.usesStorageBackend() {
 		b, closeStore, err := setupStorageBackend(ctx, cfg.Storage, app.lg.Named("storage"))
 		if err != nil {
 			return nil, errors.Wrap(err, "setup storage backend")
 		}
-		app.metricsQuerier = b
-		app.metricsSink = b
+		if cfg.MetricsBackend == MetricsBackendStorage {
+			app.metricsQuerier = b
+			app.metricsSink = b
+		}
+		if cfg.TracesBackend == MetricsBackendStorage {
+			app.traceQuerier = b.Traces()
+			app.tracesSink = b
+		}
+		if cfg.LogsBackend == MetricsBackendStorage {
+			app.logQuerier = b.Logs()
+			app.logsSink = b
+		}
+		if cfg.ProfilesBackend == MetricsBackendStorage {
+			app.profileQuerier = b.Profiles()
+			app.profilesSink = b
+		}
 		app.services["storage"] = func(ctx context.Context) error {
 			<-ctx.Done()
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -316,7 +335,11 @@ func (app *App) trySetupLoki() error {
 
 	var optimizers []logqlengine.Optimizer
 	optimizers = append(optimizers, logqlengine.DefaultOptimizers()...)
-	optimizers = append(optimizers, &chstorage.ClickhouseOptimizer{})
+	// The ClickHouse optimizer pushes filtering into chstorage's InputNode; it is a no-op for
+	// other backends, so only enable it when logs are actually served from ClickHouse.
+	if app.cfg.LogsBackend != MetricsBackendStorage {
+		optimizers = append(optimizers, &chstorage.ClickhouseOptimizer{})
+	}
 	engine, err := logqlengine.NewEngine(q, logqlengine.Options{
 		ParseOptions: logql.ParseOptions{
 			AllowDots: true,
@@ -473,6 +496,15 @@ func (app *App) setupCollector() error {
 	var factoryOpts []otelreceiver.Option
 	if app.metricsSink != nil {
 		factoryOpts = append(factoryOpts, otelreceiver.WithMetricsSink(app.metricsSink))
+	}
+	if app.tracesSink != nil {
+		factoryOpts = append(factoryOpts, otelreceiver.WithTracesSink(app.tracesSink))
+	}
+	if app.logsSink != nil {
+		factoryOpts = append(factoryOpts, otelreceiver.WithLogsSink(app.logsSink))
+	}
+	if app.profilesSink != nil {
+		factoryOpts = append(factoryOpts, otelreceiver.WithProfilesSink(app.profilesSink))
 	}
 
 	col, err := otelcol.NewCollector(otelcol.CollectorSettings{

--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -56,9 +56,18 @@ type Config struct {
 
 	// MetricsBackend selects the storage backend serving the metrics signal:
 	// "clickhouse" (default) or "storage" (the embedded github.com/oteldb/storage engine).
-	// Logs and traces always use ClickHouse.
 	MetricsBackend string `json:"metrics_backend" yaml:"metrics_backend"`
-	// Storage configures the embedded storage engine, used when MetricsBackend is "storage".
+	// TracesBackend selects the storage backend serving the traces signal:
+	// "clickhouse" (default) or "storage".
+	TracesBackend string `json:"traces_backend" yaml:"traces_backend"`
+	// LogsBackend selects the storage backend serving the logs signal:
+	// "clickhouse" (default) or "storage".
+	LogsBackend string `json:"logs_backend" yaml:"logs_backend"`
+	// ProfilesBackend selects the storage backend serving the profiles signal. Profiles have no
+	// ClickHouse implementation, so this is empty (the Pyroscope API stays unregistered) unless
+	// set to "storage" (the embedded github.com/oteldb/storage engine).
+	ProfilesBackend string `json:"profiles_backend" yaml:"profiles_backend"`
+	// Storage configures the embedded storage engine, used when a signal's backend is "storage".
 	Storage StorageConfig `json:"storage" yaml:"storage"`
 
 	Tempo       TempoConfig       `json:"tempo" yaml:"tempo"`
@@ -103,9 +112,23 @@ func (cfg *StorageConfig) setDefaults() {
 	}
 }
 
+// usesStorageBackend reports whether any signal is served by the embedded storage engine.
+func (cfg *Config) usesStorageBackend() bool {
+	return cfg.MetricsBackend == MetricsBackendStorage ||
+		cfg.TracesBackend == MetricsBackendStorage ||
+		cfg.LogsBackend == MetricsBackendStorage ||
+		cfg.ProfilesBackend == MetricsBackendStorage
+}
+
 func (cfg *Config) setDefaults() {
 	if cfg.MetricsBackend == "" {
 		cfg.MetricsBackend = MetricsBackendClickHouse
+	}
+	if cfg.TracesBackend == "" {
+		cfg.TracesBackend = MetricsBackendClickHouse
+	}
+	if cfg.LogsBackend == "" {
+		cfg.LogsBackend = MetricsBackendClickHouse
 	}
 	cfg.Storage.setDefaults()
 	if len(cfg.CollectorSignals) == 0 {
@@ -115,6 +138,28 @@ func (cfg *Config) setDefaults() {
 		}
 	}
 	if cfg.Collector == nil {
+		pipelines := map[string]any{
+			"traces": map[string]any{
+				"receivers": []string{"otlp"},
+				"exporters": []string{"oteldbexporter"},
+			},
+			"metrics": map[string]any{
+				"receivers": []string{"otlp", "prometheusremotewrite"},
+				"exporters": []string{"oteldbexporter"},
+			},
+			"logs": map[string]any{
+				"receivers": []string{"otlp"},
+				"exporters": []string{"oteldbexporter"},
+			},
+		}
+		// The profiles signal is experimental and only representable by the embedded storage
+		// engine, so its pipeline is enabled only when profiles are served from storage.
+		if cfg.ProfilesBackend == MetricsBackendStorage {
+			pipelines["profiles"] = map[string]any{
+				"receivers": []string{"otlp"},
+				"exporters": []string{"oteldbexporter"},
+			}
+		}
 		cfg.Collector = map[string]any{
 			"receivers": map[string]any{
 				"otlp": map[string]any{
@@ -136,20 +181,7 @@ func (cfg *Config) setDefaults() {
 				},
 			},
 			"service": map[string]any{
-				"pipelines": map[string]any{
-					"traces": map[string]any{
-						"receivers": []string{"otlp"},
-						"exporters": []string{"oteldbexporter"},
-					},
-					"metrics": map[string]any{
-						"receivers": []string{"otlp", "prometheusremotewrite"},
-						"exporters": []string{"oteldbexporter"},
-					},
-					"logs": map[string]any{
-						"receivers": []string{"otlp"},
-						"exporters": []string{"oteldbexporter"},
-					},
-				},
+				"pipelines": pipelines,
 			},
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -451,7 +451,7 @@ require (
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
-	github.com/oteldb/storage v0.1.0
+	github.com/oteldb/storage v0.3.0
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect
@@ -540,9 +540,9 @@ require (
 	go.opentelemetry.io/collector/consumer/consumererror v0.155.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.155.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.155.0 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.155.0 // indirect
-	go.opentelemetry.io/collector/exporter/exportertest v0.155.0 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.155.0 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.155.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.155.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.155.0
 	go.opentelemetry.io/collector/extension/extensionauth v1.61.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.155.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.155.0 // indirect
@@ -555,7 +555,7 @@ require (
 	go.opentelemetry.io/collector/internal/memorylimiter v0.155.0 // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.155.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.155.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.155.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.155.0
 	go.opentelemetry.io/collector/pdata/testdata v0.155.0 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.155.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.155.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1018,8 +1018,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.7.0-alpha.0 h1:od3skf7eTPMv+3zR6G3WZl7YVzWJUa8b8yP3XpfIgI4=
 github.com/oteldb/promql-engine v0.7.0-alpha.0/go.mod h1:j3kBzxEWSsdIinLTl7ogVolJbI2GC/fa1GU4/NpOr0k=
-github.com/oteldb/storage v0.1.0 h1:ELzsRl6+qncS6wgeeQsSShh9XW+60aekP99PPXYkeK4=
-github.com/oteldb/storage v0.1.0/go.mod h1:vK1RbOMv9OSchIIay/dnkRUZ8wSnYSNjl4139oM0v3E=
+github.com/oteldb/storage v0.3.0 h1:5+yaF8fS7UF9oscuz5tMjgCYjnLN8kLvuUsp3j3bFgc=
+github.com/oteldb/storage v0.3.0/go.mod h1:gsPNmKn41DyQ1UXsIASIRjYdw1ZR+RmWGi4zhjzGrLE=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/otelreceiver/oteldbexporter/oteldbexporter.go
+++ b/internal/otelreceiver/oteldbexporter/oteldbexporter.go
@@ -7,8 +7,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
+	"go.opentelemetry.io/collector/exporter/xexporter"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
@@ -33,6 +36,27 @@ type MetricsSink interface {
 	ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error
 }
 
+// TracesSink ingests OTLP traces batches. When set on the factory (see [WithTracesSink]) the
+// traces exporter writes to it instead of dialing ClickHouse, letting the embedded storage
+// engine serve the traces signal.
+type TracesSink interface {
+	ConsumeTraces(ctx context.Context, td ptrace.Traces) error
+}
+
+// LogsSink ingests OTLP logs batches. When set on the factory (see [WithLogsSink]) the logs
+// exporter writes to it instead of dialing ClickHouse, letting the embedded storage engine
+// serve the logs signal.
+type LogsSink interface {
+	ConsumeLogs(ctx context.Context, ld plog.Logs) error
+}
+
+// ProfilesSink ingests OTLP profiles batches. Profiles have no ClickHouse implementation, so the
+// exporter's profiles signal is only available when a sink is set (see [WithProfilesSink]); the
+// embedded storage engine then serves the profiles signal.
+type ProfilesSink interface {
+	ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) error
+}
+
 // Option configures the exporter factory.
 type Option func(*factory)
 
@@ -41,23 +65,58 @@ func WithMetricsSink(sink MetricsSink) Option {
 	return func(f *factory) { f.metricsSink = sink }
 }
 
-type factory struct {
-	metricsSink MetricsSink
+// WithTracesSink routes ingested traces to sink instead of ClickHouse.
+func WithTracesSink(sink TracesSink) Option {
+	return func(f *factory) { f.tracesSink = sink }
 }
 
-// NewFactory creates new factory of [Exporter].
+// WithLogsSink routes ingested logs to sink instead of ClickHouse.
+func WithLogsSink(sink LogsSink) Option {
+	return func(f *factory) { f.logsSink = sink }
+}
+
+// WithProfilesSink enables the exporter's profiles signal, routing ingested profiles to sink (the
+// embedded storage engine). Without it the exporter does not support the profiles signal.
+func WithProfilesSink(sink ProfilesSink) Option {
+	return func(f *factory) { f.profilesSink = sink }
+}
+
+type factory struct {
+	metricsSink  MetricsSink
+	tracesSink   TracesSink
+	logsSink     LogsSink
+	profilesSink ProfilesSink
+}
+
+// NewFactory creates new factory of [Exporter]. It always supports traces, metrics, and logs; the
+// experimental profiles signal is additionally supported when a profiles sink is configured.
 func NewFactory(opts ...Option) exporter.Factory {
 	f := &factory{}
 	for _, o := range opts {
 		o(f)
 	}
-	return exporter.NewFactory(
-		typ,
-		createDefaultConfig,
-		exporter.WithTraces(createTracesExporter, stability),
-		exporter.WithMetrics(f.createMetricsExporter, stability),
-		exporter.WithLogs(createLogsExporter, stability),
-	)
+	xopts := []xexporter.FactoryOption{
+		xexporter.WithTraces(f.createTracesExporter, stability),
+		xexporter.WithMetrics(f.createMetricsExporter, stability),
+		xexporter.WithLogs(f.createLogsExporter, stability),
+	}
+	if f.profilesSink != nil {
+		xopts = append(xopts, xexporter.WithProfiles(f.createProfilesExporter, stability))
+	}
+	return xexporter.NewFactory(typ, createDefaultConfig, xopts...)
+}
+
+// createProfilesExporter builds the profiles exporter that writes to the configured profiles sink.
+func (f *factory) createProfilesExporter(
+	ctx context.Context,
+	settings exporter.Settings,
+	cfg component.Config,
+) (xexporter.Profiles, error) {
+	if f.profilesSink == nil {
+		return nil, errors.New("profiles ingestion requires the storage backend (set profiles_backend: storage)")
+	}
+	settings.Logger.Info("Routing profiles to storage backend sink")
+	return xexporterhelper.NewProfiles(ctx, settings, cfg, f.profilesSink.ConsumeProfiles)
 }
 
 func createDefaultConfig() component.Config {
@@ -66,28 +125,37 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createTracesExporter(
+func (f *factory) createTracesExporter(
 	ctx context.Context,
 	settings exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
 	ecfg := cfg.(*Config)
-	inserter, err := ecfg.connect(ctx, settings)
-	if err != nil {
-		return nil, err
+
+	// Route traces to the configured sink (the embedded storage engine) when set, otherwise
+	// fall back to ClickHouse.
+	var consume func(context.Context, ptrace.Traces) error
+	if f.tracesSink != nil {
+		settings.Logger.Info("Routing traces to storage backend sink")
+		consume = f.tracesSink.ConsumeTraces
+	} else {
+		inserter, err := ecfg.connect(ctx, settings)
+		if err != nil {
+			return nil, err
+		}
+		consume = tracestorage.NewConsumer(inserter).ConsumeTraces
 	}
 
-	consumer := tracestorage.NewConsumer(inserter)
-	consume := consumer.ConsumeTraces
 	if ecfg.Traces.Spans.enabled() {
 		spansCfg := ecfg.Traces.Spans
 		settings.Logger.Info("Span sampling enabled",
 			zap.Bool("drop", spansCfg.Drop),
 			zap.Float64("rate", spansCfg.Rate),
 		)
+		inner := consume
 		consume = func(ctx context.Context, td ptrace.Traces) error {
 			sampleSpans(td, spansCfg)
-			return consumer.ConsumeTraces(ctx, td)
+			return inner(ctx, td)
 		}
 	}
 	return exporterhelper.NewTraces(ctx, settings, cfg, consume)
@@ -129,7 +197,7 @@ func (f *factory) createMetricsExporter(
 	return exporterhelper.NewMetrics(ctx, settings, cfg, consume)
 }
 
-func createLogsExporter(
+func (f *factory) createLogsExporter(
 	ctx context.Context,
 	settings exporter.Settings,
 	cfg component.Config,
@@ -137,6 +205,23 @@ func createLogsExporter(
 	ecfg := cfg.(*Config)
 
 	lg := settings.Logger
+
+	// Route logs to the configured sink (the embedded storage engine) when set, bypassing the
+	// ClickHouse log-processing consumer. Record sampling still applies.
+	if f.logsSink != nil {
+		lg.Info("Routing logs to storage backend sink")
+		consume := f.logsSink.ConsumeLogs
+		if ecfg.Logs.Records.enabled() {
+			recordsCfg := ecfg.Logs.Records
+			inner := consume
+			consume = func(ctx context.Context, ld plog.Logs) error {
+				sampleLogRecords(ld, recordsCfg)
+				return inner(ctx, ld)
+			}
+		}
+		return exporterhelper.NewLogs(ctx, settings, cfg, consume)
+	}
+
 	procCfg := ecfg.Logs.Processing
 	triggerAttrs := parseAttributeRefs(procCfg.TriggerAttributes, "trigger_attributes", lg)
 	formatAttrs := parseAttributeRefs(procCfg.FormatAttributes, "format_attributes", lg)

--- a/internal/otelreceiver/oteldbexporter/profiles_test.go
+++ b/internal/otelreceiver/oteldbexporter/profiles_test.go
@@ -1,0 +1,54 @@
+package oteldbexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/xexporter"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+)
+
+type fakeProfilesSink struct {
+	consumed int
+}
+
+func (s *fakeProfilesSink) ConsumeProfiles(context.Context, pprofile.Profiles) error {
+	s.consumed++
+	return nil
+}
+
+// TestProfilesSinkRouting verifies that configuring a profiles sink makes the exporter advertise
+// the experimental profiles signal and route ingested profiles to the sink.
+func TestProfilesSinkRouting(t *testing.T) {
+	sink := &fakeProfilesSink{}
+	f := NewFactory(WithProfilesSink(sink))
+
+	xf, ok := f.(xexporter.Factory)
+	require.True(t, ok, "factory must support the experimental profiles signal")
+
+	ctx := context.Background()
+	exp, err := xf.CreateProfiles(ctx, exportertest.NewNopSettings(f.Type()), createDefaultConfig())
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = exp.Shutdown(ctx) })
+
+	require.NoError(t, exp.ConsumeProfiles(ctx, pprofile.NewProfiles()))
+	require.Equal(t, 1, sink.consumed)
+}
+
+// TestProfilesUnsupportedWithoutSink verifies that without a profiles sink the exporter does not
+// advertise the profiles signal.
+func TestProfilesUnsupportedWithoutSink(t *testing.T) {
+	f := NewFactory()
+	if xf, ok := f.(xexporter.Factory); ok {
+		_, err := xf.CreateProfiles(context.Background(), exportertest.NewNopSettings(f.Type()), createDefaultConfig())
+		require.Error(t, err, "profiles must be unsupported without a sink")
+	}
+}
+
+var _ exporter.Factory = NewFactory()

--- a/internal/otelreceiver/receiver.go
+++ b/internal/otelreceiver/receiver.go
@@ -116,6 +116,18 @@ func (s *TelemetrySettings) setDefaults() {
 // storage engine). See [WithMetricsSink].
 type MetricsSink = oteldbexporter.MetricsSink
 
+// TracesSink ingests OTLP traces batches into an alternative backend (the embedded
+// storage engine). See [WithTracesSink].
+type TracesSink = oteldbexporter.TracesSink
+
+// LogsSink ingests OTLP logs batches into an alternative backend (the embedded
+// storage engine). See [WithLogsSink].
+type LogsSink = oteldbexporter.LogsSink
+
+// ProfilesSink ingests OTLP profiles batches into an alternative backend (the embedded
+// storage engine). See [WithProfilesSink].
+type ProfilesSink = oteldbexporter.ProfilesSink
+
 // Option configures [Factories].
 type Option func(*factoriesOptions)
 
@@ -127,6 +139,27 @@ type factoriesOptions struct {
 func WithMetricsSink(sink MetricsSink) Option {
 	return func(o *factoriesOptions) {
 		o.exporterOpts = append(o.exporterOpts, oteldbexporter.WithMetricsSink(sink))
+	}
+}
+
+// WithTracesSink routes ingested traces to sink instead of ClickHouse.
+func WithTracesSink(sink TracesSink) Option {
+	return func(o *factoriesOptions) {
+		o.exporterOpts = append(o.exporterOpts, oteldbexporter.WithTracesSink(sink))
+	}
+}
+
+// WithLogsSink routes ingested logs to sink instead of ClickHouse.
+func WithLogsSink(sink LogsSink) Option {
+	return func(o *factoriesOptions) {
+		o.exporterOpts = append(o.exporterOpts, oteldbexporter.WithLogsSink(sink))
+	}
+}
+
+// WithProfilesSink enables the profiles signal, routing ingested profiles to sink.
+func WithProfilesSink(sink ProfilesSink) Option {
+	return func(o *factoriesOptions) {
+		o.exporterOpts = append(o.exporterOpts, oteldbexporter.WithProfilesSink(sink))
 	}
 }
 

--- a/internal/storagebackend/convert.go
+++ b/internal/storagebackend/convert.go
@@ -1,0 +1,68 @@
+package storagebackend
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+// otelAttrs projects storage [signal.Attributes] back into an [otelstorage.Attrs] (a
+// pcommon.Map), the representation oteldb's query layer consumes. It is the inverse of the
+// pdataconv ingest converter.
+func otelAttrs(attrs signal.Attributes) otelstorage.Attrs {
+	m := pcommon.NewMap()
+	for _, kv := range attrs {
+		putSignalValue(m.PutEmpty(string(kv.Key)), kv.Value)
+	}
+	return otelstorage.Attrs(m)
+}
+
+// putSignalValue writes a storage [signal.Value] into the pdata value dst, preserving type and
+// recursing into slices/maps.
+func putSignalValue(dst pcommon.Value, v signal.Value) {
+	switch v.Kind() {
+	case signal.KindStr:
+		dst.SetStr(string(v.Str()))
+	case signal.KindBool:
+		dst.SetBool(v.Bool())
+	case signal.KindInt:
+		dst.SetInt(v.Int())
+	case signal.KindDouble:
+		dst.SetDouble(v.Double())
+	case signal.KindBytes:
+		dst.SetEmptyBytes().FromRaw(v.Bytes())
+	case signal.KindSlice:
+		s := dst.SetEmptySlice()
+		for _, e := range v.Slice() {
+			putSignalValue(s.AppendEmpty(), e)
+		}
+	case signal.KindMap:
+		m := dst.SetEmptyMap()
+		for _, kv := range v.Map() {
+			putSignalValue(m.PutEmpty(string(kv.Key)), kv.Value)
+		}
+	default: // KindEmpty
+	}
+}
+
+// otelTraceID converts a raw 16-byte trace id into an [otelstorage.TraceID]; a short or empty id
+// yields the zero (empty) id.
+func otelTraceID(b []byte) otelstorage.TraceID {
+	var id otelstorage.TraceID
+	if len(b) == len(id) {
+		copy(id[:], b)
+	}
+	return id
+}
+
+// otelSpanID converts a raw 8-byte span id into an [otelstorage.SpanID]; a short or empty id
+// yields the zero (empty) id.
+func otelSpanID(b []byte) otelstorage.SpanID {
+	var id otelstorage.SpanID
+	if len(b) == len(id) {
+		copy(id[:], b)
+	}
+	return id
+}

--- a/internal/storagebackend/ingest.go
+++ b/internal/storagebackend/ingest.go
@@ -1,0 +1,51 @@
+package storagebackend
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigprofile "github.com/oteldb/storage/signal/profile"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+)
+
+// ConsumeTraces ingests an OTLP traces batch into the storage engine. It is the traces ingestion
+// sink used when the storage backend serves traces.
+func (b *Backend) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	var batch sigtrace.Traces
+	pdataconv.AppendTraces(&batch, td)
+
+	if _, err := b.store.WriteTraces(ctx, batch); err != nil {
+		return errors.Wrap(err, "write traces")
+	}
+	return nil
+}
+
+// ConsumeLogs ingests an OTLP logs batch into the storage engine. It is the logs ingestion sink
+// used when the storage backend serves logs.
+func (b *Backend) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	var batch siglog.Logs
+	pdataconv.AppendLogs(&batch, ld)
+
+	if _, err := b.store.WriteLogs(ctx, batch); err != nil {
+		return errors.Wrap(err, "write logs")
+	}
+	return nil
+}
+
+// ConsumeProfiles ingests an OTLP profiles batch into the storage engine. It is the profiles
+// ingestion sink used when the storage backend serves profiles.
+func (b *Backend) ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) error {
+	var batch sigprofile.Profiles
+	pdataconv.AppendProfiles(&batch, pd)
+
+	if _, err := b.store.WriteProfiles(ctx, batch); err != nil {
+		return errors.Wrap(err, "write profiles")
+	}
+	return nil
+}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -1,0 +1,381 @@
+package storagebackend
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlabels"
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+var (
+	_ logstorage.Querier  = (*LogQuerier)(nil)
+	_ logqlengine.Querier = (*LogQuerier)(nil)
+)
+
+// Capabilities implements [logqlengine.Querier]. The storage backend does not push any pipeline
+// filtering down, so it advertises no supported ops; the LogQL engine applies the whole pipeline
+// (line filters, parsers, label filters) on top of the raw entry stream this backend returns.
+func (q *LogQuerier) Capabilities() (caps logqlengine.QuerierCapabilities) {
+	return caps
+}
+
+// Query implements [logqlengine.Querier]. It returns a node that streams the entries of the
+// streams matching selector; the engine wraps it to evaluate the rest of the pipeline.
+func (q *LogQuerier) Query(_ context.Context, selector []logql.LabelMatcher) (logqlengine.PipelineNode, error) {
+	return &logStreamNode{q: q, selector: selector}, nil
+}
+
+// logStreamNode is the base [logqlengine.PipelineNode] over the storage logs fetcher.
+type logStreamNode struct {
+	q        *LogQuerier
+	selector []logql.LabelMatcher
+}
+
+var _ logqlengine.PipelineNode = (*logStreamNode)(nil)
+
+// Traverse implements [logqlengine.Node].
+func (n *logStreamNode) Traverse(cb logqlengine.NodeVisitor) error { return cb(n) }
+
+// EvalPipeline implements [logqlengine.PipelineNode]. It fetches every record in the window, builds
+// each record's label set, keeps the records whose set satisfies the stream selector, and returns
+// them as entries ordered per params.Direction (and truncated to params.Limit).
+func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.EvalParams) (logqlengine.EntryIterator, error) {
+	lo, hi := fetchWindow(params.Start, params.End)
+	req := fetch.Request{
+		Tenant: n.q.b.tenant,
+		Signal: signal.Log,
+		Start:  lo,
+		End:    hi,
+	}
+
+	it, err := n.q.b.store.LogFetcher(n.q.b.tenant).Fetch(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch logs")
+	}
+	batches, err := fetch.Drain(ctx, it)
+	if err != nil {
+		return nil, errors.Wrap(err, "drain logs")
+	}
+
+	var entries []logqlengine.Entry
+	for _, batch := range batches {
+		cols := newLogColumns(batch)
+		for i := range batch.Timestamps {
+			record := cols.record(batch, i)
+			set := logqlabels.NewLabelSet()
+			set.SetFromRecord(record)
+			if !matchSelector(set, n.selector) {
+				continue
+			}
+			entries = append(entries, logqlengine.Entry{
+				Timestamp: record.Timestamp,
+				Line:      record.Body,
+				Set:       set,
+			})
+		}
+	}
+
+	sortEntries(entries, params.Direction)
+	if params.Limit > 0 && len(entries) > params.Limit {
+		entries = entries[:params.Limit]
+	}
+	return iterators.Slice(entries), nil
+}
+
+// sortEntries orders entries by timestamp ascending for forward queries and descending otherwise.
+func sortEntries(entries []logqlengine.Entry, dir logqlengine.Direction) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if dir == logqlengine.DirectionBackward {
+			return entries[i].Timestamp > entries[j].Timestamp
+		}
+		return entries[i].Timestamp < entries[j].Timestamp
+	})
+}
+
+// logColumns caches the byte/int columns of a log batch for row materialization.
+type logColumns struct {
+	body         [][]byte
+	severityText [][]byte
+	traceID      [][]byte
+	spanID       [][]byte
+	attrs        [][]byte
+	severity     []int64
+	resource     otelstorage.Attrs
+	scopeName    string
+	scopeVersion string
+	scopeAttrs   otelstorage.Attrs
+}
+
+// newLogColumns extracts the named columns and stream identity of a log batch once.
+func newLogColumns(batch *fetch.Batch) logColumns {
+	bytesCol := func(name string) [][]byte {
+		if c, ok := batch.Column(name); ok {
+			return c.Bytes
+		}
+		return nil
+	}
+	intCol := func(name string) []int64 {
+		if c, ok := batch.Column(name); ok {
+			return c.Int64
+		}
+		return nil
+	}
+	return logColumns{
+		body:         bytesCol(siglog.ColBody),
+		severityText: bytesCol(siglog.ColSeverityText),
+		traceID:      bytesCol(siglog.ColTraceID),
+		spanID:       bytesCol(siglog.ColSpanID),
+		attrs:        bytesCol(siglog.ColAttrs),
+		severity:     intCol(siglog.ColSeverity),
+		resource:     otelAttrs(batch.Series.Resource.Attributes),
+		scopeName:    string(batch.Series.Scope.Name),
+		scopeVersion: string(batch.Series.Scope.Version),
+		scopeAttrs:   otelAttrs(batch.Series.Scope.Attributes),
+	}
+}
+
+// record materializes row i into a [logstorage.Record].
+func (c logColumns) record(batch *fetch.Batch, i int) logstorage.Record {
+	r := logstorage.Record{
+		Timestamp:     otelstorage.Timestamp(batch.Timestamps[i]),
+		ResourceAttrs: c.resource,
+		ScopeName:     c.scopeName,
+		ScopeVersion:  c.scopeVersion,
+		ScopeAttrs:    c.scopeAttrs,
+	}
+	if i < len(c.body) {
+		r.Body = string(c.body[i])
+	}
+	if i < len(c.severityText) {
+		r.SeverityText = string(c.severityText[i])
+	}
+	if i < len(c.severity) {
+		r.SeverityNumber = plog.SeverityNumber(c.severity[i])
+	}
+	if i < len(c.traceID) {
+		r.TraceID = otelTraceID(c.traceID[i])
+	}
+	if i < len(c.spanID) {
+		r.SpanID = otelSpanID(c.spanID[i])
+	}
+	if i < len(c.attrs) {
+		if attrs, _, err := signal.DecodeAttributes(c.attrs[i]); err == nil {
+			r.Attrs = otelAttrs(attrs)
+		}
+	}
+	return r
+}
+
+// matchSelector reports whether the label set satisfies every selector matcher, treating an absent
+// label as the empty string (Loki semantics).
+func matchSelector(set logqlabels.LabelSet, matchers []logql.LabelMatcher) bool {
+	for _, m := range matchers {
+		value, _ := set.GetString(m.Label)
+		if !matchLabel(m, value) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchLabel evaluates one LogQL label matcher against a value.
+func matchLabel(m logql.LabelMatcher, value string) bool {
+	switch m.Op {
+	case logql.OpEq:
+		return value == m.Value
+	case logql.OpNotEq:
+		return value != m.Value
+	case logql.OpRe:
+		return m.Re != nil && m.Re.MatchString(value)
+	case logql.OpNotRe:
+		return m.Re != nil && !m.Re.MatchString(value)
+	default:
+		return false
+	}
+}
+
+// LabelNames implements [logstorage.Querier]. It returns the distinct label names of the streams
+// matching the options' selector.
+func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptions) ([]string, error) {
+	names := map[string]struct{}{}
+	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, _ string) {
+		names[name] = struct{}{}
+	}); err != nil {
+		return nil, err
+	}
+	out := sortedKeys(names)
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+// LabelValues implements [logstorage.Querier]. It returns the distinct values of labelName across
+// the streams matching the options' selector.
+func (q *LogQuerier) LabelValues(ctx context.Context, labelName string, opts logstorage.LabelsOptions) (iterators.Iterator[logstorage.Label], error) {
+	values := map[string]struct{}{}
+	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
+		if name == labelName {
+			values[value] = struct{}{}
+		}
+	}); err != nil {
+		return nil, err
+	}
+	keys := sortedKeys(values)
+	if opts.Limit > 0 && len(keys) > opts.Limit {
+		keys = keys[:opts.Limit]
+	}
+	labelsOut := make([]logstorage.Label, len(keys))
+	for i, v := range keys {
+		labelsOut[i] = logstorage.Label{Name: labelName, Value: v}
+	}
+	return iterators.Slice(labelsOut), nil
+}
+
+// Series implements [logstorage.Querier]. It returns the label sets of the streams matching any of
+// the option selectors.
+func (q *LogQuerier) Series(ctx context.Context, opts logstorage.SeriesOptions) (logstorage.Series, error) {
+	selectors := opts.Selectors
+	if len(selectors) == 0 {
+		selectors = []logql.Selector{{}}
+	}
+
+	seen := map[string]map[string]string{}
+	for _, sel := range selectors {
+		streams, err := q.logStreams(ctx, opts.Start, opts.End, sel.Matchers)
+		if err != nil {
+			return nil, err
+		}
+		for _, set := range streams {
+			m := set.AsMap()
+			key := seriesKey(m)
+			seen[key] = m
+		}
+	}
+
+	out := make(logstorage.Series, 0, len(seen))
+	for _, key := range sortedKeys(toSet(seen)) {
+		out = append(out, seen[key])
+	}
+	return out, nil
+}
+
+// DetectedLabels implements [logstorage.Querier]. It returns the cardinality of each stream label.
+func (q *LogQuerier) DetectedLabels(ctx context.Context, opts logstorage.LabelsOptions) ([]logstorage.DetectedLabel, error) {
+	values := map[string]map[string]struct{}{}
+	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
+		set, ok := values[name]
+		if !ok {
+			set = map[string]struct{}{}
+			values[name] = set
+		}
+		set[value] = struct{}{}
+	}); err != nil {
+		return nil, err
+	}
+
+	out := make([]logstorage.DetectedLabel, 0, len(values))
+	for _, name := range sortedKeys(toSet(values)) {
+		out = append(out, logstorage.DetectedLabel{Name: name, Cardinality: len(values[name])})
+	}
+	return out, nil
+}
+
+// DetectedFields implements [logstorage.Querier]. The storage backend does not parse record fields,
+// so it reports the stream labels as string fields with their value cardinality.
+func (q *LogQuerier) DetectedFields(ctx context.Context, opts logstorage.LabelsOptions) ([]logstorage.DetectedField, error) {
+	values := map[string]map[string]struct{}{}
+	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
+		set, ok := values[name]
+		if !ok {
+			set = map[string]struct{}{}
+			values[name] = set
+		}
+		set[value] = struct{}{}
+	}); err != nil {
+		return nil, err
+	}
+
+	out := make([]logstorage.DetectedField, 0, len(values))
+	for _, name := range sortedKeys(toSet(values)) {
+		out = append(out, logstorage.DetectedField{
+			Name:        name,
+			Type:        "string",
+			Cardinality: uint64(len(values[name])),
+		})
+	}
+	return out, nil
+}
+
+// logStreams returns the label sets of the streams matching the selector within [start, end].
+func (q *LogQuerier) logStreams(ctx context.Context, start, end time.Time, matchers []logql.LabelMatcher) ([]logqlabels.LabelSet, error) {
+	lo, hi := seriesWindow(start, end)
+	series, err := q.b.store.LogSeries(ctx, q.b.tenant, nil, lo, hi)
+	if err != nil {
+		return nil, errors.Wrap(err, "log series")
+	}
+
+	var out []logqlabels.LabelSet
+	for _, s := range series {
+		set := logqlabels.NewLabelSet()
+		set.SetAttrs(otelAttrs(s.Resource.Attributes), otelAttrs(s.Scope.Attributes))
+		if !matchSelector(set, matchers) {
+			continue
+		}
+		out = append(out, set)
+	}
+	return out, nil
+}
+
+// forEachLogStreamLabel calls fn for every (name, value) label pair of every matching stream.
+func (q *LogQuerier) forEachLogStreamLabel(ctx context.Context, start, end time.Time, matchers []logql.LabelMatcher, fn func(name, value string)) error {
+	streams, err := q.logStreams(ctx, start, end, matchers)
+	if err != nil {
+		return err
+	}
+	for _, set := range streams {
+		for name, value := range set.AsMap() {
+			fn(name, value)
+		}
+	}
+	return nil
+}
+
+// seriesKey is a deterministic key for a label set, used to dedupe series.
+func seriesKey(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf []byte
+	for _, k := range keys {
+		buf = append(buf, k...)
+		buf = append(buf, 0)
+		buf = append(buf, m[k]...)
+		buf = append(buf, 0)
+	}
+	return string(buf)
+}
+
+// toSet returns a set of the keys of m.
+func toSet[V any](m map[string]V) map[string]struct{} {
+	out := make(map[string]struct{}, len(m))
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out
+}

--- a/internal/storagebackend/profiles.go
+++ b/internal/storagebackend/profiles.go
@@ -1,0 +1,294 @@
+package storagebackend
+
+import (
+	"context"
+	"regexp"
+	"sort"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	sigprofile "github.com/oteldb/storage/signal/profile"
+
+	"github.com/oteldb/oteldb/internal/profileql"
+	"github.com/oteldb/oteldb/internal/profilestorage"
+)
+
+var _ profilestorage.Querier = (*ProfileQuerier)(nil)
+
+// reservedProfileLabels are the stream-identity labels carrying the profile type (see
+// signal/profile). They are folded into a stream's identity like a metric's __name__ and are not
+// user labels, so they are hidden from LabelNames/LabelValues and never matched against directly.
+var reservedProfileLabels = map[string]struct{}{
+	string(sigprofile.LabelSampleType): {},
+	string(sigprofile.LabelSampleUnit): {},
+	string(sigprofile.LabelPeriodType): {},
+	string(sigprofile.LabelPeriodUnit): {},
+}
+
+// ProfileTypes implements [profilestorage.Querier]. It enumerates the distinct profile types of the
+// tenant's streams in the window, reading the type out of each series' reserved labels.
+func (q *ProfileQuerier) ProfileTypes(ctx context.Context, opts profilestorage.ProfileTypesOptions) ([]profileql.ProfileType, error) {
+	start, end := seriesWindow(opts.Start, opts.End)
+	series, err := q.b.store.ProfileSeries(ctx, q.b.tenant, nil, start, end)
+	if err != nil {
+		return nil, errors.Wrap(err, "profile series")
+	}
+
+	seen := map[string]profileql.ProfileType{}
+	for _, s := range series {
+		pt := profileTypeOf(s)
+		seen[pt.ID()] = pt
+	}
+
+	out := make([]profileql.ProfileType, 0, len(seen))
+	for _, pt := range seen {
+		out = append(out, pt)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID() < out[j].ID() })
+	return out, nil
+}
+
+// LabelNames implements [profilestorage.Querier]. It returns the distinct user-label names of the
+// streams matching the selector, excluding the reserved profile-type labels.
+func (q *ProfileQuerier) LabelNames(ctx context.Context, opts profilestorage.LabelNamesOptions) ([]string, error) {
+	matchers, err := profileFetchMatchers(opts.Type, opts.Matchers)
+	if err != nil {
+		return nil, err
+	}
+	start, end := seriesWindow(opts.Start, opts.End)
+	series, err := q.b.store.ProfileSeries(ctx, q.b.tenant, matchers, start, end)
+	if err != nil {
+		return nil, errors.Wrap(err, "profile series")
+	}
+
+	names := map[string]struct{}{}
+	forEachUserLabel(series, func(name, _ string) {
+		names[name] = struct{}{}
+	})
+	return sortedKeys(names), nil
+}
+
+// LabelValues implements [profilestorage.Querier]. It returns the distinct values the given label
+// takes across the streams matching the selector.
+func (q *ProfileQuerier) LabelValues(ctx context.Context, label string, opts profilestorage.LabelValuesOptions) ([]string, error) {
+	matchers, err := profileFetchMatchers(opts.Type, opts.Matchers)
+	if err != nil {
+		return nil, err
+	}
+	start, end := seriesWindow(opts.Start, opts.End)
+	series, err := q.b.store.ProfileSeries(ctx, q.b.tenant, matchers, start, end)
+	if err != nil {
+		return nil, errors.Wrap(err, "profile series")
+	}
+
+	values := map[string]struct{}{}
+	forEachUserLabel(series, func(name, value string) {
+		if name == label {
+			values[value] = struct{}{}
+		}
+	})
+	return sortedKeys(values), nil
+}
+
+// SelectMergeProfile implements [profilestorage.Querier]. It fetches every matching sample, resolves
+// each sample's content-addressed stack to function frames, and merges them into a single
+// flamegraph tree.
+func (q *ProfileQuerier) SelectMergeProfile(ctx context.Context, params profilestorage.SelectProfileParams) (*profilestorage.FlameTree, error) {
+	matchers, err := profileFetchMatchers(&params.Type, params.Matchers)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver, err := q.b.store.ProfileResolver(ctx, q.b.tenant)
+	if err != nil {
+		return nil, errors.Wrap(err, "profile resolver")
+	}
+
+	lo, hi := fetchWindow(params.Start, params.End)
+	req := fetch.Request{
+		Tenant:     q.b.tenant,
+		Signal:     signal.Profile,
+		Start:      lo,
+		End:        hi,
+		Matchers:   matchers,
+		Projection: []string{sigprofile.ColStackID, sigprofile.ColValue},
+	}
+
+	it, err := q.b.store.ProfileFetcher(q.b.tenant).Fetch(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch profiles")
+	}
+	batches, err := fetch.Drain(ctx, it)
+	if err != nil {
+		return nil, errors.Wrap(err, "drain profiles")
+	}
+
+	root := &profilestorage.FlameNode{Name: "root"}
+	for _, batch := range batches {
+		stacks, ok := batch.Column(sigprofile.ColStackID)
+		if !ok {
+			continue
+		}
+		values, hasValues := batch.Column(sigprofile.ColValue)
+		for i, stackID := range stacks.Bytes {
+			var value int64 = 1
+			if hasValues && i < len(values.Int64) {
+				value = values.Int64[i]
+			}
+			frames := resolver.Resolve(stackID)
+			mergeStack(root, frames, value)
+		}
+	}
+
+	return &profilestorage.FlameTree{Root: root}, nil
+}
+
+// mergeStack folds one sample's leaf-first frames into the tree rooted at root, accumulating value
+// into every node on the root→leaf path (Total) and into the leaf (Self).
+func mergeStack(root *profilestorage.FlameNode, frames []sigprofile.Frame, value int64) {
+	root.Total += value
+	if len(frames) == 0 {
+		root.Self += value
+		return
+	}
+
+	node := root
+	// frames are leaf-first; walk the call path outermost→leaf so the tree reads root→leaf.
+	for i := len(frames) - 1; i >= 0; i-- {
+		name := frames[i].Function
+		child := childByName(node, name)
+		if child == nil {
+			child = &profilestorage.FlameNode{Name: name}
+			node.Children = append(node.Children, child)
+		}
+		child.Total += value
+		node = child
+	}
+	node.Self += value
+}
+
+// childByName returns the named child of node, or nil when absent.
+func childByName(node *profilestorage.FlameNode, name string) *profilestorage.FlameNode {
+	for _, c := range node.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// profileTypeOf reconstructs a [profileql.ProfileType] from a stream's reserved type labels. The
+// Pyroscope-style Name is not carried in storage, so it is derived from the sample type.
+func profileTypeOf(s signal.Series) profileql.ProfileType {
+	get := func(key []byte) string {
+		if v, ok := s.Resource.Attributes.Get(key); ok {
+			return valueText(v)
+		}
+		if v, ok := s.Scope.Attributes.Get(key); ok {
+			return valueText(v)
+		}
+		return ""
+	}
+	pt := profileql.ProfileType{
+		SampleType: get(sigprofile.LabelSampleType),
+		SampleUnit: get(sigprofile.LabelSampleUnit),
+		PeriodType: get(sigprofile.LabelPeriodType),
+		PeriodUnit: get(sigprofile.LabelPeriodUnit),
+	}
+	pt.Name = pt.SampleType
+	return pt
+}
+
+// forEachUserLabel calls fn for every non-reserved resource/scope attribute of every series.
+func forEachUserLabel(series []signal.Series, fn func(name, value string)) {
+	for _, s := range series {
+		visit := func(attrs signal.Attributes) {
+			for _, kv := range attrs {
+				name := string(kv.Key)
+				if _, reserved := reservedProfileLabels[name]; reserved {
+					continue
+				}
+				fn(name, valueText(kv.Value))
+			}
+		}
+		visit(s.Resource.Attributes)
+		visit(s.Scope.Attributes)
+	}
+}
+
+// profileFetchMatchers builds the fetch matchers selecting the streams of a profile-type plus the
+// user label matchers. The profile type contributes equality matchers on the reserved labels.
+func profileFetchMatchers(typ *profileql.ProfileType, matchers []profileql.LabelMatcher) ([]fetch.Matcher, error) {
+	var out []fetch.Matcher
+	if typ != nil {
+		add := func(name []byte, value string) {
+			if value == "" {
+				return
+			}
+			out = append(out, equalMatcher(name, value))
+		}
+		add(sigprofile.LabelSampleType, typ.SampleType)
+		add(sigprofile.LabelSampleUnit, typ.SampleUnit)
+		add(sigprofile.LabelPeriodType, typ.PeriodType)
+		add(sigprofile.LabelPeriodUnit, typ.PeriodUnit)
+	}
+	for _, m := range matchers {
+		fm, err := profileLabelMatcher(m)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fm)
+	}
+	return out, nil
+}
+
+// profileLabelMatcher compiles one ProfileQL label matcher into a fetch matcher.
+func profileLabelMatcher(m profileql.LabelMatcher) (fetch.Matcher, error) {
+	name := []byte(string(m.Label))
+	switch m.Op {
+	case profileql.OpEq:
+		return equalMatcher(name, m.Value), nil
+	case profileql.OpNotEq:
+		value := m.Value
+		return fetch.Matcher{Name: name, Match: func(v signal.Value) bool {
+			return valueText(v) != value
+		}}, nil
+	case profileql.OpRe, profileql.OpNotRe:
+		re := m.Re
+		if re == nil {
+			compiled, err := regexp.Compile("^(?:" + m.Value + ")$")
+			if err != nil {
+				return fetch.Matcher{}, errors.Wrap(err, "compile matcher")
+			}
+			re = compiled
+		}
+		negate := m.Op == profileql.OpNotRe
+		return fetch.Matcher{Name: name, Match: func(v signal.Value) bool {
+			return re.MatchString(valueText(v)) != negate
+		}}, nil
+	default:
+		return fetch.Matcher{}, errors.Errorf("unsupported matcher op %v", m.Op)
+	}
+}
+
+// equalMatcher builds an exact-equality fetch matcher, also setting the serializable Spec so the
+// cluster fan-out can push it to peers.
+func equalMatcher(name []byte, value string) fetch.Matcher {
+	return fetch.Matcher{
+		Name:  name,
+		Match: func(v signal.Value) bool { return valueText(v) == value },
+		Spec:  &fetch.EqualMatcher{Name: string(name), Value: value},
+	}
+}
+
+// sortedKeys returns the sorted keys of set.
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/storagebackend/profiles.go
+++ b/internal/storagebackend/profiles.go
@@ -3,6 +3,7 @@ package storagebackend
 import (
 	"context"
 	"regexp"
+	"slices"
 	"sort"
 
 	"github.com/go-faster/errors"
@@ -156,8 +157,8 @@ func mergeStack(root *profilestorage.FlameNode, frames []sigprofile.Frame, value
 
 	node := root
 	// frames are leaf-first; walk the call path outermost→leaf so the tree reads root→leaf.
-	for i := len(frames) - 1; i >= 0; i-- {
-		name := frames[i].Function
+	for _, frame := range slices.Backward(frames) {
+		name := frame.Function
 		child := childByName(node, name)
 		if child == nil {
 			child = &profilestorage.FlameNode{Name: name}

--- a/internal/storagebackend/query.go
+++ b/internal/storagebackend/query.go
@@ -1,0 +1,44 @@
+package storagebackend
+
+import (
+	"math"
+	"time"
+
+	"github.com/oteldb/storage/signal"
+)
+
+// fetchWindow converts an optional [start, end] time range into the unix-nanosecond bounds
+// expected by a [fetch.Request]. A zero start or end widens that side to the full range, so a
+// query without an explicit bound scans everything (mirroring how the metrics adapter clamps the
+// Prometheus millisecond window).
+func fetchWindow(start, end time.Time) (int64, int64) {
+	lo := int64(math.MinInt64)
+	if !start.IsZero() {
+		lo = start.UnixNano()
+	}
+	hi := int64(math.MaxInt64)
+	if !end.IsZero() {
+		hi = end.UnixNano()
+	}
+	return lo, hi
+}
+
+// seriesWindow converts an optional [start, end] range into the (start, end) unix-nanosecond
+// arguments of [storage.Storage.ProfileSeries] and similar enumeration primitives, where a zero
+// pair disables the time filter. A half-open range keeps the set bound it was given.
+func seriesWindow(start, end time.Time) (int64, int64) {
+	var lo, hi int64
+	if !start.IsZero() {
+		lo = start.UnixNano()
+	}
+	if !end.IsZero() {
+		hi = end.UnixNano()
+	}
+	return lo, hi
+}
+
+// valueText renders a typed storage value to its canonical text form, the representation matchers
+// and label enumeration compare against.
+func valueText(v signal.Value) string {
+	return string(v.AppendText(nil))
+}

--- a/internal/storagebackend/query.go
+++ b/internal/storagebackend/query.go
@@ -11,12 +11,12 @@ import (
 // expected by a [fetch.Request]. A zero start or end widens that side to the full range, so a
 // query without an explicit bound scans everything (mirroring how the metrics adapter clamps the
 // Prometheus millisecond window).
-func fetchWindow(start, end time.Time) (int64, int64) {
-	lo := int64(math.MinInt64)
+func fetchWindow(start, end time.Time) (lo, hi int64) {
+	lo = int64(math.MinInt64)
 	if !start.IsZero() {
 		lo = start.UnixNano()
 	}
-	hi := int64(math.MaxInt64)
+	hi = int64(math.MaxInt64)
 	if !end.IsZero() {
 		hi = end.UnixNano()
 	}
@@ -26,8 +26,7 @@ func fetchWindow(start, end time.Time) (int64, int64) {
 // seriesWindow converts an optional [start, end] range into the (start, end) unix-nanosecond
 // arguments of [storage.Storage.ProfileSeries] and similar enumeration primitives, where a zero
 // pair disables the time filter. A half-open range keeps the set bound it was given.
-func seriesWindow(start, end time.Time) (int64, int64) {
-	var lo, hi int64
+func seriesWindow(start, end time.Time) (lo, hi int64) {
 	if !start.IsZero() {
 		lo = start.UnixNano()
 	}

--- a/internal/storagebackend/signals.go
+++ b/internal/storagebackend/signals.go
@@ -1,0 +1,28 @@
+package storagebackend
+
+// The logs and profiles query interfaces both declare LabelNames/LabelValues with different
+// signatures, so a single type cannot satisfy both. Each signal's read interface is therefore
+// implemented by its own small wrapper over the shared [Backend] (and its single *storage.Storage),
+// obtained via the accessors below. Metrics stay on [Backend] directly (its interface does not
+// collide).
+
+// LogQuerier adapts the storage engine to oteldb's logs query interfaces
+// (logstorage.Querier and logqlengine.Querier).
+type LogQuerier struct{ b *Backend }
+
+// TraceQuerier adapts the storage engine to oteldb's traces query interfaces
+// (tracestorage.Querier and traceqlengine.Querier).
+type TraceQuerier struct{ b *Backend }
+
+// ProfileQuerier adapts the storage engine to oteldb's profiles query interface
+// (profilestorage.Querier).
+type ProfileQuerier struct{ b *Backend }
+
+// Logs returns the logs querier over the backend's storage engine.
+func (b *Backend) Logs() *LogQuerier { return &LogQuerier{b: b} }
+
+// Traces returns the traces querier over the backend's storage engine.
+func (b *Backend) Traces() *TraceQuerier { return &TraceQuerier{b: b} }
+
+// Profiles returns the profiles querier over the backend's storage engine.
+func (b *Backend) Profiles() *ProfileQuerier { return &ProfileQuerier{b: b} }

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -1,0 +1,230 @@
+package storagebackend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/profileql"
+	"github.com/oteldb/oteldb/internal/profilestorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+func newBackend(t *testing.T) (*storagebackend.Backend, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+	return storagebackend.New(store), ctx
+}
+
+// TestBackendLogsRoundtrip ingests OTLP logs through the storage sink and queries them back through
+// the LogQL querier adapter.
+func TestBackendLogsRoundtrip(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	sl := rl.ScopeLogs().AppendEmpty()
+	rec := sl.LogRecords().AppendEmpty()
+	rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	rec.Body().SetStr("hello world")
+	rec.SetSeverityNumber(plog.SeverityNumberInfo)
+
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	lq := b.Logs()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	// Pipeline query for the stream.
+	node, err := lq.Query(ctx, []logql.LabelMatcher{{Label: "service_name", Op: logql.OpEq, Value: "api"}})
+	require.NoError(t, err)
+	it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+	require.NoError(t, err)
+	entries := drain(t, it)
+	require.Len(t, entries, 1)
+	require.Equal(t, "hello world", entries[0].Line)
+
+	// A non-matching selector yields nothing.
+	node, err = lq.Query(ctx, []logql.LabelMatcher{{Label: "service_name", Op: logql.OpEq, Value: "other"}})
+	require.NoError(t, err)
+	it, err = node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+	require.NoError(t, err)
+	require.Empty(t, drain(t, it))
+
+	// LabelNames includes the stream label.
+	names, err := lq.LabelNames(ctx, logstorage.LabelsOptions{Start: start, End: end})
+	require.NoError(t, err)
+	require.Contains(t, names, "service_name")
+
+	// Series returns the stream label set.
+	series, err := lq.Series(ctx, logstorage.SeriesOptions{Start: start, End: end})
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	require.Equal(t, "api", series[0]["service_name"])
+}
+
+// TestBackendTracesRoundtrip ingests OTLP spans through the storage sink and queries them back
+// through the traces querier adapter.
+func TestBackendTracesRoundtrip(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "api")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	parent := ss.Spans().AppendEmpty()
+	parent.SetTraceID(traceID)
+	parent.SetSpanID(pcommon.SpanID([8]byte{1, 1, 1, 1, 1, 1, 1, 1}))
+	parent.SetName("GET /")
+	parent.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	parent.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	parent.Attributes().PutStr("http.method", "GET")
+
+	child := ss.Spans().AppendEmpty()
+	child.SetTraceID(traceID)
+	child.SetSpanID(pcommon.SpanID([8]byte{2, 2, 2, 2, 2, 2, 2, 2}))
+	child.SetName("db.query")
+	child.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	child.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+
+	require.NoError(t, b.ConsumeTraces(ctx, td))
+
+	tq := b.Traces()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	// TraceByID returns both spans.
+	var id [16]byte = traceID
+	spans := drain(t, mustTraceByID(t, ctx, tq, id, start, end))
+	require.Len(t, spans, 2)
+
+	// SearchTags by span attribute returns the matching span.
+	found := drain(t, mustSearchTags(t, ctx, tq, map[string]string{"http.method": "GET"}, start, end))
+	require.Len(t, found, 1)
+	require.Equal(t, "GET /", found[0].Name)
+
+	// TagNames includes the span attribute.
+	tagNames, err := tq.TagNames(ctx, tracestorage.TagNamesOptions{Start: start, End: end})
+	require.NoError(t, err)
+	var keys []string
+	for _, tn := range tagNames {
+		keys = append(keys, tn.Name)
+	}
+	require.Contains(t, keys, "http.method")
+}
+
+// TestBackendProfilesRoundtrip ingests an OTLP profile through the storage sink and queries the
+// merged flamegraph back through the profiles querier adapter.
+func TestBackendProfilesRoundtrip(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+
+	pd := pprofile.NewProfiles()
+	dict := pd.Dictionary()
+	dict.StringTable().Append("", "cpu", "nanoseconds", "main")
+
+	fn := dict.FunctionTable().AppendEmpty()
+	fn.SetNameStrindex(3)
+	mp := dict.MappingTable().AppendEmpty()
+	mp.SetFilenameStrindex(3)
+	loc := dict.LocationTable().AppendEmpty()
+	loc.SetMappingIndex(0)
+	line := loc.Lines().AppendEmpty()
+	line.SetFunctionIndex(0)
+	line.SetLine(42)
+	stack := dict.StackTable().AppendEmpty()
+	stack.LocationIndices().Append(0)
+
+	rp := pd.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutStr("service.name", "api")
+	scp := rp.ScopeProfiles().AppendEmpty()
+	p := scp.Profiles().AppendEmpty()
+	p.SampleType().SetTypeStrindex(1)
+	p.SampleType().SetUnitStrindex(2)
+	p.PeriodType().SetTypeStrindex(1)
+	p.PeriodType().SetUnitStrindex(2)
+	p.SetTime(pcommon.Timestamp(ts.UnixNano()))
+	s := p.Samples().AppendEmpty()
+	s.SetStackIndex(0)
+	s.Values().Append(123)
+	s.TimestampsUnixNano().Append(uint64(ts.UnixNano()))
+
+	require.NoError(t, b.ConsumeProfiles(ctx, pd))
+
+	pq := b.Profiles()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	// ProfileTypes enumerates the ingested type.
+	types, err := pq.ProfileTypes(ctx, profilestorage.ProfileTypesOptions{Start: start, End: end})
+	require.NoError(t, err)
+	require.Len(t, types, 1)
+	require.Equal(t, "cpu", types[0].SampleType)
+	require.Equal(t, "nanoseconds", types[0].SampleUnit)
+
+	// SelectMergeProfile resolves the stack and accumulates the sample value.
+	tree, err := pq.SelectMergeProfile(ctx, profilestorage.SelectProfileParams{
+		Type: profileql.ProfileType{
+			Name:       "cpu",
+			SampleType: "cpu",
+			SampleUnit: "nanoseconds",
+			PeriodType: "cpu",
+			PeriodUnit: "nanoseconds",
+		},
+		Start: start,
+		End:   end,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(123), tree.Total())
+	require.NotNil(t, tree.Root)
+	require.Len(t, tree.Root.Children, 1)
+	require.Equal(t, "main", tree.Root.Children[0].Name)
+	require.Equal(t, int64(123), tree.Root.Children[0].Self)
+}
+
+func drain[T any](t *testing.T, it iterators.Iterator[T]) []T {
+	t.Helper()
+	t.Cleanup(func() { _ = it.Close() })
+	var out []T
+	var v T
+	for it.Next(&v) {
+		out = append(out, v)
+	}
+	require.NoError(t, it.Err())
+	return out
+}
+
+func mustTraceByID(t *testing.T, ctx context.Context, tq *storagebackend.TraceQuerier, id [16]byte, start, end time.Time) iterators.Iterator[tracestorage.Span] {
+	t.Helper()
+	it, err := tq.TraceByID(ctx, id, tracestorage.TraceByIDOptions{Start: start, End: end})
+	require.NoError(t, err)
+	return it
+}
+
+func mustSearchTags(t *testing.T, ctx context.Context, tq *storagebackend.TraceQuerier, tags map[string]string, start, end time.Time) iterators.Iterator[tracestorage.Span] {
+	t.Helper()
+	it, err := tq.SearchTags(ctx, tags, tracestorage.SearchTagsOptions{Start: start, End: end})
+	require.NoError(t, err)
+	return it
+}

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -116,11 +116,11 @@ func TestBackendTracesRoundtrip(t *testing.T) {
 
 	// TraceByID returns both spans.
 	var id [16]byte = traceID
-	spans := drain(t, mustTraceByID(t, ctx, tq, id, start, end))
+	spans := drain(t, mustTraceByID(ctx, t, tq, id, start, end))
 	require.Len(t, spans, 2)
 
 	// SearchTags by span attribute returns the matching span.
-	found := drain(t, mustSearchTags(t, ctx, tq, map[string]string{"http.method": "GET"}, start, end))
+	found := drain(t, mustSearchTags(ctx, t, tq, map[string]string{"http.method": "GET"}, start, end))
 	require.Len(t, found, 1)
 	require.Equal(t, "GET /", found[0].Name)
 
@@ -215,14 +215,14 @@ func drain[T any](t *testing.T, it iterators.Iterator[T]) []T {
 	return out
 }
 
-func mustTraceByID(t *testing.T, ctx context.Context, tq *storagebackend.TraceQuerier, id [16]byte, start, end time.Time) iterators.Iterator[tracestorage.Span] {
+func mustTraceByID(ctx context.Context, t *testing.T, tq *storagebackend.TraceQuerier, id [16]byte, start, end time.Time) iterators.Iterator[tracestorage.Span] {
 	t.Helper()
 	it, err := tq.TraceByID(ctx, id, tracestorage.TraceByIDOptions{Start: start, End: end})
 	require.NoError(t, err)
 	return it
 }
 
-func mustSearchTags(t *testing.T, ctx context.Context, tq *storagebackend.TraceQuerier, tags map[string]string, start, end time.Time) iterators.Iterator[tracestorage.Span] {
+func mustSearchTags(ctx context.Context, t *testing.T, tq *storagebackend.TraceQuerier, tags map[string]string, start, end time.Time) iterators.Iterator[tracestorage.Span] {
 	t.Helper()
 	it, err := tq.SearchTags(ctx, tags, tracestorage.SearchTagsOptions{Start: start, End: end})
 	require.NoError(t, err)

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -1,12 +1,14 @@
-// Package storagebackend adapts the embeddable github.com/oteldb/storage engine to
-// oteldb's metric query and ingestion interfaces, so the metrics signal can be served from
-// the native Go storage engine instead of ClickHouse.
+// Package storagebackend adapts the embeddable github.com/oteldb/storage engine to oteldb's
+// query and ingestion interfaces, so any signal can be served from the native Go storage
+// engine instead of ClickHouse.
 //
-// Only the metrics path is wired: the storage engine currently implements metrics
-// (gauge/sum) end-to-end, while logs and traces stay on ClickHouse. A Backend implements
-// oteldb's metric querier seam (Prometheus storage.Queryable + ExemplarQueryable, the PromQL
-// engine's MetricsScanners, and metricstorage.MetadataQuerier) and the metrics ingestion
-// sink (ConsumeMetrics) over a single shared *storage.Storage instance.
+// All four signals are wired over a single shared *storage.Storage instance. [Backend]
+// implements the metrics seam directly (Prometheus storage.Queryable + ExemplarQueryable, the
+// PromQL engine's MetricsScanners, metricstorage.MetadataQuerier) and the ingestion sinks for
+// every signal (ConsumeMetrics/ConsumeTraces/ConsumeLogs/ConsumeProfiles). Because the logs and
+// profiles read interfaces declare colliding method names, each non-metric signal's query
+// interface is implemented by a small wrapper obtained via [Backend.Logs], [Backend.Traces],
+// and [Backend.Profiles] (see signals.go).
 package storagebackend
 
 import (

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -1,0 +1,339 @@
+package storagebackend
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/traceql"
+	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+var (
+	_ tracestorage.Querier  = (*TraceQuerier)(nil)
+	_ traceqlengine.Querier = (*TraceQuerier)(nil)
+)
+
+// SelectSpansets implements [traceqlengine.Querier]. It returns every trace whose spans fall in the
+// window, grouped by trace id; the TraceQL engine evaluates the spanset matchers on the result
+// (mirroring the in-memory reference querier).
+func (q *TraceQuerier) SelectSpansets(ctx context.Context, params traceqlengine.SelectSpansetsParams) (iterators.Iterator[traceqlengine.Trace], error) {
+	spans, err := q.scanSpans(ctx, params.Start, params.End)
+	if err != nil {
+		return nil, err
+	}
+
+	order := make([]otelstorage.TraceID, 0)
+	byTrace := map[otelstorage.TraceID][]tracestorage.Span{}
+	for _, span := range spans {
+		if _, ok := byTrace[span.TraceID]; !ok {
+			order = append(order, span.TraceID)
+		}
+		byTrace[span.TraceID] = append(byTrace[span.TraceID], span)
+	}
+
+	traces := make([]traceqlengine.Trace, 0, len(order))
+	for _, id := range order {
+		if params.Limit > 0 && len(traces) >= params.Limit {
+			break
+		}
+		traces = append(traces, traceqlengine.Trace{TraceID: id, Spans: byTrace[id]})
+	}
+	return iterators.Slice(traces), nil
+}
+
+// TraceByID implements [tracestorage.Querier]. It fetches every span of one trace by id.
+func (q *TraceQuerier) TraceByID(ctx context.Context, id otelstorage.TraceID, _ tracestorage.TraceByIDOptions) (iterators.Iterator[tracestorage.Span], error) {
+	batches, err := q.b.store.Trace(ctx, q.b.tenant, id[:])
+	if err != nil {
+		return nil, errors.Wrap(err, "trace by id")
+	}
+	var spans []tracestorage.Span
+	for _, batch := range batches {
+		spans = append(spans, materializeSpans(batch)...)
+	}
+	return iterators.Slice(spans), nil
+}
+
+// SearchTags implements [tracestorage.Querier]. It returns the spans whose attributes match every
+// requested tag and whose duration is within the optional bounds.
+func (q *TraceQuerier) SearchTags(ctx context.Context, tags map[string]string, opts tracestorage.SearchTagsOptions) (iterators.Iterator[tracestorage.Span], error) {
+	spans, err := q.scanSpans(ctx, opts.Start, opts.End)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []tracestorage.Span
+	for _, span := range spans {
+		if !durationInRange(span, opts.MinDuration, opts.MaxDuration) {
+			continue
+		}
+		if spanMatchesTags(span, tags) {
+			out = append(out, span)
+		}
+	}
+	return iterators.Slice(out), nil
+}
+
+// TagNames implements [tracestorage.Querier]. It enumerates the distinct attribute names seen on the
+// spans in the window, restricted to the requested scope.
+func (q *TraceQuerier) TagNames(ctx context.Context, opts tracestorage.TagNamesOptions) ([]tracestorage.TagName, error) {
+	spans, err := q.scanSpans(ctx, opts.Start, opts.End)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[tracestorage.TagName]struct{}{}
+	for _, span := range spans {
+		forEachSpanTag(span, func(scope traceql.AttributeScope, name, _ string) {
+			if opts.Scope != traceql.ScopeNone && opts.Scope != scope {
+				return
+			}
+			seen[tracestorage.TagName{Scope: scope, Name: name}] = struct{}{}
+		})
+	}
+
+	out := make([]tracestorage.TagName, 0, len(seen))
+	for tn := range seen {
+		out = append(out, tn)
+	}
+	return out, nil
+}
+
+// TagValues implements [tracestorage.Querier]. It enumerates the distinct values the attribute takes
+// across the spans in the window.
+func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions) (iterators.Iterator[tracestorage.Tag], error) {
+	spans, err := q.scanSpans(ctx, opts.Start, opts.End)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]tracestorage.Tag{}
+	for _, span := range spans {
+		forEachSpanTag(span, func(scope traceql.AttributeScope, name, value string) {
+			if name != attr.Name {
+				return
+			}
+			if attr.Scope != traceql.ScopeNone && attr.Scope != scope {
+				return
+			}
+			seen[value] = tracestorage.Tag{Name: name, Value: value, Type: traceql.TypeString, Scope: scope}
+		})
+	}
+
+	out := make([]tracestorage.Tag, 0, len(seen))
+	for _, tag := range seen {
+		out = append(out, tag)
+	}
+	return iterators.Slice(out), nil
+}
+
+// scanSpans fetches and materializes every span in the window.
+func (q *TraceQuerier) scanSpans(ctx context.Context, start, end time.Time) ([]tracestorage.Span, error) {
+	lo, hi := fetchWindow(start, end)
+	req := fetch.Request{
+		Tenant: q.b.tenant,
+		Signal: signal.Trace,
+		Start:  lo,
+		End:    hi,
+	}
+
+	it, err := q.b.store.TraceFetcher(q.b.tenant).Fetch(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch spans")
+	}
+	batches, err := fetch.Drain(ctx, it)
+	if err != nil {
+		return nil, errors.Wrap(err, "drain spans")
+	}
+
+	var spans []tracestorage.Span
+	for _, batch := range batches {
+		spans = append(spans, materializeSpans(batch)...)
+	}
+	return spans, nil
+}
+
+// materializeSpans converts one trace batch into spans, decoding the per-span columns and the
+// stream's resource/scope identity.
+func materializeSpans(batch *fetch.Batch) []tracestorage.Span {
+	bytesCol := func(name string) [][]byte {
+		if c, ok := batch.Column(name); ok {
+			return c.Bytes
+		}
+		return nil
+	}
+	intCol := func(name string) []int64 {
+		if c, ok := batch.Column(name); ok {
+			return c.Int64
+		}
+		return nil
+	}
+
+	var (
+		duration  = intCol(sigtrace.ColDuration)
+		kind      = intCol(sigtrace.ColKind)
+		status    = intCol(sigtrace.ColStatusCode)
+		traceID   = bytesCol(sigtrace.ColTraceID)
+		spanID    = bytesCol(sigtrace.ColSpanID)
+		parentID  = bytesCol(sigtrace.ColParentSpanID)
+		name      = bytesCol(sigtrace.ColName)
+		statusMsg = bytesCol(sigtrace.ColStatusMsg)
+		attrs     = bytesCol(sigtrace.ColAttrs)
+		events    = bytesCol(sigtrace.ColEvents)
+		links     = bytesCol(sigtrace.ColLinks)
+
+		resourceAttrs = otelAttrs(batch.Series.Resource.Attributes)
+		scopeName     = string(batch.Series.Scope.Name)
+		scopeVersion  = string(batch.Series.Scope.Version)
+		scopeAttrs    = otelAttrs(batch.Series.Scope.Attributes)
+	)
+
+	at := func(s [][]byte, i int) []byte {
+		if i < len(s) {
+			return s[i]
+		}
+		return nil
+	}
+	atInt := func(s []int64, i int) int64 {
+		if i < len(s) {
+			return s[i]
+		}
+		return 0
+	}
+
+	spans := make([]tracestorage.Span, 0, len(batch.Timestamps))
+	for i := range batch.Timestamps {
+		start := batch.Timestamps[i]
+		span := tracestorage.Span{
+			TraceID:       otelTraceID(at(traceID, i)),
+			SpanID:        otelSpanID(at(spanID, i)),
+			ParentSpanID:  otelSpanID(at(parentID, i)),
+			Name:          string(at(name, i)),
+			Kind:          int32(atInt(kind, i)),
+			Start:         otelstorage.Timestamp(start),
+			End:           otelstorage.Timestamp(start + atInt(duration, i)),
+			StatusCode:    int32(atInt(status, i)),
+			StatusMessage: string(at(statusMsg, i)),
+			ResourceAttrs: resourceAttrs,
+			ScopeName:     scopeName,
+			ScopeVersion:  scopeVersion,
+			ScopeAttrs:    scopeAttrs,
+		}
+		if raw := at(attrs, i); len(raw) > 0 {
+			if decoded, _, err := signal.DecodeAttributes(raw); err == nil {
+				span.Attrs = otelAttrs(decoded)
+			}
+		}
+		if raw := at(events, i); len(raw) > 0 {
+			if decoded, err := sigtrace.DecodeEvents(raw); err == nil {
+				span.Events = convertEvents(decoded)
+			}
+		}
+		if raw := at(links, i); len(raw) > 0 {
+			if decoded, err := sigtrace.DecodeLinks(raw); err == nil {
+				span.Links = convertLinks(decoded)
+			}
+		}
+		spans = append(spans, span)
+	}
+	return spans
+}
+
+// convertEvents maps storage span events to tracestorage events.
+func convertEvents(evs []sigtrace.Event) []tracestorage.Event {
+	if len(evs) == 0 {
+		return nil
+	}
+	out := make([]tracestorage.Event, len(evs))
+	for i, e := range evs {
+		out[i] = tracestorage.Event{
+			Timestamp: otelstorage.Timestamp(e.Time),
+			Name:      string(e.Name),
+			Attrs:     otelAttrs(e.Attributes),
+		}
+	}
+	return out
+}
+
+// convertLinks maps storage span links to tracestorage links.
+func convertLinks(ls []sigtrace.Link) []tracestorage.Link {
+	if len(ls) == 0 {
+		return nil
+	}
+	out := make([]tracestorage.Link, len(ls))
+	for i, l := range ls {
+		out[i] = tracestorage.Link{
+			TraceID:    otelTraceID(l.TraceID),
+			SpanID:     otelSpanID(l.SpanID),
+			TraceState: string(l.TraceState),
+			Attrs:      otelAttrs(l.Attributes),
+		}
+	}
+	return out
+}
+
+// durationInRange reports whether the span's duration is within the optional [min, max] bounds.
+func durationInRange(span tracestorage.Span, min, max time.Duration) bool {
+	d := time.Duration(span.End - span.Start)
+	if min > 0 && d < min {
+		return false
+	}
+	if max > 0 && d > max {
+		return false
+	}
+	return true
+}
+
+// spanMatchesTags reports whether the span carries every requested tag with the requested value.
+func spanMatchesTags(span tracestorage.Span, tags map[string]string) bool {
+	for k, want := range tags {
+		got, ok := lookupSpanTag(span, k)
+		if !ok || got != want {
+			return false
+		}
+	}
+	return true
+}
+
+// lookupSpanTag returns the string value of a tag on the span, searching the intrinsic name, then
+// span, resource, and scope attributes.
+func lookupSpanTag(span tracestorage.Span, name string) (string, bool) {
+	if name == "name" {
+		return span.Name, span.Name != ""
+	}
+	for _, attrs := range []otelstorage.Attrs{span.Attrs, span.ResourceAttrs, span.ScopeAttrs} {
+		if attrs.IsZero() {
+			continue
+		}
+		if v, ok := attrs.AsMap().Get(name); ok {
+			return v.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// forEachSpanTag calls fn for every attribute of the span, tagged with its scope.
+func forEachSpanTag(span tracestorage.Span, fn func(scope traceql.AttributeScope, name, value string)) {
+	visit := func(scope traceql.AttributeScope, attrs otelstorage.Attrs) {
+		if attrs.IsZero() {
+			return
+		}
+		attrs.AsMap().Range(func(k string, v pcommon.Value) bool {
+			fn(scope, k, v.AsString())
+			return true
+		})
+	}
+	visit(traceql.ScopeResource, span.ResourceAttrs)
+	visit(traceql.ScopeInstrumentation, span.ScopeAttrs)
+	visit(traceql.ScopeSpan, span.Attrs)
+}

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -282,13 +282,14 @@ func convertLinks(ls []sigtrace.Link) []tracestorage.Link {
 	return out
 }
 
-// durationInRange reports whether the span's duration is within the optional [min, max] bounds.
-func durationInRange(span tracestorage.Span, min, max time.Duration) bool {
+// durationInRange reports whether the span's duration is within the optional [minDur, maxDur]
+// bounds.
+func durationInRange(span tracestorage.Span, minDur, maxDur time.Duration) bool {
 	d := time.Duration(span.End - span.Start)
-	if min > 0 && d < min {
+	if minDur > 0 && d < minDur {
 		return false
 	}
-	if max > 0 && d > max {
+	if maxDur > 0 && d > maxDur {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary

Bumps `github.com/oteldb/storage` to **v0.3.0** and wires the **TraceQL (Tempo)**, **LogQL (Loki)**, and **ProfileQL (Pyroscope)** handlers to read from — and ingest into — the embedded storage engine, alongside the existing metrics path.

Each signal can now be served from the native Go storage engine instead of ClickHouse, selected per-signal via config. Both the query side (API handler queriers) and the ingestion side (collector exporter sinks) are wired.

## What's included

- **`chore(deps)`** — bump `oteldb/storage` to v0.3.0 (adds the `otlp/pdataconv` trace/log/profile bridges and `LogSeries`/`TraceSeries` enumeration primitives), plus the experimental `pprofile` + `xexporter` collector packages.
- **`feat(storagebackend)` query adapters** — `TraceQuerier` (`tracestorage.Querier` + `traceqlengine.Querier`), `LogQuerier` (`logstorage.Querier` + `logqlengine.Querier`), `ProfileQuerier` (`profilestorage.Querier`) over the storage `fetch` seam. Logs/profiles declare colliding `LabelNames`/`LabelValues` signatures, so each signal's querier is a small wrapper obtained via `Backend.Logs()/Traces()/Profiles()`.
- **`feat(storagebackend)` ingestion sinks** — `ConsumeTraces/ConsumeLogs/ConsumeProfiles` converting OTLP pdata → storage signal model.
- **`feat(oteldbexporter)`** — `TracesSink`/`LogsSink`/`ProfilesSink` + `With*Sink` options. Traces/logs fall back to ClickHouse when no sink is set; the **experimental profiles signal** (via `xexporter.WithProfiles`) is only registered when a profiles sink is configured (profiles have no ClickHouse path).
- **`feat(oteldb)` wiring** — per-signal backend selection (`traces_backend` / `logs_backend` / `profiles_backend`, each `clickhouse` | `storage`). A single shared storage engine backs every signal set to `storage`. When `profiles_backend: storage`, an experimental OTLP `profiles` pipeline (`otlp → oteldbexporter`) is added to the default collector config. The ClickHouse LogQL optimizer is skipped when logs are served from storage.

## Tests

- `internal/storagebackend/signals_test.go` — round-trips OTLP ingest → storage → query for logs, traces, and profiles (flamegraph merge, stack resolution, tag/label enumeration).
- `internal/otelreceiver/oteldbexporter/profiles_test.go` — verifies the exporter advertises and routes the profiles signal to the sink, and that profiles is unsupported without a sink.
- `go build ./...`, `go vet`, and existing metrics round-trip all pass.

## Notes

- `github.com/oteldb/storage` is not in the public checksum DB, so builds currently need `GOSUMDB=off` (or a CI equivalent) to resolve v0.3.0.
- No GitHub issue number was supplied; happy to link one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
