### PR TITLE
feat(storagebackend): offload clean pipeline label-equality filters

### DIFF
--- a/integration/lokie2e/bench_pipeline_label_offload_storage_test.go
+++ b/integration/lokie2e/bench_pipeline_label_offload_storage_test.go
@@ -1,0 +1,73 @@
+package lokie2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLPipelineLabelFilter measures a pipeline label filter (`| level="..."`) on a clean
+// record-attribute label over one stream. LogQLOptimizer extracts the filter and the querier
+// offloads it to a per-record fetch condition, so only matching records are materialized.
+func BenchmarkLogQLPipelineLabelFilter(b *testing.B) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+	backend := storagebackend.New(store)
+
+	const (
+		levels       = 20
+		perLevel     = 300
+		selectedLeve = "level-07"
+	)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("app", "bench") // stream selector label
+	sl := rl.ScopeLogs().AppendEmpty()
+	for l := range levels {
+		for r := range perLevel {
+			lr := sl.LogRecords().AppendEmpty()
+			lr.SetTimestamp(pcommon.Timestamp(now.Add(time.Duration(r) * time.Millisecond).UnixNano()))
+			lr.Body().SetStr(fmt.Sprintf("request %d", r))
+			lr.Attributes().PutStr("level", fmt.Sprintf("level-%02d", l))
+		}
+	}
+	require.NoError(b, backend.ConsumeLogs(ctx, ld))
+
+	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+		ParseOptions: logql.ParseOptions{AllowDots: true},
+		Optimizers:   []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}},
+	})
+	require.NoError(b, err)
+
+	params := logqlengine.EvalParams{
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+		Direction: logqlengine.DirectionForward,
+		Limit:     10000,
+	}
+	query, err := engine.NewQuery(ctx, fmt.Sprintf(`{app="bench"} | level = %q`, selectedLeve))
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := query.Eval(ctx, params); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -47,6 +47,10 @@ type logStreamNode struct {
 	// into the fetch by [LogQLOptimizer]. They prune parts and drop records at the storage layer;
 	// the engine still applies the full pipeline, so they only ever skip work.
 	conditions []fetch.Condition
+	// pipelineLabels are equality label filters (`| L="v"`) extracted from the pipeline by
+	// [LogQLOptimizer] that can be resolved against the stored label set, just like selector
+	// matchers. streamFilters resolves them to Matchers/Conditions.
+	pipelineLabels []logql.LabelMatcher
 }
 
 var _ logqlengine.PipelineNode = (*logStreamNode)(nil)
@@ -130,11 +134,15 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 // drops rows at the fetch layer.
 func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matchers []fetch.Matcher, conditions []fetch.Condition) {
 	wanted := map[string]string{}
-	for _, m := range n.selector {
-		if m.Op == logql.OpEq && m.Value != "" {
-			wanted[string(m.Label)] = m.Value
+	addEq := func(matchers []logql.LabelMatcher) {
+		for _, m := range matchers {
+			if m.Op == logql.OpEq && m.Value != "" {
+				wanted[string(m.Label)] = m.Value
+			}
 		}
 	}
+	addEq(n.selector)       // stream selector labels
+	addEq(n.pipelineLabels) // offloaded pipeline label filters (| L="v")
 	if len(wanted) == 0 {
 		return nil, nil
 	}

--- a/internal/storagebackend/logs_optimizer.go
+++ b/internal/storagebackend/logs_optimizer.go
@@ -62,6 +62,40 @@ func (o *LogQLOptimizer) optimizePipeline(n logqlengine.PipelineNode) {
 		return
 	}
 	sn.conditions = lineFilterConditions(pn.Pipeline)
+	sn.pipelineLabels = labelFilterMatchers(pn.Pipeline)
+}
+
+// labelFilterMatchers extracts the equality label filters (`| L="v"`) that can be resolved against
+// the stored label set: those appearing before any stage that adds, renames, or drops labels (after
+// which a filter could reference a derived label rather than a stored one). Only simple equality
+// predicates on non-empty values are returned; streamFilters then decides per label whether the
+// offload is sound (clean name; resource → Matcher, record → Condition). The filters stay in the
+// engine pipeline, so this only ever skips work.
+func labelFilterMatchers(pipeline []logql.PipelineStage) (out []logql.LabelMatcher) {
+	for _, stage := range pipeline {
+		switch stage := stage.(type) {
+		case *logql.LabelFilter:
+			if m, ok := equalityLabelMatcher(stage.Pred); ok {
+				out = append(out, m)
+			}
+		case *logql.LineFilter, *logql.LineFormat, *logql.DecolorizeExpr:
+			// These do not change the stored label set; keep scanning.
+		default:
+			// A parser, label_format, drop/keep, distinct, or unknown stage may change labels, so a
+			// later filter could reference a derived label. Stop offloading here.
+			return out
+		}
+	}
+	return out
+}
+
+// equalityLabelMatcher returns the underlying matcher of a simple `label = "value"` predicate.
+func equalityLabelMatcher(pred logql.LabelPredicate) (logql.LabelMatcher, bool) {
+	m, ok := logql.UnparenLabelPredicate(pred).(*logql.LabelMatcher)
+	if !ok || m.Op != logql.OpEq || m.Value == "" {
+		return logql.LabelMatcher{}, false
+	}
+	return *m, true
 }
 
 // lineFilterConditions builds storage fetch conditions from the leading offloadable line filters of

--- a/internal/storagebackend/logs_optimizer_test.go
+++ b/internal/storagebackend/logs_optimizer_test.go
@@ -28,14 +28,27 @@ func TestLogQLOptimizerEquivalence(t *testing.T) {
 	rl := ld.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().PutStr("service.name", "api")
 	sl := rl.ScopeLogs().AppendEmpty()
-	bodies := []string{
-		"GET /a 200", "POST /b 200", "GET /c 404", "HEAD /d 200",
-		"GET /a 500", "DELETE /e 200", "xGETy embedded", "get lowercase",
+	records := []struct {
+		body, level, method string
+	}{
+		{"GET /a 200", "info", "GET"},
+		{"POST /b 200", "info", "POST"},
+		{"GET /c 404", "error", "GET"},
+		{"HEAD /d 200", "info", "HEAD"},
+		{"GET /a 500", "error", "GET"},
+		{"DELETE /e 200", "warn", "DELETE"},
+		{"xGETy embedded", "info", "GET"},
+		{"get lowercase", "info", "GET"},
+		// A JSON body whose PARSED level ("debug") differs from the STORED level attr ("error"):
+		// after `| json`, a `| level=...` filter must see "debug", so it must NOT be offloaded.
+		{`{"level":"debug","method":"PUT"}`, "error", "PUT"},
 	}
-	for i, body := range bodies {
+	for i, r := range records {
 		rec := sl.LogRecords().AppendEmpty()
 		rec.SetTimestamp(pcommon.Timestamp(ts.Add(time.Duration(i) * time.Millisecond).UnixNano()))
-		rec.Body().SetStr(body)
+		rec.Body().SetStr(r.body)
+		rec.Attributes().PutStr("level", r.level)        // clean record-attribute label
+		rec.Attributes().PutStr("http.method", r.method) // dotted record-attribute label
 	}
 	require.NoError(t, b.ConsumeLogs(ctx, ld))
 
@@ -60,12 +73,22 @@ func TestLogQLOptimizerEquivalence(t *testing.T) {
 
 	for _, query := range []string{
 		`{service_name="api"}`,
-		`{service_name="api"} |= "GET"`,                       // offloaded: positive substring
-		`{service_name="api"} |= "GET" |= "404"`,              // two offloaded filters (AND)
-		`{service_name="api"} != "GET"`,                       // not offloaded (negated)
-		`{service_name="api"} |~ "GET|POST"`,                  // not offloaded (regexp)
-		`{service_name="api"} |= "GET" != "404"`,              // mixed
-		`count_over_time({service_name="api"} |= "GET" [1h])`, // metric query with offloaded filter
+		`{service_name="api"} |= "GET"`,                                   // offloaded: positive substring
+		`{service_name="api"} |= "GET" |= "404"`,                          // two offloaded filters (AND)
+		`{service_name="api"} != "GET"`,                                   // not offloaded (negated)
+		`{service_name="api"} |~ "GET|POST"`,                              // not offloaded (regexp)
+		`{service_name="api"} |= "GET" != "404"`,                          // mixed
+		`count_over_time({service_name="api"} |= "GET" [1h])`,             // metric query with offloaded filter
+		`{service_name="api"} | level = "error"`,                          // offloaded: clean record-attr label filter
+		`{service_name="api"} |= "GET" | level = "info"`,                  // line filter + label filter, both offloaded
+		`{service_name="api"} | level = "error" | level = "info"`,         // contradictory (empty), offloaded
+		`{service_name="api"} | http_method = "GET"`,                      // dotted label filter, not offloaded
+		`{service_name="api"} | level != "info"`,                          // negated label filter, not offloaded
+		`{service_name="api"} | label_format dummy="x" | level = "error"`, // label_format before: not offloaded
+		`{service_name="api"} | logfmt | level = "error"`,                 // parser before: must NOT offload (parsed field)
+		`{service_name="api"} | json | level = "debug"`,                   // parsed level=debug, must NOT offload stored level
+		`{service_name="api"} | json | level = "error"`,                   // parsed level shadows stored; must NOT offload
+		`count_over_time({service_name="api"} | level = "error" [1h])`,    // metric query with label filter
 	} {
 		t.Run(query, func(t *testing.T) {
 			require.Equal(t,


### PR DESCRIPTION
Follow-up to #1088. Extends `LogQLOptimizer` to offload **pipeline label filters** (`| L="v"`) — the same fetch-layer offload already done for selectors, now for the pipeline.

## What it does
The optimizer extracts equality label filters that appear **before any label-producing stage** (parsers, `label_format`, `drop`/`keep`) and attaches them to the log node; `streamFilters` resolves them like selector matchers — a resource/scope label → postings `Matcher`, a clean record-attribute label → per-record `Condition`. Dotted/ambiguous labels fall back to the engine.

`BenchmarkLogQLPipelineLabelFilter` (20 levels in one stream, select 1): **5033µs → 1399µs (3.6×)**, 2.3× fewer allocations.

## Correctness crux: stop before label-producing stages
A `| json | level="error"` filter targets the **parsed** `level`, not the stored attribute, so it must **not** be offloaded. The equivalence test now ingests a JSON body whose parsed `level` ("debug") differs from its stored `level` attr ("error") and asserts offloaded == engine-only across:
- log + metric queries, line+label combinations, negation, contradictions;
- `| json | level=…` and `| logfmt | level=…` (parser shadowing);
- `| label_format … | level=…` (label_format shadowing).

I verified the JSON-shadow case **fails** if parsers are wrongly treated as offload-safe, so it's a real guard.

The engine still applies the full pipeline, so the offload only ever skips work.

## Testing
- `go test ./cmd/oteldb/ ./internal/storagebackend/ ./integration/lokie2e/` — pass
- `golangci-lint run` — 0 issues