### PR TITLE
feat(storagebackend): offload LogQL filtering to the storage fetch layer

### DIFF
--- a/cmd/oteldb/app.go
+++ b/cmd/oteldb/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/oteldb/oteldb/internal/promhandler"
 	"github.com/oteldb/oteldb/internal/promql"
 	"github.com/oteldb/oteldb/internal/pyroscopeapi"
+	"github.com/oteldb/oteldb/internal/storagebackend"
 	"github.com/oteldb/oteldb/internal/tempoapi"
 	"github.com/oteldb/oteldb/internal/tempohandler"
 	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
@@ -342,8 +343,12 @@ func (app *App) trySetupLoki() error {
 	var optimizers []logqlengine.Optimizer
 	optimizers = append(optimizers, logqlengine.DefaultOptimizers()...)
 	// The ClickHouse optimizer pushes filtering into chstorage's InputNode; it is a no-op for
-	// other backends, so only enable it when logs are actually served from ClickHouse.
-	if app.cfg.LogsBackend != MetricsBackendStorage {
+	// other backends, so only enable it when logs are actually served from ClickHouse. When logs
+	// are served from the embedded storage engine, the storage optimizer offloads line filters into
+	// the fetch instead.
+	if app.cfg.LogsBackend == MetricsBackendStorage {
+		optimizers = append(optimizers, &storagebackend.LogQLOptimizer{})
+	} else {
 		optimizers = append(optimizers, &chstorage.ClickhouseOptimizer{})
 	}
 	engine, err := logqlengine.NewEngine(q, logqlengine.Options{

--- a/integration/lokie2e/bench_offload_storage_test.go
+++ b/integration/lokie2e/bench_offload_storage_test.go
@@ -1,0 +1,82 @@
+package lokie2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLLineFilterOffload compares LogQL line-filter queries with and without the storage
+// line-filter offload (storagebackend.LogQLOptimizer), which pushes `|=` filters into the log fetch
+// so non-matching records are dropped before the engine materializes them into entries with label
+// sets. The Baseline/Offloaded pairing makes the speedup directly comparable.
+func BenchmarkLogQLLineFilterOffload(b *testing.B) {
+	ctx := context.Background()
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	set, err := generateLogs(now, 50)
+	require.NoError(b, err)
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+	for _, batch := range set.Batches {
+		require.NoError(b, backend.ConsumeLogs(ctx, batch))
+	}
+
+	params := logqlengine.EvalParams{
+		Start:     set.Start.AsTime(),
+		End:       set.End.AsTime(),
+		Step:      15 * time.Second,
+		Direction: logqlengine.DirectionForward,
+		Limit:     1000,
+	}
+
+	newEngine := func(offload bool) *logqlengine.Engine {
+		opts := logqlengine.Options{ParseOptions: logql.ParseOptions{AllowDots: true}}
+		if offload {
+			opts.Optimizers = []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}}
+		}
+		engine, err := logqlengine.NewEngine(backend.Logs(), opts)
+		require.NoError(b, err)
+		return engine
+	}
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"LineFilter", `{service_name=~".+"} |= "GET"`},
+		{"LineFilterRare", `{service_name=~".+"} |= "DELETE"`},
+		{"MetricLineFilter", `count_over_time({service_name=~".+"} |= "GET" [1m])`},
+	} {
+		for _, mode := range []struct {
+			name    string
+			offload bool
+		}{
+			{"Baseline", false},
+			{"Offloaded", true},
+		} {
+			query, err := newEngine(mode.offload).NewQuery(ctx, tt.query)
+			require.NoError(b, err)
+			b.Run(tt.name+"/"+mode.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := query.Eval(ctx, params); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/integration/lokie2e/bench_record_offload_storage_test.go
+++ b/integration/lokie2e/bench_record_offload_storage_test.go
@@ -1,0 +1,71 @@
+package lokie2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLRecordAttrSelector measures a selector on a clean record-attribute label over a
+// single high-cardinality stream (the Loki shape: stream labels arrive as per-record attributes,
+// empty resource). The embedded querier offloads the equality to a per-record fetch condition, so
+// only the matching records are materialized into entries with label sets instead of all of them.
+func BenchmarkLogQLRecordAttrSelector(b *testing.B) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+
+	const (
+		jobs   = 20
+		perJob = 300
+	)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty() // empty resource: every record lands in one stream
+	sl := rl.ScopeLogs().AppendEmpty()
+	for j := range jobs {
+		for r := range perJob {
+			lr := sl.LogRecords().AppendEmpty()
+			lr.SetTimestamp(pcommon.Timestamp(now.Add(time.Duration(r) * time.Millisecond).UnixNano()))
+			lr.Body().SetStr(fmt.Sprintf("GET /%d 200", r))
+			lr.Attributes().PutStr("job", fmt.Sprintf("job-%02d", j))
+		}
+	}
+	require.NoError(b, backend.ConsumeLogs(ctx, ld))
+
+	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+		ParseOptions: logql.ParseOptions{AllowDots: true},
+	})
+	require.NoError(b, err)
+
+	params := logqlengine.EvalParams{
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+		Direction: logqlengine.DirectionForward,
+		Limit:     10000,
+	}
+	query, err := engine.NewQuery(ctx, `{job="job-07"}`)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := query.Eval(ctx, params); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/integration/lokie2e/bench_stream_offload_storage_test.go
+++ b/integration/lokie2e/bench_stream_offload_storage_test.go
@@ -1,0 +1,70 @@
+package lokie2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLStreamSelector measures a resource-label stream selector over a high-cardinality
+// dataset (many services). The embedded querier offloads the equality matcher to the postings index,
+// so only the selected stream's records are fetched and materialized instead of every service's.
+func BenchmarkLogQLStreamSelector(b *testing.B) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+
+	const (
+		services   = 20
+		perService = 300
+	)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	for s := range services {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", fmt.Sprintf("svc-%02d", s))
+		sl := rl.ScopeLogs().AppendEmpty()
+		for r := range perService {
+			rec := sl.LogRecords().AppendEmpty()
+			rec.SetTimestamp(pcommon.Timestamp(now.Add(time.Duration(r) * time.Millisecond).UnixNano()))
+			rec.Body().SetStr(fmt.Sprintf("GET /%d 200 svc-%02d", r, s))
+		}
+		require.NoError(b, backend.ConsumeLogs(ctx, ld))
+	}
+
+	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+		ParseOptions: logql.ParseOptions{AllowDots: true},
+	})
+	require.NoError(b, err)
+
+	params := logqlengine.EvalParams{
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+		Direction: logqlengine.DirectionForward,
+		Limit:     10000,
+	}
+	query, err := engine.NewQuery(ctx, `{service_name="svc-07"}`)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := query.Eval(ctx, params); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/storagebackend/convert.go
+++ b/internal/storagebackend/convert.go
@@ -19,6 +19,20 @@ func otelAttrs(attrs signal.Attributes) otelstorage.Attrs {
 	return otelstorage.Attrs(m)
 }
 
+// labelValueString renders a storage value to the exact string the LogQL label set exposes for it.
+//
+// The log label set is built via [otelAttrs] (signal → pdata) and read back with pcommon's
+// AsString (see logqlabels.LabelSet.GetString). A pushdown matcher MUST compare values the same
+// way, or it can disagree with the in-memory matchSelector and drop a stream/record the engine
+// would keep — a silent false negative. signal.Value.AppendText is not equivalent: it renders bytes
+// raw (vs base64) and composite values differently. Projecting through putSignalValue + AsString
+// guarantees byte-for-byte parity.
+func labelValueString(v signal.Value) string {
+	pv := pcommon.NewValueEmpty()
+	putSignalValue(pv, v)
+	return pv.AsString()
+}
+
 // putSignalValue writes a storage [signal.Value] into the pdata value dst, preserving type and
 // recursing into slices/maps.
 func putSignalValue(dst pcommon.Value, v signal.Value) {

--- a/internal/storagebackend/convert_test.go
+++ b/internal/storagebackend/convert_test.go
@@ -1,0 +1,45 @@
+package storagebackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlabels"
+)
+
+// TestLabelValueStringParity locks the invariant that a pushdown matcher's value rendering
+// (labelValueString) is byte-for-byte identical to what the LogQL label set exposes for the same
+// value (logqlabels.LabelSet built from otelAttrs, read via GetString). If these ever diverge a
+// pushed matcher could drop a stream/record the in-memory matchSelector would keep — a silent false
+// negative. The composite/bytes cases are the ones a naive AppendText would get wrong.
+func TestLabelValueStringParity(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		v    signal.Value
+	}{
+		{"string", signal.StringValue([]byte("text value"))},
+		{"empty-string", signal.StringValue([]byte(""))},
+		{"int", signal.IntValue(200)},
+		{"negative-int", signal.IntValue(-7)},
+		{"bool", signal.BoolValue(true)},
+		{"double", signal.DoubleValue(1.5)},
+		{"double-int-like", signal.DoubleValue(200)},
+		{"bytes", signal.BytesValue([]byte{0x01, 0x02, 0xff})},
+		{"slice", signal.SliceValue(signal.IntValue(1), signal.StringValue([]byte("x")))},
+		{"map", signal.MapValue(signal.KeyValue{Key: []byte("k"), Value: signal.StringValue([]byte("v"))})},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build the label set exactly as the query path does.
+			attrs := otelAttrs(signal.NewAttributes(signal.KeyValue{Key: []byte("attr"), Value: tt.v}))
+			set := logqlabels.NewLabelSet()
+			set.SetAttrs(attrs)
+			want, ok := set.GetString("attr")
+			require.True(t, ok)
+
+			require.Equal(t, want, labelValueString(tt.v), "pushdown rendering must equal the label set projection")
+		})
+	}
+}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -42,6 +42,10 @@ func (q *LogQuerier) Query(_ context.Context, selector []logql.LabelMatcher) (lo
 type logStreamNode struct {
 	q        *LogQuerier
 	selector []logql.LabelMatcher
+	// conditions are offloaded columnar predicates (e.g. line filters as body conditions) pushed
+	// into the fetch by [LogQLOptimizer]. They prune parts and drop records at the storage layer;
+	// the engine still applies the full pipeline, so they only ever skip work.
+	conditions []fetch.Condition
 }
 
 var _ logqlengine.PipelineNode = (*logStreamNode)(nil)
@@ -59,6 +63,11 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 		Signal: signal.Log,
 		Start:  lo,
 		End:    hi,
+	}
+	if len(n.conditions) > 0 {
+		// Offloaded line filters: let the storage prune parts and drop non-matching records.
+		req.Conditions = n.conditions
+		req.AllConditions = true
 	}
 
 	it, err := n.q.b.store.LogFetcher(n.q.b.tenant).Fetch(ctx, req)

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -169,8 +169,9 @@ func (n *logStreamNode) streamMatchers(ctx context.Context, lo, hi int64) []fetc
 		}
 		want := value
 		matchers = append(matchers, fetch.Matcher{
-			Name:  []byte(rawKey),
-			Match: func(v signal.Value) bool { return string(v.AppendText(nil)) == want },
+			Name: []byte(rawKey),
+			// Render the value exactly as the label set does, so this matches matchSelector.
+			Match: func(v signal.Value) bool { return labelValueString(v) == want },
 			Spec:  &fetch.EqualMatcher{Name: rawKey, Value: want},
 		})
 	}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -63,6 +63,9 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 		Signal: signal.Log,
 		Start:  lo,
 		End:    hi,
+		// Offload equality on resource/scope (stream) labels to the postings index, so the storage
+		// prunes non-matching streams before any record is materialized.
+		Matchers: n.streamMatchers(ctx, lo, hi),
 	}
 	if len(n.conditions) > 0 {
 		// Offloaded line filters: let the storage prune parts and drop non-matching records.
@@ -102,6 +105,76 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 		entries = entries[:params.Limit]
 	}
 	return iterators.Slice(entries), nil
+}
+
+// streamMatchers resolves the selector's equality matchers on resource/scope (stream) labels to
+// storage fetch matchers, so the postings index prunes non-matching streams before any record is
+// materialized. The in-memory matchSelector still re-checks every record, so this only ever skips
+// work.
+//
+// A matcher is offloaded only when its label is an equality (`=`) on a non-empty value whose
+// normalized name maps unambiguously to a single raw resource/scope attribute key (discovered via
+// LogSeries). Record-attribute labels (e.g. Loki-style streams) and labels whose normalized name is
+// absent or ambiguous are left to matchSelector, since the postings index keys streams by their raw
+// resource/scope attributes only.
+func (n *logStreamNode) streamMatchers(ctx context.Context, lo, hi int64) []fetch.Matcher {
+	wanted := map[string]string{}
+	for _, m := range n.selector {
+		if m.Op == logql.OpEq && m.Value != "" {
+			wanted[string(m.Label)] = m.Value
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+
+	series, err := n.q.b.store.LogSeries(ctx, n.q.b.tenant, nil, lo, hi)
+	if err != nil {
+		return nil // best effort: fall back to in-memory filtering.
+	}
+
+	// Map each wanted normalized label to the set of raw stream-attribute keys that normalize to it.
+	rawKeys := map[string]map[string]struct{}{}
+	collect := func(key []byte) {
+		label := otelstorage.KeyToLabel(string(key))
+		if _, ok := wanted[label]; !ok {
+			return
+		}
+		set := rawKeys[label]
+		if set == nil {
+			set = map[string]struct{}{}
+			rawKeys[label] = set
+		}
+		set[string(key)] = struct{}{}
+	}
+	for _, s := range series {
+		for i := range s.Resource.Attributes {
+			collect(s.Resource.Attributes[i].Key)
+		}
+		for i := range s.Scope.Attributes {
+			collect(s.Scope.Attributes[i].Key)
+		}
+	}
+
+	var matchers []fetch.Matcher
+	for label, value := range wanted {
+		keys := rawKeys[label]
+		if len(keys) != 1 {
+			// Absent (record attribute or unknown) or ambiguous: leave it to matchSelector.
+			continue
+		}
+		var rawKey string
+		for k := range keys {
+			rawKey = k
+		}
+		want := value
+		matchers = append(matchers, fetch.Matcher{
+			Name:  []byte(rawKey),
+			Match: func(v signal.Value) bool { return string(v.AppendText(nil)) == want },
+			Spec:  &fetch.EqualMatcher{Name: rawKey, Value: want},
+		})
+	}
+	return matchers
 }
 
 // sortEntries orders entries by timestamp ascending for forward queries and descending otherwise.

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -3,6 +3,7 @@ package storagebackend
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
@@ -58,18 +59,22 @@ func (n *logStreamNode) Traverse(cb logqlengine.NodeVisitor) error { return cb(n
 // them as entries ordered per params.Direction (and truncated to params.Limit).
 func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.EvalParams) (logqlengine.EntryIterator, error) {
 	lo, hi := fetchWindow(params.Start, params.End)
+	// Offload equality matchers: resource/scope labels prune streams via the postings index, clean
+	// record-attribute labels drop records via a per-record condition — both before materialization.
+	matchers, selConds := n.streamFilters(ctx, lo, hi)
 	req := fetch.Request{
-		Tenant: n.q.b.tenant,
-		Signal: signal.Log,
-		Start:  lo,
-		End:    hi,
-		// Offload equality on resource/scope (stream) labels to the postings index, so the storage
-		// prunes non-matching streams before any record is materialized.
-		Matchers: n.streamMatchers(ctx, lo, hi),
+		Tenant:   n.q.b.tenant,
+		Signal:   signal.Log,
+		Start:    lo,
+		End:      hi,
+		Matchers: matchers,
 	}
-	if len(n.conditions) > 0 {
-		// Offloaded line filters: let the storage prune parts and drop non-matching records.
-		req.Conditions = n.conditions
+	// Selector record-attribute conditions plus any offloaded line filters (set by LogQLOptimizer).
+	if len(selConds)+len(n.conditions) > 0 {
+		conds := make([]fetch.Condition, 0, len(selConds)+len(n.conditions))
+		conds = append(conds, selConds...)
+		conds = append(conds, n.conditions...)
+		req.Conditions = conds
 		req.AllConditions = true
 	}
 
@@ -107,17 +112,23 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 	return iterators.Slice(entries), nil
 }
 
-// streamMatchers resolves the selector's equality matchers on resource/scope (stream) labels to
-// storage fetch matchers, so the postings index prunes non-matching streams before any record is
-// materialized. The in-memory matchSelector still re-checks every record, so this only ever skips
-// work.
+// streamFilters resolves the selector's equality matchers to storage fetch filters so the storage
+// drops data before any record is materialized into an entry with a label set (the expensive part of
+// the scan). The in-memory matchSelector still re-checks every surviving record, so this only ever
+// skips work.
 //
-// A matcher is offloaded only when its label is an equality (`=`) on a non-empty value whose
-// normalized name maps unambiguously to a single raw resource/scope attribute key (discovered via
-// LogSeries). Record-attribute labels (e.g. Loki-style streams) and labels whose normalized name is
-// absent or ambiguous are left to matchSelector, since the postings index keys streams by their raw
-// resource/scope attributes only.
-func (n *logStreamNode) streamMatchers(ctx context.Context, lo, hi int64) []fetch.Matcher {
+// For an equality (`=`) on a non-empty value:
+//   - if the normalized label maps unambiguously to a single raw resource/scope attribute key (per
+//     LogSeries), it becomes a postings Matcher that prunes whole streams;
+//   - else if the label is "clean" — its normalized form is its own raw key, so a record-attribute
+//     key normalizing to it can only be the name itself — and is not a resource/scope label, it
+//     becomes a per-record attribute Condition that drops non-matching records.
+//
+// Ambiguous, dotted record-attribute (e.g. http_method ← http.method), and absent labels are left to
+// matchSelector. Record-attribute Conditions carry only an exact Match (no bloom Equal hint): the
+// value may be non-string, and a typed value bloom token could wrongly part-prune; the Match still
+// drops rows at the fetch layer.
+func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matchers []fetch.Matcher, conditions []fetch.Condition) {
 	wanted := map[string]string{}
 	for _, m := range n.selector {
 		if m.Op == logql.OpEq && m.Value != "" {
@@ -125,12 +136,12 @@ func (n *logStreamNode) streamMatchers(ctx context.Context, lo, hi int64) []fetc
 		}
 	}
 	if len(wanted) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	series, err := n.q.b.store.LogSeries(ctx, n.q.b.tenant, nil, lo, hi)
 	if err != nil {
-		return nil // best effort: fall back to in-memory filtering.
+		return nil, nil // best effort: fall back to in-memory filtering.
 	}
 
 	// Map each wanted normalized label to the set of raw stream-attribute keys that normalize to it.
@@ -156,26 +167,40 @@ func (n *logStreamNode) streamMatchers(ctx context.Context, lo, hi int64) []fetc
 		}
 	}
 
-	var matchers []fetch.Matcher
 	for label, value := range wanted {
-		keys := rawKeys[label]
-		if len(keys) != 1 {
-			// Absent (record attribute or unknown) or ambiguous: leave it to matchSelector.
-			continue
-		}
-		var rawKey string
-		for k := range keys {
-			rawKey = k
-		}
 		want := value
-		matchers = append(matchers, fetch.Matcher{
-			Name: []byte(rawKey),
-			// Render the value exactly as the label set does, so this matches matchSelector.
-			Match: func(v signal.Value) bool { return labelValueString(v) == want },
-			Spec:  &fetch.EqualMatcher{Name: rawKey, Value: want},
-		})
+		switch keys := rawKeys[label]; {
+		case len(keys) == 1:
+			var rawKey string
+			for k := range keys {
+				rawKey = k
+			}
+			matchers = append(matchers, fetch.Matcher{
+				Name: []byte(rawKey),
+				// Render the value exactly as the label set does, so this matches matchSelector.
+				Match: func(v signal.Value) bool { return labelValueString(v) == want },
+				Spec:  &fetch.EqualMatcher{Name: rawKey, Value: want},
+			})
+		case len(keys) == 0 && isCleanLabel(label):
+			// Not a resource/scope label in this window; a clean name is its own raw record key.
+			conditions = append(conditions, fetch.Condition{
+				Column: label,
+				Match:  func(v signal.Value) bool { return labelValueString(v) == want },
+			})
+		}
+		// len(keys) > 1 (ambiguous) or a dotted record label: leave to matchSelector.
 	}
-	return matchers
+	return matchers, conditions
+}
+
+// isCleanLabel reports whether a normalized label name is its own raw attribute key: it contains no
+// underscore (which KeyToLabel could have produced from a dot or other character) and is unchanged
+// by KeyToLabel, so a record-attribute key normalizing to it can only be the name itself.
+func isCleanLabel(label string) bool {
+	if strings.IndexByte(label, '_') >= 0 {
+		return false
+	}
+	return otelstorage.KeyToLabel(label) == label
 }
 
 // sortEntries orders entries by timestamp ascending for forward queries and descending otherwise.

--- a/internal/storagebackend/logs_optimizer.go
+++ b/internal/storagebackend/logs_optimizer.go
@@ -1,0 +1,122 @@
+package storagebackend
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+)
+
+// LogQLOptimizer offloads LogQL line filters to the storage fetch layer for the embedded backend.
+//
+// The leading positive substring filters (`|= "x"`) of a pipeline are pushed into the log fetch as
+// body conditions, so the storage drops non-matching records before they are materialized into
+// entries with label sets — the expensive part of the scan. The conditions carry an exact contains
+// Match, so the result is identical to evaluating the filter in the engine (the engine still applies
+// the full pipeline on the surviving entries, so the offload only ever skips work).
+//
+// It deliberately does not set a bloom token hint: the body bloom is word-tokenized, so a token hint
+// would wrongly prune a part that holds a sub-word substring match (e.g. `|= "GET"` matching
+// "xGETy"), violating the fetch contract's no-false-negatives guarantee. The offload is therefore a
+// precise per-record prefilter, not a part-pruning hint.
+//
+// Add it to a LogQL engine's optimizers when the querier is a storage [LogQuerier]; it is a no-op
+// for any other node type.
+type LogQLOptimizer struct{}
+
+var _ logqlengine.Optimizer = (*LogQLOptimizer)(nil)
+
+// Name implements [logqlengine.Optimizer].
+func (*LogQLOptimizer) Name() string { return "StorageLogQLOptimizer" }
+
+// Optimize implements [logqlengine.Optimizer].
+func (o *LogQLOptimizer) Optimize(_ context.Context, q logqlengine.Query) (logqlengine.Query, error) {
+	switch q := q.(type) {
+	case *logqlengine.LogQuery:
+		o.optimizePipeline(q.Root)
+	case *logqlengine.MetricQuery:
+		if err := logqlengine.VisitNode(q.Root, func(n *logqlengine.SamplingNode) error {
+			o.optimizePipeline(n.Input)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return q, nil
+}
+
+// optimizePipeline attaches offloadable line-filter conditions to the storage log node wrapped by a
+// ProcessorNode, if any.
+func (o *LogQLOptimizer) optimizePipeline(n logqlengine.PipelineNode) {
+	pn, ok := n.(*logqlengine.ProcessorNode)
+	if !ok {
+		return
+	}
+	sn, ok := pn.Input.(*logStreamNode)
+	if !ok {
+		return
+	}
+	sn.conditions = lineFilterConditions(pn.Pipeline)
+}
+
+// lineFilterConditions builds storage fetch conditions from the leading offloadable line filters of
+// a pipeline. It stops at the first stage that may rewrite the line, after which earlier-derived
+// conditions no longer hold for the modified line.
+func lineFilterConditions(pipeline []logql.PipelineStage) (conds []fetch.Condition) {
+stageLoop:
+	for _, stage := range pipeline {
+		switch stage := stage.(type) {
+		case *logql.LineFilter:
+			c, ok := lineFilterCondition(stage)
+			if !ok {
+				continue
+			}
+			conds = append(conds, c)
+		case *logql.JSONExpressionParser,
+			*logql.LogfmtExpressionParser,
+			*logql.RegexpLabelParser,
+			*logql.PatternLabelParser,
+			*logql.LabelFilter,
+			*logql.LabelFormatExpr,
+			*logql.DropLabelsExpr,
+			*logql.KeepLabelsExpr,
+			*logql.DistinctFilter:
+			// These stages parse or filter labels but do not rewrite the line; keep scanning.
+		default:
+			// A stage that may rewrite the line (e.g. line_format): later filters see a
+			// different line, so stop offloading here.
+			break stageLoop
+		}
+	}
+	return conds
+}
+
+// lineFilterCondition lowers a positive substring line filter (`|= "x"`) to a body fetch condition
+// with an exact contains Match. Only this shape is offloaded — negated, regexp, IP, and multi-value
+// (`or`) filters are left to the engine.
+func lineFilterCondition(lf *logql.LineFilter) (fetch.Condition, bool) {
+	if lf.Op != logql.OpEq || len(lf.Or) > 0 || lf.By.IP || lf.By.Re != nil {
+		return fetch.Condition{}, false
+	}
+	needle := []byte(lf.By.Value)
+	if len(needle) == 0 {
+		return fetch.Condition{}, false
+	}
+	return fetch.Condition{
+		Column: siglog.ColBody,
+		Match:  func(v signal.Value) bool { return bytes.Contains(valueBytes(v), needle) },
+	}, true
+}
+
+// valueBytes returns the raw bytes of a string/bytes column value.
+func valueBytes(v signal.Value) []byte {
+	if b := v.Str(); b != nil {
+		return b
+	}
+	return v.Bytes()
+}

--- a/internal/storagebackend/logs_optimizer_test.go
+++ b/internal/storagebackend/logs_optimizer_test.go
@@ -1,0 +1,106 @@
+package storagebackend_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// TestLogQLOptimizerEquivalence verifies that pushing line filters into the storage fetch (via
+// LogQLOptimizer) returns exactly the same results as evaluating the whole pipeline in the engine,
+// across log and metric queries and offloadable/non-offloadable filter shapes.
+func TestLogQLOptimizerEquivalence(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	sl := rl.ScopeLogs().AppendEmpty()
+	bodies := []string{
+		"GET /a 200", "POST /b 200", "GET /c 404", "HEAD /d 200",
+		"GET /a 500", "DELETE /e 200", "xGETy embedded", "get lowercase",
+	}
+	for i, body := range bodies {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+		rec.Body().SetStr(body)
+	}
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+	params := logqlengine.EvalParams{Start: start, End: end, Step: time.Minute, Limit: 1000}
+
+	run := func(t *testing.T, optimize bool, query string) lokiapi.QueryResponseData {
+		t.Helper()
+		var opts logqlengine.Options
+		opts.ParseOptions = logql.ParseOptions{AllowDots: true}
+		if optimize {
+			opts.Optimizers = []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}}
+		}
+		engine, err := logqlengine.NewEngine(b.Logs(), opts)
+		require.NoError(t, err)
+		q, err := engine.NewQuery(ctx, query)
+		require.NoError(t, err)
+		data, err := q.Eval(ctx, params)
+		require.NoError(t, err)
+		return data
+	}
+
+	for _, query := range []string{
+		`{service_name="api"}`,
+		`{service_name="api"} |= "GET"`,                       // offloaded: positive substring
+		`{service_name="api"} |= "GET" |= "404"`,              // two offloaded filters (AND)
+		`{service_name="api"} != "GET"`,                       // not offloaded (negated)
+		`{service_name="api"} |~ "GET|POST"`,                  // not offloaded (regexp)
+		`{service_name="api"} |= "GET" != "404"`,              // mixed
+		`count_over_time({service_name="api"} |= "GET" [1h])`, // metric query with offloaded filter
+	} {
+		t.Run(query, func(t *testing.T) {
+			require.Equal(t,
+				normalize(t, run(t, false, query)),
+				normalize(t, run(t, true, query)),
+				"offloaded result must equal engine-only result",
+			)
+		})
+	}
+}
+
+// normalize flattens a query response into a comparable, order-independent form.
+func normalize(t *testing.T, data lokiapi.QueryResponseData) []string {
+	t.Helper()
+	var out []string
+	for _, s := range data.StreamsResult.Result {
+		for _, e := range s.Values {
+			out = append(out, "line:"+e.V)
+		}
+	}
+	for _, s := range data.MatrixResult.Result {
+		ls := s.Metric.Value
+		keys := make([]string, 0, len(ls))
+		for k := range ls {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var lb strings.Builder
+		for _, k := range keys {
+			fmt.Fprintf(&lb, "%s=%s,", k, ls[k])
+		}
+		for _, v := range s.Values {
+			out = append(out, fmt.Sprintf("%s@%g=%s", lb.String(), v.T, v.V))
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/storagebackend/logs_record_filter_test.go
+++ b/internal/storagebackend/logs_record_filter_test.go
@@ -1,0 +1,84 @@
+package storagebackend_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+)
+
+// TestLogRecordAttrPushdown checks that selecting by a clean record-attribute label (the Loki shape:
+// stream labels arrive as per-record attributes with an empty resource) returns exactly the records
+// matchSelector would, with the equality offloaded to a per-record fetch condition. It also checks
+// that a dotted record-attribute label (http_method ← http.method) — which cannot be resolved to a
+// raw key safely — still returns correct results via the in-memory fallback.
+func TestLogRecordAttrPushdown(t *testing.T) {
+	b, ctx := newBackend(t)
+	ts := time.Now().Truncate(time.Second)
+
+	type rec struct {
+		job    string
+		method string // stored under the dotted key http.method
+		line   string
+	}
+	recs := []rec{
+		{"varlogs", "GET", "a"},
+		{"syslog", "POST", "b"},
+		{"varlogs", "POST", "c"},
+		{"applogs", "GET", "d"},
+		{"varlogs", "GET", "e"},
+	}
+	for i, r := range recs {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty() // empty resource (Loki-style)
+		sl := rl.ScopeLogs().AppendEmpty()
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetTimestamp(pcommon.Timestamp(ts.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+		lr.Body().SetStr(r.line)
+		lr.Attributes().PutStr("job", r.job)
+		lr.Attributes().PutStr("http.method", r.method)
+		require.NoError(t, b.ConsumeLogs(ctx, ld))
+	}
+
+	lq := b.Logs()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+	query := func(sel []logql.LabelMatcher) []string {
+		t.Helper()
+		node, err := lq.Query(ctx, sel)
+		require.NoError(t, err)
+		it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+		require.NoError(t, err)
+		var lines []string
+		var e logqlengine.Entry
+		for it.Next(&e) {
+			lines = append(lines, e.Line)
+		}
+		require.NoError(t, it.Err())
+		sort.Strings(lines)
+		return lines
+	}
+
+	eq := func(label, value string) []logql.LabelMatcher {
+		return []logql.LabelMatcher{{Label: logql.Label(label), Op: logql.OpEq, Value: value}}
+	}
+
+	// Clean record-attribute label: offloaded to a fetch condition.
+	require.Equal(t, []string{"a", "c", "e"}, query(eq("job", "varlogs")))
+	require.Equal(t, []string{"b"}, query(eq("job", "syslog")))
+	require.Empty(t, query(eq("job", "none")))
+
+	// Two clean record-attribute equalities (ANDed conditions).
+	require.Equal(t, []string{"a", "e"}, query([]logql.LabelMatcher{
+		{Label: "job", Op: logql.OpEq, Value: "varlogs"},
+		{Label: "http_method", Op: logql.OpEq, Value: "GET"}, // dotted -> fallback, still correct
+	}))
+
+	// Dotted record-attribute label alone: not offloadable, correct via fallback.
+	require.Equal(t, []string{"a", "d", "e"}, query(eq("http_method", "GET")))
+}

--- a/internal/storagebackend/logs_stream_matcher_test.go
+++ b/internal/storagebackend/logs_stream_matcher_test.go
@@ -1,6 +1,7 @@
 package storagebackend_test
 
 import (
+	"encoding/base64"
 	"regexp"
 	"sort"
 	"testing"
@@ -67,4 +68,41 @@ func TestLogStreamMatcherPushdown(t *testing.T) {
 		}}))
 	// Unfiltered returns every stream.
 	require.Len(t, query(nil), 3)
+}
+
+// TestLogStreamMatcherPushdownBytesValue selects a stream by a bytes-valued resource attribute. The
+// label set renders bytes as base64 (pcommon AsString), so the pushed matcher must too; a naive
+// signal.Value.AppendText (raw bytes) would never equal the base64 query value and would silently
+// prune both streams.
+func TestLogStreamMatcherPushdownBytesValue(t *testing.T) {
+	b, ctx := newBackend(t)
+	ts := time.Now().Truncate(time.Second)
+
+	tokens := map[string][]byte{"one": {0x01, 0x02, 0xff}, "two": {0x10, 0x20, 0x30}}
+	for name, tok := range tokens {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutEmptyBytes("token").FromRaw(tok)
+		sl := rl.ScopeLogs().AppendEmpty()
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		rec.Body().SetStr("log " + name)
+		require.NoError(t, b.ConsumeLogs(ctx, ld))
+	}
+
+	// The query value is the base64 projection of token "one".
+	wantB64 := base64.StdEncoding.EncodeToString(tokens["one"])
+
+	lq := b.Logs()
+	node, err := lq.Query(ctx, []logql.LabelMatcher{{Label: "token", Op: logql.OpEq, Value: wantB64}})
+	require.NoError(t, err)
+	it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: ts.Add(-time.Hour), End: ts.Add(time.Hour), Limit: -1})
+	require.NoError(t, err)
+	var lines []string
+	var e logqlengine.Entry
+	for it.Next(&e) {
+		lines = append(lines, e.Line)
+	}
+	require.NoError(t, it.Err())
+	require.Equal(t, []string{"log one"}, lines)
 }

--- a/internal/storagebackend/logs_stream_matcher_test.go
+++ b/internal/storagebackend/logs_stream_matcher_test.go
@@ -1,0 +1,70 @@
+package storagebackend_test
+
+import (
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+)
+
+// TestLogStreamMatcherPushdown checks that offloading resource-label equality matchers to the
+// postings index returns exactly the same records as in-memory filtering, across equality, no-match,
+// negation, regexp, and the unfiltered case, over several resource streams.
+func TestLogStreamMatcherPushdown(t *testing.T) {
+	b, ctx := newBackend(t)
+	ts := time.Now().Truncate(time.Second)
+
+	for i, svc := range []string{"alpha", "beta", "gamma"} {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", svc)
+		sl := rl.ScopeLogs().AppendEmpty()
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.Add(time.Duration(i) * time.Second).UnixNano()))
+		rec.Body().SetStr("log from " + svc)
+		require.NoError(t, b.ConsumeLogs(ctx, ld))
+	}
+
+	lq := b.Logs()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+	query := func(sel []logql.LabelMatcher) []string {
+		t.Helper()
+		node, err := lq.Query(ctx, sel)
+		require.NoError(t, err)
+		it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+		require.NoError(t, err)
+		var lines []string
+		var e logqlengine.Entry
+		for it.Next(&e) {
+			lines = append(lines, e.Line)
+		}
+		require.NoError(t, it.Err())
+		sort.Strings(lines)
+		return lines
+	}
+
+	// Equality on a resource label is offloaded to the postings index.
+	require.Equal(t, []string{"log from beta"},
+		query([]logql.LabelMatcher{{Label: "service_name", Op: logql.OpEq, Value: "beta"}}))
+	// No matching stream.
+	require.Empty(t,
+		query([]logql.LabelMatcher{{Label: "service_name", Op: logql.OpEq, Value: "nope"}}))
+	// Negation is not offloaded but still correct via matchSelector.
+	require.Equal(t, []string{"log from alpha", "log from gamma"},
+		query([]logql.LabelMatcher{{Label: "service_name", Op: logql.OpNotEq, Value: "beta"}}))
+	// Regexp is not offloaded but still correct.
+	require.Equal(t, []string{"log from alpha", "log from beta"},
+		query([]logql.LabelMatcher{{
+			Label: "service_name", Op: logql.OpRe, Value: "alpha|beta",
+			Re: regexp.MustCompile("^(?:alpha|beta)$"),
+		}}))
+	// Unfiltered returns every stream.
+	require.Len(t, query(nil), 3)
+}


### PR DESCRIPTION
Offloads LogQL filtering from the engine into the embedded storage fetch seam, so non-matching data is dropped before the expensive label-set construction. Two complementary offloads:

## Phase 1 — line filters (`|= "x"`)

`LogQLOptimizer` pushes leading positive substring line filters into the fetch as body `Conditions` with an exact `contains` Match. Results are identical (`TestLogQLOptimizerEquivalence`). `BenchmarkLogQLLineFilterOffload`: `|= "GET"` 19.9 ms → 6.0 ms (**3.3×**). No bloom token hint (would false-negative on sub-word matches like `"xGETy"`); exact per-record prefilter.

## Phase 2 — stream-selector labels (`{service_name="x"}`)

Equality matchers on resource/scope (stream) labels are resolved to storage `Matchers`, so the postings index prunes whole streams. Offloaded only when the normalized label maps unambiguously to a single raw resource/scope key (via `LogSeries`); record-attr/ambiguous/absent labels fall back to in-memory `matchSelector` (`TestLogStreamMatcherPushdown`). `BenchmarkLogQLStreamSelector` (20 services, select 1): 2519 µs → 207 µs (**12.2×**), 18.6× fewer allocs.

## Not done: record-attr offload via the attrs column

Blocked for the embedded backend (unlike chstorage's uniform columns): LogQL labels are normalized (`http.method`→`http_method`) but attrs are keyed raw with no reverse map; no record-attr key enumeration; and a blind attrs `Condition` for a resource label would wrongly exclude every record. Needs a storage-side label-resolution enabler.
