### PR TITLE
feat(storagebackend): opt-in parallel LogQL result materialization

### DIFF
--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -104,6 +104,9 @@ type StorageConfig struct {
 	// FlushInterval is the max age of unflushed head data before it is flushed to a part.
 	// Zero uses the engine default. Ignored for the ephemeral memory backend.
 	FlushInterval time.Duration `json:"flush_interval" yaml:"flush_interval"`
+	// LogQueryParallelism enables concurrent materialization of LogQL query results across up to
+	// this many workers. Zero or one (default) keeps the sequential path. Opt-in.
+	LogQueryParallelism int `json:"log_query_parallelism" yaml:"log_query_parallelism"`
 }
 
 func (cfg *StorageConfig) setDefaults() {

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -50,8 +50,8 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger)
 		zap.String("backend", cmp.Or(cfg.Backend, "memory")),
 		zap.Int("log_query_parallelism", cfg.LogQueryParallelism),
 	)
-	backend := storagebackend.New(store,
+	b := storagebackend.New(store,
 		storagebackend.WithLogParallelism(cfg.LogQueryParallelism),
 	)
-	return backend, store.Close, nil
+	return b, store.Close, nil
 }

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -48,6 +48,10 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger)
 
 	lg.Info("Using embedded storage engine for metrics",
 		zap.String("backend", cmp.Or(cfg.Backend, "memory")),
+		zap.Int("log_query_parallelism", cfg.LogQueryParallelism),
 	)
-	return storagebackend.New(store), store.Close, nil
+	backend := storagebackend.New(store,
+		storagebackend.WithLogParallelism(cfg.LogQueryParallelism),
+	)
+	return backend, store.Close, nil
 }

--- a/integration/lokie2e/bench_parallel_materialize_storage_test.go
+++ b/integration/lokie2e/bench_parallel_materialize_storage_test.go
@@ -1,0 +1,80 @@
+package lokie2e_test
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// BenchmarkLogQLMaterializeParallel measures a materialization-heavy log query (every record
+// survives, so the cost is dominated by building per-record label sets) with the sequential path
+// (parallelism off) versus the opt-in parallel materializer.
+func BenchmarkLogQLMaterializeParallel(b *testing.B) {
+	const records = 50_000
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	build := func(parallelism int) *logqlengine.Engine {
+		ctx := context.Background()
+		store, err := storage.InMemory()
+		require.NoError(b, err)
+		b.Cleanup(func() { _ = store.Close(ctx) })
+		backend := storagebackend.New(store, storagebackend.WithLogParallelism(parallelism))
+
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		for i := range records {
+			lr := sl.LogRecords().AppendEmpty()
+			lr.SetTimestamp(pcommon.Timestamp(now.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+			lr.Body().SetStr(fmt.Sprintf("request %d completed", i))
+			lr.Attributes().PutStr("env", "bench")
+		}
+		require.NoError(b, backend.ConsumeLogs(ctx, ld))
+
+		engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+			ParseOptions: logql.ParseOptions{AllowDots: true},
+		})
+		require.NoError(b, err)
+		return engine
+	}
+
+	params := logqlengine.EvalParams{
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+		Direction: logqlengine.DirectionForward,
+		Limit:     records,
+	}
+
+	for _, mode := range []struct {
+		name        string
+		parallelism int
+	}{
+		{"Sequential", 0},
+		{fmt.Sprintf("Parallel-%d", runtime.GOMAXPROCS(0)), runtime.GOMAXPROCS(0)},
+	} {
+		engine := build(mode.parallelism)
+		query, err := engine.NewQuery(context.Background(), `{env="bench"}`)
+		require.NoError(b, err)
+		b.Run(mode.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := query.Eval(context.Background(), params); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/oteldb/storage/query/fetch"
 	"github.com/oteldb/storage/signal"
@@ -87,22 +88,9 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 		return nil, errors.Wrap(err, "drain logs")
 	}
 
-	var entries []logqlengine.Entry
-	for _, batch := range batches {
-		cols := newLogColumns(batch)
-		for i := range batch.Timestamps {
-			record := cols.record(batch, i)
-			set := logqlabels.NewLabelSet()
-			set.SetFromRecord(record)
-			if !matchSelector(set, n.selector) {
-				continue
-			}
-			entries = append(entries, logqlengine.Entry{
-				Timestamp: record.Timestamp,
-				Line:      record.Body,
-				Set:       set,
-			})
-		}
+	entries, err := n.materialize(ctx, batches)
+	if err != nil {
+		return nil, err
 	}
 
 	sortEntries(entries, params.Direction)
@@ -110,6 +98,95 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 		entries = entries[:params.Limit]
 	}
 	return iterators.Slice(entries), nil
+}
+
+// logMaterializeThreshold is the minimum number of fetched records before the parallel materializer
+// is used; below it the sequential path wins (goroutine + merge overhead). It is a var so tests can
+// exercise the parallel path on small inputs.
+var logMaterializeThreshold = 2048
+
+// materialize builds the matching entries from the fetched batches. With [Backend] log parallelism
+// enabled and enough records it splits the flattened record sequence into contiguous chunks built
+// concurrently and merges them in order; otherwise it runs sequentially. Because the chunks are
+// contiguous and merged in order, the merged entries are in the same order as the sequential path,
+// so the later stable sort yields the same output regardless of worker scheduling.
+func (n *logStreamNode) materialize(ctx context.Context, batches []*fetch.Batch) ([]logqlengine.Entry, error) {
+	offsets := make([]int, len(batches)+1)
+	total := 0
+	for b, batch := range batches {
+		offsets[b] = total
+		total += len(batch.Timestamps)
+	}
+	offsets[len(batches)] = total
+
+	workers := n.q.b.logParallelism
+	if workers <= 1 || total < logMaterializeThreshold {
+		return n.materializeRange(batches, offsets, 0, total), nil
+	}
+	if workers > total {
+		workers = total
+	}
+
+	chunkSize := (total + workers - 1) / workers
+	results := make([][]logqlengine.Entry, workers)
+	grp, grpCtx := errgroup.WithContext(ctx)
+	grp.SetLimit(workers)
+	for w := range workers {
+		lo := w * chunkSize
+		hi := min(lo+chunkSize, total)
+		if lo >= hi {
+			break
+		}
+		grp.Go(func() error {
+			if err := grpCtx.Err(); err != nil {
+				return err
+			}
+			results[w] = n.materializeRange(batches, offsets, lo, hi)
+			return nil
+		})
+	}
+	if err := grp.Wait(); err != nil {
+		return nil, err
+	}
+
+	merged := make([]logqlengine.Entry, 0, total)
+	for _, r := range results {
+		merged = append(merged, r...)
+	}
+	return merged, nil
+}
+
+// materializeRange materializes the matching entries for the global record range [lo, hi) over the
+// flattened batch sequence (offsets[b] is the global index of batch b's first record). It is the
+// single materialization primitive shared by the sequential and parallel paths, so both produce the
+// same entries in the same order for a given range. It reads only immutable batch state and builds a
+// fresh label set per record, so it is safe to call concurrently over disjoint ranges.
+func (n *logStreamNode) materializeRange(batches []*fetch.Batch, offsets []int, lo, hi int) []logqlengine.Entry {
+	var out []logqlengine.Entry
+	for b := range batches {
+		bLo, bHi := offsets[b], offsets[b+1]
+		if bHi <= lo || bLo >= hi {
+			continue
+		}
+		batch := batches[b]
+		cols := newLogColumns(batch)
+		start := max(lo-bLo, 0)
+		end := min(hi-bLo, len(batch.Timestamps))
+		for i := start; i < end; i++ {
+			record := cols.record(batch, i)
+			set := logqlabels.NewLabelSet()
+			set.SetFromRecord(record)
+			if !matchSelector(set, n.selector) {
+				continue
+			}
+			out = append(out, logqlengine.Entry{
+				Timestamp: record.Timestamp,
+				Line:      record.Body,
+				Set:       set,
+			})
+		}
+	}
+	return out
 }
 
 // streamFilters resolves the selector's equality matchers to storage fetch filters so the storage

--- a/internal/storagebackend/logs_parallel_test.go
+++ b/internal/storagebackend/logs_parallel_test.go
@@ -1,0 +1,140 @@
+package storagebackend_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// parallelTestData ingests a dataset that exercises both materialization shapes:
+//   - one big empty-resource stream (Loki-style) of bigStream records, so chunk boundaries fall
+//     inside a single batch;
+//   - several resource streams whose timestamps overlap the big stream, so the merged result has
+//     ties that must be ordered identically regardless of worker scheduling.
+//
+// Every record carries env="test" so a single selector matches all of them.
+func parallelTestData(tb testing.TB, parallelism int) (backend *storagebackend.Backend, start, end time.Time) {
+	tb.Helper()
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = store.Close(ctx) })
+	backend = storagebackend.New(store, storagebackend.WithLogParallelism(parallelism))
+
+	base := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	const bigStream = 3000
+
+	// Big empty-resource stream.
+	{
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		for i := range bigStream {
+			lr := sl.LogRecords().AppendEmpty()
+			lr.SetTimestamp(pcommon.Timestamp(base.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+			lr.Body().SetStr(fmt.Sprintf("big %d", i))
+			lr.Attributes().PutStr("env", "test")
+			lr.Attributes().PutStr("job", fmt.Sprintf("job-%d", i%10))
+		}
+		require.NoError(tb, backend.ConsumeLogs(ctx, ld))
+	}
+	// Several resource streams with timestamps overlapping the big stream (forces ties).
+	for s := range 5 {
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", fmt.Sprintf("svc-%d", s))
+		sl := rl.ScopeLogs().AppendEmpty()
+		for j := range 100 {
+			lr := sl.LogRecords().AppendEmpty()
+			lr.SetTimestamp(pcommon.Timestamp(base.Add(time.Duration(j) * time.Millisecond).UnixNano()))
+			lr.Body().SetStr(fmt.Sprintf("svc%d %d", s, j))
+			lr.Attributes().PutStr("env", "test")
+		}
+		require.NoError(tb, backend.ConsumeLogs(ctx, ld))
+	}
+
+	return backend, base.Add(-time.Hour), base.Add(time.Hour)
+}
+
+// resultRows drains a query into a fully-ordered, comparable representation: one row per entry in
+// result order, capturing timestamp, line, and the sorted label set. Any divergence in selection,
+// order (including tie order), or labels between two runs shows up as a row difference.
+func resultRows(tb testing.TB, b *storagebackend.Backend, sel []logql.LabelMatcher, params logqlengine.EvalParams) []string {
+	tb.Helper()
+	node, err := b.Logs().Query(context.Background(), sel)
+	require.NoError(tb, err)
+	it, err := node.EvalPipeline(context.Background(), params)
+	require.NoError(tb, err)
+
+	var rows []string
+	var e logqlengine.Entry
+	for it.Next(&e) {
+		var labels []string
+		e.Set.Range(func(k logql.Label, v pcommon.Value) {
+			labels = append(labels, fmt.Sprintf("%s=%s", k, v.AsString()))
+		})
+		sort.Strings(labels)
+		rows = append(rows, fmt.Sprintf("%d|%s|%v", e.Timestamp, e.Line, labels))
+	}
+	require.NoError(tb, it.Err())
+	return rows
+}
+
+// TestLogMaterializeParallelEquivalence proves the parallel materializer returns byte-for-byte the
+// same result as the sequential one, across data shapes, parallelism degrees, selectivity, limits,
+// and directions. Run with -race to also prove the workers are data-race free.
+func TestLogMaterializeParallelEquivalence(t *testing.T) {
+	t.Parallel()
+
+	parallels := []int{1, 2, 3, 7, 8, 64, 4096} // 4096 > total records: workers clamp to record count
+	backends := make(map[int]*storagebackend.Backend, len(parallels)+1)
+	seq, start, end := parallelTestData(t, 0) // sequential reference
+	backends[0] = seq
+	for _, p := range parallels {
+		b, _, _ := parallelTestData(t, p)
+		backends[p] = b
+	}
+
+	eq := func(label, value string) []logql.LabelMatcher {
+		return []logql.LabelMatcher{{Label: logql.Label(label), Op: logql.OpEq, Value: value}}
+	}
+	re := func(label, value string) []logql.LabelMatcher {
+		return []logql.LabelMatcher{{Label: logql.Label(label), Op: logql.OpRe, Value: value}}
+	}
+
+	cases := []struct {
+		name   string
+		sel    []logql.LabelMatcher
+		params logqlengine.EvalParams
+	}{
+		{"AllRecords", eq("env", "test"), logqlengine.EvalParams{Start: start, End: end, Limit: -1}},
+		{"Selective", eq("job", "job-3"), logqlengine.EvalParams{Start: start, End: end, Limit: -1}},
+		{"ResourceStream", eq("service_name", "svc-2"), logqlengine.EvalParams{Start: start, End: end, Limit: -1}},
+		{"Empty", eq("env", "absent"), logqlengine.EvalParams{Start: start, End: end, Limit: -1}},
+		{"ForwardLimit", eq("env", "test"), logqlengine.EvalParams{Start: start, End: end, Direction: logqlengine.DirectionForward, Limit: 17}},
+		{"BackwardLimit", eq("env", "test"), logqlengine.EvalParams{Start: start, End: end, Direction: logqlengine.DirectionBackward, Limit: 23}},
+		{"RegexAll", re("env", "te.*"), logqlengine.EvalParams{Start: start, End: end, Limit: -1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := resultRows(t, backends[0], tc.sel, tc.params)
+			for _, p := range parallels {
+				require.Equalf(t, want, resultRows(t, backends[p], tc.sel, tc.params),
+					"parallelism %d must equal sequential", p)
+			}
+		})
+	}
+}

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -40,13 +40,31 @@ import (
 type Backend struct {
 	store  *storage.Storage
 	tenant signal.TenantID
+	// logParallelism is the max number of workers used to materialize log query results across the
+	// fetched record set. <= 1 keeps the sequential path (the default). See [WithLogParallelism].
+	logParallelism int
+}
+
+// Option configures a [Backend].
+type Option func(*Backend)
+
+// WithLogParallelism enables concurrent materialization of LogQL query results across up to n
+// workers. The fetched record set is split into contiguous chunks built in parallel and merged in
+// order, so the result is identical to the sequential path regardless of scheduling. Opt-in: n <= 1
+// (the default) keeps the sequential path. Effective only above an internal record-count threshold.
+func WithLogParallelism(n int) Option {
+	return func(b *Backend) { b.logParallelism = n }
 }
 
 // New returns a Backend over store. The query side reads across all tenants and the ingest
 // side derives tenants from each batch's Resource/Scope (via the engine's tenant callback),
 // so the empty tenant id here scopes reads to the federated cross-tenant view.
-func New(store *storage.Storage) *Backend {
-	return &Backend{store: store}
+func New(store *storage.Storage, opts ...Option) *Backend {
+	b := &Backend{store: store}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
 }
 
 // queryable builds a fresh Prometheus queryable over the engine's current data. A new


### PR DESCRIPTION
Building per-record label sets (`SetFromRecord` + `matchSelector`) dominates the embedded LogQL scan. This adds an **opt-in** parallel materializer for `logStreamNode.EvalPipeline`: the fetched record set is split into contiguous chunks built concurrently and merged in order. No engine change — the node just fills its slice faster.

## Opt-in
- `storagebackend.New(store, storagebackend.WithLogParallelism(n))`
- config `storage.log_query_parallelism` (default **1 = sequential**)
- gated by an internal record-count threshold (small queries stay sequential)

## Correctness — by construction, then proven
- Sequential and parallel share **one** `materializeRange` primitive over a flattened `[lo,hi)` record range. Chunks are **contiguous** and merged in **chunk order**, so the merged entries are in the *same order* as the sequential build; the existing **stable** sort then yields identical output regardless of scheduling.
- Workers read only **immutable** batch state, build **fresh** label sets, and write **disjoint** result slots (no shared mutation).
- Handles both shapes: one big Loki-style stream (chunk boundaries fall *inside* a batch) and many streams (boundaries at batch edges).

`TestLogMaterializeParallelEquivalence` ingests a big empty-resource stream **plus** several streams with overlapping timestamps (so the merge has **ties** that must order identically), then asserts parallel == sequential **byte-for-byte** across parallelism degrees `{1,2,3,7,8,64,4096}`, selectivity, empty results, forward/backward **limits**, and regex. **Passes under `-race`** (proves the workers are data-race free).

## Edge cases handled
- Ties (overlapping timestamps) → stable sort + in-order merge → deterministic.
- `Limit`/direction → applied after merge+sort, unchanged.
- `workers > total records` → clamped.
- Below threshold or `n<=1` → sequential.
- Context cancellation / errors → `errgroup`.

## Benchmark
`BenchmarkLogQLMaterializeParallel` (50k records, every record survives): **42ms → 24.5ms (~1.7×)**. Not N-core: the materialization is parallelized but the downstream **sort/group/fetch stay sequential** (Amdahl). Allocations unchanged (parallelism cuts wall-clock, not allocs — a complementary `SetFromRecord` alloc reduction would help the sequential path too).

## Scope
Logs only (the "loki engine" path). The shared `logqlengine` is pull-based/sequential; true engine parallelism would be query sharding — more invasive for less gain than this node-level materialization, which already benefits log **and** metric queries (the sampler reads the same `EvalPipeline`).

## Testing
- `go test -race ./internal/storagebackend/` — pass
- `go test ./cmd/oteldb/ ./integration/lokie2e/` — pass
- `golangci-lint run` — 0 issues