### PR TITLE
test(integration): e2e storage query benchmarks + ProfileQL suite

### DIFF
--- a/integration/lokie2e/bench_query_storage_test.go
+++ b/integration/lokie2e/bench_query_storage_test.go
@@ -1,0 +1,94 @@
+package lokie2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLStorage benchmarks representative real-world LogQL queries end-to-end against the
+// embedded storage engine: a realistic set of HTTP access logs (thousands of records across several
+// streams) is ingested through the storage sink, then each query is evaluated through the LogQL
+// engine over the storage fetch seam — log selectors, line filters, label filters, and metric
+// queries (count_over_time/rate/sum by).
+func BenchmarkLogQLStorage(b *testing.B) {
+	ctx := context.Background()
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	set, err := generateLogs(now, 50) // ~6k access-log records across testService/fooService streams
+	require.NoError(b, err)
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+	for _, batch := range set.Batches {
+		require.NoError(b, backend.ConsumeLogs(ctx, batch))
+	}
+
+	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+		ParseOptions: logql.ParseOptions{AllowDots: true},
+	})
+	require.NoError(b, err)
+
+	params := logqlengine.EvalParams{
+		Start:     set.Start.AsTime(),
+		End:       set.End.AsTime(),
+		Step:      15 * time.Second,
+		Direction: logqlengine.DirectionForward,
+		Limit:     1000,
+	}
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"StreamSelector", `{service_name="testService"}`},
+		{"LineFilterInclude", `{service_name=~".+"} |= "GET"`},
+		{"LineFilterExclude", `{service_name=~".+"} != "HEAD"`},
+		{"LabelFilter", `{service_name=~".+"} | http_method = "POST"`},
+		{"CountOverTime", `count_over_time({service_name=~".+"}[1m])`},
+		{"Rate", `rate({service_name=~".+"}[1m])`},
+		{"SumByMethod", `sum by (http_method) (count_over_time({service_name=~".+"}[1m]))`},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			query, err := engine.NewQuery(ctx, tt.query)
+			require.NoError(b, err)
+
+			// Sanity-check the query is meaningful (non-empty) before timing.
+			data, err := query.Eval(ctx, params)
+			require.NoError(b, err)
+			require.True(b, queryDataNonEmpty(data), "query %q returned no data", tt.query)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := query.Eval(ctx, params); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func queryDataNonEmpty(data lokiapi.QueryResponseData) bool {
+	if s, ok := data.GetStreamsResult(); ok {
+		return len(s.Result) > 0
+	}
+	if m, ok := data.GetMatrixResult(); ok {
+		return len(m.Result) > 0
+	}
+	if v, ok := data.GetVectorResult(); ok {
+		return len(v.Result) > 0
+	}
+	return false
+}

--- a/integration/prome2e/bench_query_storage_test.go
+++ b/integration/prome2e/bench_query_storage_test.go
@@ -1,0 +1,83 @@
+package prome2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+
+	oteldbpromql "github.com/oteldb/oteldb/internal/promql"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkPromQLStorage benchmarks representative real-world PromQL queries end-to-end against the
+// embedded storage engine: the captured Prometheus test corpus (~4 MiB of node-exporter-style
+// metrics) is ingested through the OTLP storage sink, then each query is executed as a range query
+// through the PromQL engine over the storage fetch seam — raw selectors, rate, and aggregations.
+func BenchmarkPromQLStorage(b *testing.B) {
+	ctx := context.Background()
+
+	set, err := readBatchSet("_testdata/metrics.json")
+	require.NoError(b, err)
+	require.NotEmpty(b, set.Batches)
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+	for _, batch := range set.Batches {
+		require.NoError(b, backend.ConsumeMetrics(ctx, batch))
+	}
+
+	engine, err := oteldbpromql.New(backend, oteldbpromql.EngineOpts{
+		MaxSamples:           1_000_000,
+		Timeout:              time.Minute,
+		LookbackDelta:        5 * time.Minute,
+		EnableNegativeOffset: true,
+	})
+	require.NoError(b, err)
+
+	var (
+		start = set.Start.AsTime()
+		end   = set.End.AsTime()
+		step  = 15 * time.Second
+	)
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"Selector", `prometheus_http_requests_total`},
+		{"Rate", `rate(prometheus_http_requests_total[5m])`},
+		{"SumByHandler", `sum by (handler) (prometheus_http_requests_total)`},
+		{"CountSeries", `count(prometheus_http_requests_total)`},
+		{"AvgByHandler", `avg by (handler) (prometheus_http_requests_total)`},
+		{"Topk", `topk(5, prometheus_http_requests_total)`},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			exec := func() *promql.Result {
+				q, err := engine.NewRangeQuery(ctx, backend, promql.NewPrometheusQueryOpts(false, 0), tt.query, start, end, step)
+				require.NoError(b, err)
+				defer q.Close()
+				res := q.Exec(ctx)
+				require.NoError(b, res.Err)
+				return res
+			}
+
+			// Sanity-check the query is meaningful (non-empty) before timing.
+			res := exec()
+			m, ok := res.Value.(promql.Matrix)
+			require.Truef(b, ok && len(m) > 0, "query %q returned no series", tt.query)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = exec()
+			}
+		})
+	}
+}

--- a/integration/pyroe2e/bench_storage_test.go
+++ b/integration/pyroe2e/bench_storage_test.go
@@ -1,0 +1,86 @@
+package pyroe2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/profileql/profileqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkInserterProfilesStorage measures the overhead of ingesting profiles into the embedded
+// storage engine, mirroring the inserter benchmarks of the other signals.
+func BenchmarkInserterProfilesStorage(b *testing.B) {
+	ctx := context.Background()
+	start := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	pd, _, _ := generateProfiles(start, []string{"frontend", "backend"}, 50)
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var sinkErr error
+	for i := 0; i < b.N; i++ {
+		sinkErr = backend.ConsumeProfiles(ctx, pd)
+	}
+	if sinkErr != nil {
+		b.Fatal(sinkErr)
+	}
+}
+
+// BenchmarkProfileQLStorage benchmarks representative real-world ProfileQL queries end-to-end
+// against the embedded storage engine: a CPU profiles dataset across several services is ingested
+// through the storage sink, then each query is evaluated through the ProfileQL engine over the
+// storage fetch seam — a merged flamegraph, a label-filtered flamegraph, and the full flamebearer
+// render path.
+func BenchmarkProfileQLStorage(b *testing.B) {
+	ctx := context.Background()
+	backend, start, end, _ := newBackend(b, []string{"frontend", "backend"}, 100)
+
+	engine := profileqlengine.NewEngine(backend.Profiles(), profileqlengine.Options{})
+	params := profileqlengine.EvalParams{Start: start.Add(-time.Hour), End: end.Add(time.Hour)}
+
+	b.Run("MergeAll", func(b *testing.B) {
+		res, err := engine.Select(ctx, profileTypeID, params)
+		require.NoError(b, err)
+		require.Positive(b, res.Tree.Total())
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := engine.Select(ctx, profileTypeID, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("FilterByService", func(b *testing.B) {
+		query := profileTypeID + `{service.name="frontend"}`
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := engine.Select(ctx, query, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Flamebearer", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := engine.Eval(ctx, profileTypeID, params); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/integration/pyroe2e/common_test.go
+++ b/integration/pyroe2e/common_test.go
@@ -1,0 +1,115 @@
+// Package pyroe2e_test provides end-to-end tests and benchmarks for the ProfileQL/Pyroscope query
+// path against the embedded github.com/oteldb/storage engine.
+package pyroe2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+const (
+	profileSampleType = "cpu"
+	profileSampleUnit = "nanoseconds"
+	// profileTypeID is the canonical ProfileQL type id for the generated CPU profiles
+	// (name:sampleType:sampleUnit:periodType:periodUnit, where name == sampleType).
+	profileTypeID = "cpu:cpu:nanoseconds:cpu:nanoseconds"
+)
+
+// frames are the function names that make up the generated call stacks (root-most last).
+var frames = []string{"main", "serveHTTP", "queryDB", "encodeJSON", "gcAssist"}
+
+// stacks are leaf-first call stacks expressed as indices into frames.
+var stacks = [][]int{
+	{2, 1, 0}, // queryDB <- serveHTTP <- main
+	{3, 1, 0}, // encodeJSON <- serveHTTP <- main
+	{4, 0},    // gcAssist <- main
+}
+
+// generateProfiles builds a CPU profiles dataset: for each service, profilesPerService profiles
+// spaced one second apart starting at start, each carrying a sample on every call stack. It returns
+// the batch, the [start, end] window covering it, and the total sample value sum.
+func generateProfiles(start time.Time, services []string, profilesPerService int) (pd pprofile.Profiles, end time.Time, total int64) {
+	pd = pprofile.NewProfiles()
+	dict := pd.Dictionary()
+
+	st := dict.StringTable()
+	st.Append("")                // 0: reserved empty
+	st.Append(profileSampleType) // 1
+	st.Append(profileSampleUnit) // 2
+	for _, name := range frames {
+		st.Append(name)
+	}
+	frameStr := func(i int) int32 { return int32(3 + i) }
+
+	dict.MappingTable().AppendEmpty().SetFilenameStrindex(0)
+	for i := range frames {
+		dict.FunctionTable().AppendEmpty().SetNameStrindex(frameStr(i))
+		loc := dict.LocationTable().AppendEmpty()
+		loc.SetMappingIndex(0)
+		line := loc.Lines().AppendEmpty()
+		line.SetFunctionIndex(int32(i))
+		line.SetLine(int64(10 * (i + 1)))
+	}
+	for _, frameRefs := range stacks {
+		stk := dict.StackTable().AppendEmpty()
+		for _, fr := range frameRefs {
+			stk.LocationIndices().Append(int32(fr))
+		}
+	}
+
+	end = start
+	for _, svc := range services {
+		rp := pd.ResourceProfiles().AppendEmpty()
+		rp.Resource().Attributes().PutStr("service.name", svc)
+		scp := rp.ScopeProfiles().AppendEmpty()
+
+		t := start
+		for n := range profilesPerService {
+			p := scp.Profiles().AppendEmpty()
+			p.SampleType().SetTypeStrindex(1)
+			p.SampleType().SetUnitStrindex(2)
+			p.PeriodType().SetTypeStrindex(1)
+			p.PeriodType().SetUnitStrindex(2)
+			p.SetTime(pcommon.Timestamp(t.UnixNano()))
+
+			for si := range stacks {
+				s := p.Samples().AppendEmpty()
+				s.SetStackIndex(int32(si))
+				v := int64(100*(si+1) + n)
+				s.Values().Append(v)
+				s.TimestampsUnixNano().Append(uint64(t.UnixNano()))
+				total += v
+			}
+
+			t = t.Add(time.Second)
+			if t.After(end) {
+				end = t
+			}
+		}
+	}
+	return pd, end, total
+}
+
+// newBackend opens an in-memory storage backend with the generated profiles ingested.
+func newBackend(tb testing.TB, services []string, profilesPerService int) (_ *storagebackend.Backend, start, end time.Time, total int64) {
+	tb.Helper()
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = store.Close(ctx) })
+
+	backend := storagebackend.New(store)
+	start = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	pd, end, total := generateProfiles(start, services, profilesPerService)
+	require.NoError(tb, backend.ConsumeProfiles(ctx, pd))
+	return backend, start, end, total
+}

--- a/integration/pyroe2e/storage_test.go
+++ b/integration/pyroe2e/storage_test.go
@@ -1,0 +1,88 @@
+package pyroe2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/profileql/profileqlengine"
+	"github.com/oteldb/oteldb/internal/profilestorage"
+)
+
+// TestStorageBackend exercises the embedded storage profiles backend end-to-end: generated CPU
+// profiles for several services are ingested through the storage ingestion sink (ConsumeProfiles),
+// then queried back through the ProfileQL engine and the profiles querier — profile-type and label
+// enumeration, a merged flamegraph over all services, and a per-service filtered flamegraph.
+//
+// Like the other storage_test suites it needs no ClickHouse or Docker — the storage engine runs
+// fully in memory — so it runs as a normal unit test.
+func TestStorageBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	services := []string{"frontend", "backend"}
+	backend, start, end, total := newBackend(t, services, 50)
+
+	pq := backend.Profiles()
+	opts := profilestorage.ProfileTypesOptions{Start: start.Add(-time.Hour), End: end.Add(time.Hour)}
+
+	t.Run("ProfileTypes", func(t *testing.T) {
+		types, err := pq.ProfileTypes(ctx, opts)
+		require.NoError(t, err)
+		require.Len(t, types, 1)
+		require.Equal(t, profileTypeID, types[0].ID())
+		require.Equal(t, profileSampleType, types[0].SampleType)
+		require.Equal(t, profileSampleUnit, types[0].SampleUnit)
+	})
+
+	t.Run("Labels", func(t *testing.T) {
+		names, err := pq.LabelNames(ctx, profilestorage.LabelNamesOptions{Start: start.Add(-time.Hour), End: end.Add(time.Hour)})
+		require.NoError(t, err)
+		require.Contains(t, names, "service.name")
+
+		values, err := pq.LabelValues(ctx, "service.name", profilestorage.LabelValuesOptions{Start: start.Add(-time.Hour), End: end.Add(time.Hour)})
+		require.NoError(t, err)
+		require.ElementsMatch(t, services, values, "label values are the service names")
+	})
+
+	engine := profileqlengine.NewEngine(pq, profileqlengine.Options{})
+	params := profileqlengine.EvalParams{Start: start.Add(-time.Hour), End: end.Add(time.Hour)}
+
+	t.Run("MergeAllServices", func(t *testing.T) {
+		res, err := engine.Select(ctx, profileTypeID, params)
+		require.NoError(t, err)
+		require.NotNil(t, res.Tree.Root)
+		// The merged flamegraph accumulates every ingested sample value.
+		require.Equal(t, total, res.Tree.Total())
+		require.NotEmpty(t, res.Tree.Root.Children)
+	})
+
+	t.Run("FilterByService", func(t *testing.T) {
+		res, err := engine.Select(ctx, profileTypeID+`{service.name="frontend"}`, params)
+		require.NoError(t, err)
+		require.Positive(t, res.Tree.Total())
+		require.Less(t, res.Tree.Total(), total, "single service is a subset of the total")
+	})
+
+	t.Run("Flamebearer", func(t *testing.T) {
+		fb, err := engine.Eval(ctx, profileTypeID, params)
+		require.NoError(t, err)
+		require.NotNil(t, fb)
+		require.NotEmpty(t, fb.Flamebearer.Names, "flamegraph should resolve function names")
+	})
+
+	t.Run("NoMatch", func(t *testing.T) {
+		res, err := engine.Select(ctx, profileTypeID+`{service.name="does-not-exist"}`, params)
+		require.NoError(t, err)
+		require.Zero(t, res.Tree.Total())
+	})
+
+	// A non-matching profile type yields an empty tree.
+	t.Run("UnknownType", func(t *testing.T) {
+		res, err := engine.Select(ctx, `memory:inuse_space:bytes:space:bytes`, params)
+		require.NoError(t, err)
+		require.Zero(t, res.Tree.Total())
+	})
+}

--- a/integration/tempoe2e/bench_query_storage_test.go
+++ b/integration/tempoe2e/bench_query_storage_test.go
@@ -1,0 +1,63 @@
+package tempoe2e_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
+)
+
+// BenchmarkTraceQLStorageSuite benchmarks representative real-world TraceQL queries end-to-end
+// against the embedded storage engine: a captured trace corpus is ingested through the storage
+// sink, then each query is evaluated through the TraceQL engine over the storage fetch seam —
+// attribute filters, intrinsics, boolean combinations, and a scalar pipeline.
+func BenchmarkTraceQLStorageSuite(b *testing.B) {
+	ctx := context.Background()
+
+	set, err := readBatchSet()
+	require.NoError(b, err)
+	require.NotEmpty(b, set.Batches)
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+	for _, batch := range set.Batches {
+		require.NoError(b, backend.ConsumeTraces(ctx, batch))
+	}
+
+	engine := traceqlengine.NewEngine(backend.Traces(), traceqlengine.Options{})
+	params := traceqlengine.EvalParams{Limit: 200}
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"AttrFilter", `{ .http.method = "POST" }`},
+		{"AttrAndStatus", `{ .http.method = "POST" && .http.status_code = 200 }`},
+		{"SpanName", `{ name = "list-articles" }`},
+		{"DurationIntrinsic", `{ duration > 0ns }`},
+		{"RegexAttr", `{ .http.method =~ "POST|GET" }`},
+		{"ScalarPipeline", `{ .http.method = "POST" } | count() > 0`},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			// Sanity-check the query is meaningful (non-empty) before timing.
+			res, err := engine.Eval(ctx, tt.query, params)
+			require.NoError(b, err)
+			require.NotEmptyf(b, res.Traces, "query %q returned no traces", tt.query)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := engine.Eval(ctx, tt.query, params); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Comprehensive real-world **end-to-end benchmarks and tests** against the embedded `github.com/oteldb/storage` engine for all four query languages. Each benchmark ingests a realistic dataset through the storage ingestion sink, then drives queries through the actual query engine over the storage fetch seam (no ClickHouse, no Docker — runs as normal `go test`).

## What's added

| Signal | Benchmark | Test |
|---|---|---|
| **PromQL** | `BenchmarkPromQLStorage` — selector / rate / sum-by / count / avg / topk over the captured ~4 MiB Prometheus corpus | `TestStorageBackend` (existing) |
| **LogQL** | `BenchmarkLogQLStorage` — selector / line-filter (incl/excl) / label-filter / count_over_time / rate / sum-by over ~6k access-log records | `TestStorageBackend` (existing) |
| **TraceQL** | `BenchmarkTraceQLStorageSuite` — attr / intrinsic / regex / boolean / scalar-pipeline over the captured trace corpus | `TestStorageBackend` (existing) |
| **ProfileQL** | `BenchmarkInserterProfilesStorage`, `BenchmarkProfileQLStorage` (merge / filter / flamebearer) | **`TestStorageBackend` (new)** — profile types, labels, merged + per-service flamegraphs, no-match, unknown-type |

ProfileQL had **no** storage integration coverage; this adds a new `integration/pyroe2e` package with a CPU-profile generator (multiple services, call stacks, samples over time), the conformance test, and the inserter + query benchmarks.

## Notes
- Each query benchmark **sanity-checks a non-empty result** before the timed loop, so the numbers reflect real work (not empty scans).
- The LogQL numbers make the offloading headroom visible: line/label filters cost ~the same as a bare selector (~19 ms) because the embedded querier currently does no pushdown — a useful baseline for the storage-level offload discussed separately.
- Benchmarks are engine-direct (like the existing `BenchmarkTraceQLStorage`) to measure the storage+engine hot path without HTTP noise; the conformance tests for prom/loki/tempo still exercise the full HTTP API.

## Testing
- `go test -run TestStorageBackend ./integration/{prome2e,lokie2e,tempoe2e,pyroe2e}/` — pass
- `go test -bench Storage -benchtime=1x ./integration/{...}` — 27 benchmarks run green
- `golangci-lint run ./integration/...` — 0 issues