### PR TITLE
feat(storagebackend): adopt storage v0.5.0 (LogKeys + observability)

### DIFF
--- a/cmd/oteldb/app.go
+++ b/cmd/oteldb/app.go
@@ -116,7 +116,7 @@ func newApp(ctx context.Context, cfg Config, m *sdkapp.Telemetry) (_ *App, err e
 	// ClickHouse. For each swapped signal both the query side (the API handler's querier) and
 	// the ingestion side (the collector exporter's sink) are replaced.
 	if cfg.usesStorageBackend() {
-		b, closeStore, err := setupStorageBackend(ctx, cfg.Storage, app.lg.Named("storage"))
+		b, closeStore, err := setupStorageBackend(ctx, cfg.Storage, app.lg.Named("storage"), app.telemetry)
 		if err != nil {
 			return nil, errors.Wrap(err, "setup storage backend")
 		}

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/go-faster/errors"
+	"github.com/go-faster/sdk/app"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/storage"
@@ -17,8 +18,13 @@ import (
 // setupStorageBackend constructs the embedded storage engine and an adapter implementing
 // oteldb's metric query and ingestion interfaces. The returned close func stops and flushes
 // the engine. It is used when [Config.MetricsBackend] is [MetricsBackendStorage].
-func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger) (*storagebackend.Backend, func(context.Context) error, error) {
-	var opts []storage.Option
+func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger, m *app.Telemetry) (*storagebackend.Backend, func(context.Context) error, error) {
+	// The engine logs, traces, and meters through the injected providers (no-op if absent).
+	opts := []storage.Option{
+		storage.WithLogger(lg),
+		storage.WithTracerProvider(m.TracerProvider()),
+		storage.WithMeterProvider(m.MeterProvider()),
+	}
 	switch cfg.Backend {
 	case "", "memory":
 		opts = append(opts,

--- a/go.mod
+++ b/go.mod
@@ -451,7 +451,7 @@ require (
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
-	github.com/oteldb/storage v0.4.0
+	github.com/oteldb/storage v0.5.0
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1018,8 +1018,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.7.0-alpha.0 h1:od3skf7eTPMv+3zR6G3WZl7YVzWJUa8b8yP3XpfIgI4=
 github.com/oteldb/promql-engine v0.7.0-alpha.0/go.mod h1:j3kBzxEWSsdIinLTl7ogVolJbI2GC/fa1GU4/NpOr0k=
-github.com/oteldb/storage v0.4.0 h1:xGfd7gJBzYeZY0CA9xn0s1GbuiawB5+Dd9vwfxk1Ryg=
-github.com/oteldb/storage v0.4.0/go.mod h1:Xjn2nr5HKRXlooV93E6NGuriAjsk38h2FGz9ZRZuhWw=
+github.com/oteldb/storage v0.5.0 h1:Txdm78ZTR2Ib0Nk6zksPlaWWmGvgQxH/ac5jwyzrVVw=
+github.com/oteldb/storage v0.5.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -3,12 +3,12 @@ package storagebackend
 import (
 	"context"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/collector/pdata/plog"
 
+	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/query/fetch"
 	"github.com/oteldb/storage/signal"
 	siglog "github.com/oteldb/storage/signal/log"
@@ -121,17 +121,19 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 // the scan). The in-memory matchSelector still re-checks every surviving record, so this only ever
 // skips work.
 //
-// For an equality (`=`) on a non-empty value:
-//   - if the normalized label maps unambiguously to a single raw resource/scope attribute key (per
-//     LogSeries), it becomes a postings Matcher that prunes whole streams;
-//   - else if the label is "clean" — its normalized form is its own raw key, so a record-attribute
-//     key normalizing to it can only be the name itself — and is not a resource/scope label, it
-//     becomes a per-record attribute Condition that drops non-matching records.
+// Resolution uses the engine's key index (LogKeys), which reports every attribute key in the window
+// together with the scope(s) it was observed in (resource/scope = stream identity, record = the
+// per-record attrs column). For an equality (`=`) on a non-empty value, the normalized label is
+// matched back to its raw key(s):
+//   - a single raw key seen only in stream scope becomes a postings Matcher that prunes whole streams;
+//   - a single raw key seen only in record scope becomes a per-record Condition that drops
+//     non-matching records — this resolves dotted labels too (http_method ← http.method).
 //
-// Ambiguous, dotted record-attribute (e.g. http_method ← http.method), and absent labels are left to
-// matchSelector. Record-attribute Conditions carry only an exact Match (no bloom Equal hint): the
-// value may be non-string, and a typed value bloom token could wrongly part-prune; the Match still
-// drops rows at the fetch layer.
+// Absent labels, collisions (a label mapping to multiple raw keys), and mixed-scope keys (resource on
+// some streams, record on others — soundly pushable as neither) are left to matchSelector.
+// Record-attribute Conditions carry only an exact Match (no bloom Equal hint): the value may be
+// non-string, and a typed value bloom token could wrongly part-prune; the Match still drops rows at
+// the fetch layer.
 func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matchers []fetch.Matcher, conditions []fetch.Condition) {
 	wanted := map[string]string{}
 	addEq := func(matchers []logql.LabelMatcher) {
@@ -147,68 +149,57 @@ func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matche
 		return nil, nil
 	}
 
-	series, err := n.q.b.store.LogSeries(ctx, n.q.b.tenant, nil, lo, hi)
+	keys, err := n.q.b.store.LogKeys(ctx, n.q.b.tenant, lo, hi)
 	if err != nil {
 		return nil, nil // best effort: fall back to in-memory filtering.
 	}
 
-	// Map each wanted normalized label to the set of raw stream-attribute keys that normalize to it.
-	rawKeys := map[string]map[string]struct{}{}
-	collect := func(key []byte) {
-		label := otelstorage.KeyToLabel(string(key))
-		if _, ok := wanted[label]; !ok {
-			return
-		}
-		set := rawKeys[label]
-		if set == nil {
-			set = map[string]struct{}{}
-			rawKeys[label] = set
-		}
-		set[string(key)] = struct{}{}
+	// Resolve each wanted normalized label to its raw attribute key(s) and their merged scope. A
+	// label maps to multiple raw keys only on a collision (e.g. http.method and http_method both
+	// present); the scope bitset distinguishes stream identity from per-record attributes.
+	type resolved struct {
+		rawKey string
+		scope  storage.KeyScope
 	}
-	for _, s := range series {
-		for i := range s.Resource.Attributes {
-			collect(s.Resource.Attributes[i].Key)
+	byLabel := map[string][]resolved{}
+	for _, ki := range keys {
+		label := otelstorage.KeyToLabel(string(ki.Key))
+		if _, ok := wanted[label]; !ok {
+			continue
 		}
-		for i := range s.Scope.Attributes {
-			collect(s.Scope.Attributes[i].Key)
-		}
+		byLabel[label] = append(byLabel[label], resolved{rawKey: string(ki.Key), scope: ki.Scope})
 	}
 
 	for label, value := range wanted {
-		want := value
-		switch keys := rawKeys[label]; {
-		case len(keys) == 1:
-			var rawKey string
-			for k := range keys {
-				rawKey = k
-			}
+		cands := byLabel[label]
+		if len(cands) != 1 {
+			// Absent (label not stored) or ambiguous (collision): leave it to matchSelector.
+			continue
+		}
+		c, want := cands[0], value
+		stream := c.scope&(storage.KeyScopeResource|storage.KeyScopeScope) != 0
+		record := c.scope&storage.KeyScopeRecord != 0
+		switch {
+		case stream && !record:
+			// A resource/scope label: prune whole streams via the postings index.
 			matchers = append(matchers, fetch.Matcher{
-				Name: []byte(rawKey),
+				Name: []byte(c.rawKey),
 				// Render the value exactly as the label set does, so this matches matchSelector.
 				Match: func(v signal.Value) bool { return labelValueString(v) == want },
-				Spec:  &fetch.EqualMatcher{Name: rawKey, Value: want},
+				Spec:  &fetch.EqualMatcher{Name: c.rawKey, Value: want},
 			})
-		case len(keys) == 0 && isCleanLabel(label):
-			// Not a resource/scope label in this window; a clean name is its own raw record key.
+		case record && !stream:
+			// A per-record attribute: drop non-matching records at the fetch layer. Match only (no
+			// bloom Equal hint): a typed value token could wrongly part-prune.
 			conditions = append(conditions, fetch.Condition{
-				Column: label,
+				Column: c.rawKey,
 				Match:  func(v signal.Value) bool { return labelValueString(v) == want },
 			})
 		}
-		// len(keys) > 1 (ambiguous) or a dotted record label: leave to matchSelector.
+		// Mixed scope (resource on some streams, record on others) can't be pushed soundly as either
+		// a Matcher or a Condition: leave it to matchSelector.
 	}
 	return matchers, conditions
-}
-
-// isCleanLabel reports whether a normalized label name is its own raw attribute key: it contains no
-// underscore (which KeyToLabel could have produced from a dot or other character) and is unchanged
-// by KeyToLabel, so a record-attribute key normalizing to it can only be the name itself.
-func isCleanLabel(label string) bool {
-	if strings.IndexByte(label, '_') >= 0 {
-		return false
-	}
-	return otelstorage.KeyToLabel(label) == label
 }
 
 // sortEntries orders entries by timestamp ascending for forward queries and descending otherwise.
@@ -331,6 +322,22 @@ func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptio
 		names[name] = struct{}{}
 	}); err != nil {
 		return nil, err
+	}
+	// Stream enumeration only surfaces resource/scope labels. Record attributes live in the per-record
+	// column, so add their (normalized) key names from the engine's key index. They are window-global
+	// rather than stream-scoped, so only fold them in for an unfiltered listing — a stream selector
+	// can't soundly restrict them.
+	if len(opts.Query.Matchers) == 0 {
+		lo, hi := seriesWindow(opts.Start, opts.End)
+		keys, err := q.b.store.LogKeys(ctx, q.b.tenant, lo, hi)
+		if err != nil {
+			return nil, errors.Wrap(err, "log keys")
+		}
+		for _, ki := range keys {
+			if ki.Scope&storage.KeyScopeRecord != 0 {
+				names[otelstorage.KeyToLabel(string(ki.Key))] = struct{}{}
+			}
+		}
 	}
 	out := sortedKeys(names)
 	if opts.Limit > 0 && len(out) > opts.Limit {

--- a/internal/storagebackend/logs_optimizer_test.go
+++ b/internal/storagebackend/logs_optimizer_test.go
@@ -82,7 +82,7 @@ func TestLogQLOptimizerEquivalence(t *testing.T) {
 		`{service_name="api"} | level = "error"`,                          // offloaded: clean record-attr label filter
 		`{service_name="api"} |= "GET" | level = "info"`,                  // line filter + label filter, both offloaded
 		`{service_name="api"} | level = "error" | level = "info"`,         // contradictory (empty), offloaded
-		`{service_name="api"} | http_method = "GET"`,                      // dotted label filter, not offloaded
+		`{service_name="api"} | http_method = "GET"`,                      // dotted label filter, offloaded via LogKeys
 		`{service_name="api"} | level != "info"`,                          // negated label filter, not offloaded
 		`{service_name="api"} | label_format dummy="x" | level = "error"`, // label_format before: not offloaded
 		`{service_name="api"} | logfmt | level = "error"`,                 // parser before: must NOT offload (parsed field)

--- a/internal/storagebackend/logs_record_filter_test.go
+++ b/internal/storagebackend/logs_record_filter_test.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/oteldb/oteldb/internal/logql"
 	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/logstorage"
 )
 
-// TestLogRecordAttrPushdown checks that selecting by a clean record-attribute label (the Loki shape:
-// stream labels arrive as per-record attributes with an empty resource) returns exactly the records
-// matchSelector would, with the equality offloaded to a per-record fetch condition. It also checks
-// that a dotted record-attribute label (http_method ← http.method) — which cannot be resolved to a
-// raw key safely — still returns correct results via the in-memory fallback.
+// TestLogRecordAttrPushdown checks that selecting by a record-attribute label (the Loki shape: stream
+// labels arrive as per-record attributes with an empty resource) returns exactly the records
+// matchSelector would, with the equality offloaded to a per-record fetch condition. Since the LogKeys
+// rewire, a dotted record-attribute label (http_method ← http.method) resolves to its raw key
+// (http.method) via the engine's key index and is also offloaded — still returning correct results.
 func TestLogRecordAttrPushdown(t *testing.T) {
 	b, ctx := newBackend(t)
 	ts := time.Now().Truncate(time.Second)
@@ -73,12 +74,41 @@ func TestLogRecordAttrPushdown(t *testing.T) {
 	require.Equal(t, []string{"b"}, query(eq("job", "syslog")))
 	require.Empty(t, query(eq("job", "none")))
 
-	// Two clean record-attribute equalities (ANDed conditions).
+	// Two record-attribute equalities (ANDed conditions); the dotted one resolves via LogKeys.
 	require.Equal(t, []string{"a", "e"}, query([]logql.LabelMatcher{
 		{Label: "job", Op: logql.OpEq, Value: "varlogs"},
-		{Label: "http_method", Op: logql.OpEq, Value: "GET"}, // dotted -> fallback, still correct
+		{Label: "http_method", Op: logql.OpEq, Value: "GET"}, // dotted -> resolved to http.method, offloaded
 	}))
 
-	// Dotted record-attribute label alone: not offloadable, correct via fallback.
+	// Dotted record-attribute label alone: offloaded via its raw key (http.method).
 	require.Equal(t, []string{"a", "d", "e"}, query(eq("http_method", "GET")))
+}
+
+// TestLogRecordAttrLabelNames checks that LabelNames lists record-attribute keys (sourced from the
+// engine's key index via LogKeys), normalized to LogQL labels, alongside resource/scope labels.
+// Without LogKeys, stream enumeration alone would miss per-record attribute keys entirely.
+func TestLogRecordAttrLabelNames(t *testing.T) {
+	b, ctx := newBackend(t)
+	ts := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api") // resource (stream) label
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	lr.Body().SetStr("hello")
+	lr.Attributes().PutStr("job", "varlogs")     // clean record-attribute key
+	lr.Attributes().PutStr("http.method", "GET") // dotted record-attribute key -> http_method
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	lq := b.Logs()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+	names, err := lq.LabelNames(ctx, logstorage.LabelsOptions{Start: start, End: end})
+	require.NoError(t, err)
+
+	require.Contains(t, names, "service_name") // resource label
+	require.Contains(t, names, "job")          // clean record-attribute key
+	require.Contains(t, names, "http_method")  // dotted record-attribute key, normalized
+	require.True(t, sort.StringsAreSorted(names), "label names must be sorted")
 }


### PR DESCRIPTION
## Summary

Adopts `github.com/oteldb/storage` **v0.5.0** in the embedded storage backend and takes advantage of the two new capabilities it ships.

### Observability wiring
`setupStorageBackend` now threads oteldb's telemetry into the engine via the new options, so embedded-storage logs/traces/metrics flow into oteldb's own providers:

```go
storage.WithLogger(lg)
storage.WithTracerProvider(m.TracerProvider())
storage.WithMeterProvider(m.MeterProvider())
```

### LogKeys-based filter resolution
v0.5.0 exposes `LogKeys(ctx, tenant, start, end) []KeyInfo`, a window-scoped key index reporting every attribute key with the scope(s) it was observed in (`KeyScopeResource`/`KeyScopeScope` = stream identity, `KeyScopeRecord` = per-record attrs column). Stream/record filter resolution is rewired onto it:

- A label resolving to a single **stream-scope** raw key → postings `Matcher` (prunes whole streams).
- A label resolving to a single **record-scope** raw key → per-record `Condition` (drops non-matching records). **This now includes dotted labels** — `http_method` resolves to its raw key `http.method` and is offloaded, where before it fell back to in-memory filtering.
- **Collisions** (a label mapping to multiple raw keys), **mixed-scope** keys (resource on some streams, record on others — soundly pushable as neither), and **absent** labels fall back to `matchSelector`.

This replaces the previous `LogSeries` + `isCleanLabel` heuristic with a sound, index-backed resolution.

### LabelNames record-attribute keys
`LabelNames` now lists per-record attribute keys (sourced from `LogKeys`), normalized to LogQL labels, for unfiltered listings — closing a gap where record-only attributes (e.g. Loki-style streams) never appeared in label discovery.

## Tests
- Updated the optimizer-equivalence and record-filter tests to reflect dotted-label offloading (results unchanged; equivalence still holds).
- Added `TestLogRecordAttrLabelNames` covering record-key label listing (clean + dotted, normalized, sorted).
- `go test -race ./internal/storagebackend/... ./internal/logql/... ./cmd/oteldb/...` — green.
- `golangci-lint run` — clean.

The bump is otherwise non-breaking (full build + tests pass).
