### PR TITLE
feat(oteldb): clustered embedded storage engine + local-disk cluster demo

### DIFF
--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -1,0 +1,75 @@
+name: "Cluster E2E"
+
+# End-to-end test for the storage-engine cluster (dev/local/storage-cluster): three oteldb nodes on
+# local file backends, replicating over an etcd ring. A metric, a log, and a trace are ingested at
+# one node via OTLP and queried back through the PromQL / LogQL / TraceQL APIs of *other* nodes, so a
+# pass proves cross-node routing + replication across all three signals.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: false
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: actions/checkout@v7
+
+      - name: Get Go environment
+        run: |
+          echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+          echo "goversion=$(go env GOVERSION)" >> $GITHUB_ENV
+
+      # Shared with the compliance jobs: same `task build-deploy`, so reuse one Go build/module cache.
+      - name: Set up cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.cache }}
+            ${{ env.modcache }}
+          key: compliance-${{ runner.os }}-go-${{ env.goversion }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            compliance-${{ runner.os }}-go-${{ env.goversion }}-
+
+      - name: Install Task
+        uses: go-task/setup-task@v2
+
+      - name: Build binaries
+        run: task build-deploy
+
+      - name: Start cluster
+        working-directory: dev/local/storage-cluster
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build oteldb-1 oteldb-2 oteldb-3
+
+      - name: Verify ingest + cross-node queries
+        run: |
+          go run ./dev/local/storage-cluster/cmd/cluster-verify \
+            -otlp localhost:14317 \
+            -prometheus http://localhost:9092 \
+            -loki http://localhost:3100 \
+            -tempo http://localhost:3200 \
+            -timeout 120s
+
+      - name: Dump cluster logs
+        if: failure()
+        working-directory: dev/local/storage-cluster
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color
+
+      - name: Cleanup
+        if: always()
+        working-directory: dev/local/storage-cluster
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down --remove-orphans --volumes --timeout 10

--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -107,6 +107,34 @@ type StorageConfig struct {
 	// LogQueryParallelism enables concurrent materialization of LogQL query results across up to
 	// this many workers. Zero or one (default) keeps the sequential path. Opt-in.
 	LogQueryParallelism int `json:"log_query_parallelism" yaml:"log_query_parallelism"`
+	// Cluster, when set with a non-empty Etcd endpoint list, joins this node to a storage cluster:
+	// nodes coordinate through etcd, form a rendezvous-hash ring, and replicate writes across each
+	// other's local backends. Unset (or empty Etcd) ⇒ a single-node engine.
+	Cluster *StorageClusterConfig `json:"cluster" yaml:"cluster"`
+}
+
+// StorageClusterConfig configures the embedded storage engine's distribution layer (the shared-
+// nothing cluster: each node keeps its shards on its own local backend and replicates them to RF
+// peers). It maps onto storage's cluster.Config.
+type StorageClusterConfig struct {
+	// Etcd is the etcd endpoint list used for membership coordination. Enables cluster mode.
+	Etcd []string `json:"etcd" yaml:"etcd"`
+	// ID is this node's stable ring identity. Empty ⇒ the OS hostname.
+	ID string `json:"id" yaml:"id"`
+	// Zone is this node's failure domain (replicas are spread across zones). Optional.
+	Zone string `json:"zone" yaml:"zone"`
+	// Addr is the host:port peers use to reach this node's replication server. Empty ⇒
+	// "<ID or hostname>:<Port>".
+	Addr string `json:"addr" yaml:"addr"`
+	// Port is the replication-server port used when Addr is derived from the hostname. Zero ⇒ 7946.
+	Port int `json:"port" yaml:"port"`
+	// RF is the replication factor (replicas per write). Zero ⇒ the storage default (3).
+	RF int `json:"rf" yaml:"rf"`
+	// ShardsPerTenant splits each tenant's metric series across this many independently-placed
+	// shards. Zero or one ⇒ a single shard per tenant.
+	ShardsPerTenant int `json:"shards_per_tenant" yaml:"shards_per_tenant"`
+	// Root is the etcd key prefix for this cluster's state. Empty ⇒ "/oteldb".
+	Root string `json:"root" yaml:"root"`
 }
 
 func (cfg *StorageConfig) setDefaults() {

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -3,6 +3,10 @@ package main
 import (
 	"cmp"
 	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/app"
@@ -11,6 +15,8 @@ import (
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/backend"
 	backendfile "github.com/oteldb/storage/backend/file"
+	"github.com/oteldb/storage/cluster"
+	"github.com/oteldb/storage/cluster/etcd"
 
 	"github.com/oteldb/oteldb/internal/storagebackend"
 )
@@ -39,12 +45,23 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "open file backend")
 		}
-		opts = append(opts, storage.WithBackend(fb))
+		// Keep the WAL alongside the parts so the unflushed head survives a restart, not just the
+		// flushed parts.
+		opts = append(opts,
+			storage.WithBackend(fb),
+			storage.WithWALDir(filepath.Join(cfg.Dir, "wal")),
+		)
 		if cfg.FlushInterval > 0 {
 			opts = append(opts, storage.WithFlushInterval(int64(cfg.FlushInterval)))
 		}
 	default:
 		return nil, nil, errors.Errorf("unknown storage backend %q", cfg.Backend)
+	}
+
+	if clusterOpt, err := clusterOption(cfg.Cluster, lg); err != nil {
+		return nil, nil, err
+	} else if clusterOpt != nil {
+		opts = append(opts, clusterOpt)
 	}
 
 	store, err := storage.Open(ctx, storage.Options{}, opts...)
@@ -60,4 +77,47 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 		storagebackend.WithLogParallelism(cfg.LogQueryParallelism),
 	)
 	return b, store.Close, nil
+}
+
+// clusterOption builds the storage cluster option from the config, or returns (nil, nil) when
+// clustering is not configured (no etcd endpoints). The node identity and replication address
+// default to the OS hostname, so every node in a deployment can share one config file.
+func clusterOption(cfg *StorageClusterConfig, lg *zap.Logger) (storage.Option, error) {
+	if cfg == nil || len(cfg.Etcd) == 0 {
+		return nil, nil
+	}
+
+	id := cfg.ID
+	if id == "" {
+		host, err := os.Hostname()
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve hostname for cluster id")
+		}
+		id = host
+	}
+
+	addr := cfg.Addr
+	if addr == "" {
+		port := cfg.Port
+		if port == 0 {
+			port = 7946
+		}
+		addr = net.JoinHostPort(id, strconv.Itoa(port))
+	}
+
+	lg.Info("Joining storage cluster",
+		zap.Strings("etcd", cfg.Etcd),
+		zap.String("id", id),
+		zap.String("zone", cfg.Zone),
+		zap.String("addr", addr),
+		zap.Int("rf", cfg.RF),
+		zap.Int("shards_per_tenant", cfg.ShardsPerTenant),
+	)
+	return storage.WithCluster(&cluster.Config{
+		Etcd:            cfg.Etcd,
+		Self:            etcd.Member{ID: id, Zone: cfg.Zone, Addr: addr},
+		RF:              cfg.RF,
+		ShardsPerTenant: cfg.ShardsPerTenant,
+		Root:            cfg.Root,
+	}), nil
 }

--- a/cmd/oteldb/storage_backend_test.go
+++ b/cmd/oteldb/storage_backend_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/storage"
+)
+
+// applyOption applies a storage.Option to a fresh Options and returns it, so tests can inspect what
+// clusterOption configured.
+func applyOption(t *testing.T, opt storage.Option) storage.Options {
+	t.Helper()
+	var o storage.Options
+	require.NotNil(t, opt)
+	opt(&o)
+	return o
+}
+
+func TestClusterOption(t *testing.T) {
+	lg := zap.NewNop()
+
+	t.Run("DisabledWhenNoEtcd", func(t *testing.T) {
+		opt, err := clusterOption(nil, lg)
+		require.NoError(t, err)
+		require.Nil(t, opt)
+
+		opt, err = clusterOption(&StorageClusterConfig{ID: "n1"}, lg) // no etcd endpoints
+		require.NoError(t, err)
+		require.Nil(t, opt)
+	})
+
+	t.Run("Explicit", func(t *testing.T) {
+		opt, err := clusterOption(&StorageClusterConfig{
+			Etcd: []string{"http://etcd:2379"}, ID: "node-1", Zone: "z1",
+			Addr: "node-1:9000", RF: 2, ShardsPerTenant: 4, Root: "/x",
+		}, lg)
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.NotNil(t, o.Cluster)
+		require.Equal(t, []string{"http://etcd:2379"}, o.Cluster.Etcd)
+		require.Equal(t, "node-1", o.Cluster.Self.ID)
+		require.Equal(t, "z1", o.Cluster.Self.Zone)
+		require.Equal(t, "node-1:9000", o.Cluster.Self.Addr)
+		require.Equal(t, 2, o.Cluster.RF)
+		require.Equal(t, 4, o.Cluster.ShardsPerTenant)
+		require.Equal(t, "/x", o.Cluster.Root)
+	})
+
+	t.Run("AddrDerivedFromID", func(t *testing.T) {
+		opt, err := clusterOption(&StorageClusterConfig{Etcd: []string{"e"}, ID: "node-7"}, lg)
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.Equal(t, "node-7:7946", o.Cluster.Self.Addr, "default replication port")
+
+		opt, err = clusterOption(&StorageClusterConfig{Etcd: []string{"e"}, ID: "node-7", Port: 1234}, lg)
+		require.NoError(t, err)
+		o = applyOption(t, opt)
+		require.Equal(t, "node-7:1234", o.Cluster.Self.Addr)
+	})
+
+	t.Run("IDAndAddrDefaultToHostname", func(t *testing.T) {
+		host, err := os.Hostname()
+		require.NoError(t, err)
+		opt, err := clusterOption(&StorageClusterConfig{Etcd: []string{"e"}}, lg)
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.Equal(t, host, o.Cluster.Self.ID)
+		require.Equal(t, host+":7946", o.Cluster.Self.Addr)
+	})
+}
+
+// TestStorageClusterConfigYAML checks the cluster block parses from the documented YAML shape via
+// the real config loader.
+func TestStorageClusterConfigYAML(t *testing.T) {
+	const data = `
+storage:
+  backend: file
+  dir: /data
+  cluster:
+    etcd: ["http://etcd-1:2379", "http://etcd-2:2379"]
+    id: oteldb-1
+    zone: a
+    addr: oteldb-1:7946
+    rf: 3
+    shards_per_tenant: 8
+    root: /oteldb
+`
+	f, err := os.CreateTemp("", "oteldb.yml")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(f.Name()) }()
+	_, err = f.WriteString(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cfg, err := loadConfig(f.Name())
+	require.NoError(t, err)
+
+	require.Equal(t, "file", cfg.Storage.Backend)
+	require.NotNil(t, cfg.Storage.Cluster)
+	require.Equal(t, []string{"http://etcd-1:2379", "http://etcd-2:2379"}, cfg.Storage.Cluster.Etcd)
+	require.Equal(t, "oteldb-1", cfg.Storage.Cluster.ID)
+	require.Equal(t, "a", cfg.Storage.Cluster.Zone)
+	require.Equal(t, "oteldb-1:7946", cfg.Storage.Cluster.Addr)
+	require.Equal(t, 3, cfg.Storage.Cluster.RF)
+	require.Equal(t, 8, cfg.Storage.Cluster.ShardsPerTenant)
+	require.Equal(t, "/oteldb", cfg.Storage.Cluster.Root)
+}

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -68,3 +68,18 @@ storage:
 
 To scale out, add another `oteldb-N` service (with its own `hostname` and data volume) pointing at
 the same etcd — it joins the ring and takes ownership of a share of the data automatically.
+
+## Automated test
+
+The **Cluster E2E** CI job (`.github/workflows/cluster-e2e.yml`) starts this stack with the
+[`docker-compose.ci.yml`](./docker-compose.ci.yml) overlay and runs
+[`cmd/cluster-verify`](./cmd/cluster-verify), which pushes one metric, log, and trace via OTLP to one
+node and asserts they are served by the PromQL/LogQL/TraceQL APIs of other nodes — exercising
+cross-node routing and replication for every signal. Run it locally with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build oteldb-1 oteldb-2 oteldb-3
+go run ./cmd/cluster-verify -otlp localhost:14317 -prometheus http://localhost:9092 \
+  -loki http://localhost:3100 -tempo http://localhost:3200
+```
+

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -1,0 +1,70 @@
+# Clustered storage-engine demo
+
+A three-node **oteldb cluster on the embedded storage engine** — no ClickHouse and **no shared
+object store**. Each node keeps its data on a **local file backend** and replicates writes to its
+peers (RF=2) over an etcd-coordinated [rendezvous-hash](https://en.wikipedia.org/wiki/Rendezvous_hashing)
+ring. This is the shared-nothing model: data is sharded and replicated across the nodes' own disks.
+
+## Run
+
+```bash
+docker compose -f dev/local/storage-cluster/docker-compose.yml up --build
+```
+
+Open Grafana at <http://localhost:3000> (anonymous admin) — PromQL, LogQL, and TraceQL datasources
+are pre-provisioned against `oteldb-1`.
+
+## Topology
+
+```
+                 ┌──────── etcd ────────┐   (membership + ring state)
+                 │          │           │
+            ┌─ oteldb-1 ─ oteldb-2 ─ oteldb-3 ─┐   each: local file backend, RF=2 replication
+            │     ▲           ▲                │
+   client ──┘  OTLP        OTLP └── server     │
+   (ingest @ oteldb-1)   (ingest @ oteldb-2)   │
+                 │                             │
+              Grafana ── queries oteldb-1 ─────┘  (fans out across the ring, merges replicas)
+```
+
+| Service    | Role | Host ports |
+|------------|------|------------|
+| `etcd`     | membership + ring coordination | — |
+| `oteldb-1` | cluster node (file backend) | 9090, 3100, 3200, 4040, 4317 |
+| `oteldb-2` | cluster node (file backend) | 9091 → its PromQL |
+| `oteldb-3` | cluster node (file backend) | 9092 → its PromQL |
+| `client`/`server` | OTLP generators (logs/metrics/traces) | — |
+| `grafana`  | dashboards | 3000 |
+
+## What it demonstrates
+
+- **Ingest anywhere.** `client` pushes OTLP to `oteldb-1` and `server` pushes to `oteldb-2`; each
+  node routes every write to the ring's owning replicas. Nothing is pinned to the node that received
+  it.
+- **Query anywhere.** Grafana queries only `oteldb-1`, yet sees data ingested at `oteldb-2` too,
+  because a query fans out across the ring and merges replicas. Compare `oteldb-1` (host `:9090`),
+  `oteldb-2` (`:9091`), and `oteldb-3` (`:9092`) — `up`-style queries return the same series.
+- **Replication / failure tolerance.** With RF=2 every series lives on two of the three nodes. Stop
+  one (`docker compose -f dev/local/storage-cluster/docker-compose.yml stop oteldb-2`) and queries
+  still return its data from the replica; restart it and it rejoins the ring.
+
+## Configuration
+
+Every node runs `oteldb --embedded` with the shared [`oteldb.yml`](./oteldb.yml). The only thing that
+differs between nodes is the container `hostname`: the cluster id and replication address default to
+it, so `oteldb-1` advertises `oteldb-1:7946`, `oteldb-2` advertises `oteldb-2:7946`, and so on. The
+cluster block:
+
+```yaml
+storage:
+  backend: file
+  dir: /data
+  cluster:
+    etcd: ["http://etcd:2379"]
+    port: 7946   # replication server port; address is <hostname>:<port>
+    rf: 2        # replicas per write
+    root: /oteldb
+```
+
+To scale out, add another `oteldb-N` service (with its own `hostname` and data volume) pointing at
+the same etcd — it joins the ring and takes ownership of a share of the data automatically.

--- a/dev/local/storage-cluster/cmd/cluster-verify/main.go
+++ b/dev/local/storage-cluster/cmd/cluster-verify/main.go
@@ -1,0 +1,250 @@
+// Command cluster-verify is an end-to-end check for the storage cluster: it pushes one deterministic
+// metric, log, and trace via OTLP to one node, then queries them back through the PromQL, LogQL, and
+// TraceQL APIs of *other* nodes. Success proves a write to one node is routed/replicated through the
+// ring and served by another — across all three signals.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// service is the resource service.name carried by every pushed signal; the queries select on it.
+const service = "cluster-e2e"
+
+// metricName is the gauge pushed and queried back via PromQL.
+const metricName = "cluster_e2e_value"
+
+func main() {
+	var (
+		otlp    = flag.String("otlp", "localhost:4317", "OTLP gRPC endpoint to push signals to (the ingest node)")
+		prom    = flag.String("prometheus", "http://localhost:9090", "PromQL base URL to query (a different node)")
+		loki    = flag.String("loki", "http://localhost:3100", "LogQL base URL to query (a different node)")
+		tempo   = flag.String("tempo", "http://localhost:3200", "TraceQL base URL to query (a different node)")
+		timeout = flag.Duration("timeout", 90*time.Second, "max time to wait for each query to return the data")
+	)
+	flag.Parse()
+
+	if err := run(*otlp, *prom, *loki, *tempo, *timeout); err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL:", err)
+		os.Exit(1)
+	}
+	fmt.Println("OK: metric, log, and trace ingested on one node and served by another")
+}
+
+func run(otlp, prom, loki, tempo string, timeout time.Duration) error {
+	ctx := context.Background()
+
+	// Wait until every query node is serving before writing, so the ring is fully formed and the
+	// write replicates to the right owners (otherwise it could land before a node has joined).
+	ready := map[string]string{
+		"PromQL " + prom:   prom + "/api/v1/query?query=" + url.QueryEscape("vector(1)"),
+		"LogQL " + loki:    loki + "/loki/api/v1/labels",
+		"TraceQL " + tempo: tempo + "/api/echo",
+	}
+	for name, u := range ready {
+		if err := retry(func() error { return get2xx(ctx, u) }, timeout); err != nil {
+			return fmt.Errorf("%s not ready: %w", name, err)
+		}
+	}
+	fmt.Println(">> all query nodes ready")
+
+	now := time.Now()
+	if err := retry(func() error { return push(ctx, otlp, now) }, timeout); err != nil {
+		return fmt.Errorf("push signals to %s: %w", otlp, err)
+	}
+	fmt.Printf(">> pushed metric/log/trace to %s (service.name=%s)\n", otlp, service)
+
+	start, end := now.Add(-time.Hour), now.Add(time.Hour)
+	checks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"PromQL " + prom, func() error { return checkProm(ctx, prom) }},
+		{"LogQL " + loki, func() error { return checkLoki(ctx, loki, start, end) }},
+		{"TraceQL " + tempo, func() error { return checkTempo(ctx, tempo, start, end) }},
+	}
+	for _, c := range checks {
+		if err := retry(c.fn, timeout); err != nil {
+			return fmt.Errorf("%s: %w", c.name, err)
+		}
+		fmt.Printf(">> %s served the data\n", c.name)
+	}
+	return nil
+}
+
+// get2xx GETs a URL and returns an error unless the response is 2xx (readiness probe).
+func get2xx(ctx context.Context, rawURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = res.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, 1<<16))
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("status %d", res.StatusCode)
+	}
+	return nil
+}
+
+// retry runs fn until it succeeds or the timeout elapses (signals need a moment to be queryable).
+func retry(fn func() error, timeout time.Duration) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxInterval = 3 * time.Second
+	bo.MaxElapsedTime = timeout
+	return backoff.Retry(fn, bo)
+}
+
+func push(ctx context.Context, target string, ts time.Time) error {
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := pmetricotlp.NewGRPCClient(conn).Export(ctx, pmetricotlp.NewExportRequestFromMetrics(buildMetric(ts))); err != nil {
+		return fmt.Errorf("export metrics: %w", err)
+	}
+	if _, err := plogotlp.NewGRPCClient(conn).Export(ctx, plogotlp.NewExportRequestFromLogs(buildLog(ts))); err != nil {
+		return fmt.Errorf("export logs: %w", err)
+	}
+	if _, err := ptraceotlp.NewGRPCClient(conn).Export(ctx, ptraceotlp.NewExportRequestFromTraces(buildTrace(ts))); err != nil {
+		return fmt.Errorf("export traces: %w", err)
+	}
+	return nil
+}
+
+func buildMetric(ts time.Time) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", service)
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(metricName)
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	dp.SetDoubleValue(42)
+	return md
+}
+
+func buildLog(ts time.Time) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", service)
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(ts))
+	lr.Body().SetStr("cluster-e2e log line")
+	return ld
+}
+
+func buildTrace(ts time.Time) ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", service)
+	s := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	s.SetTraceID(pcommon.TraceID{0x0c, 0x1e, 0x57, 0x2e, 0xe2, 0xe0, 0x0c, 0x1e, 0x57, 0x2e, 0xe2, 0xe0, 0x0c, 0x1e, 0x57, 0x2e})
+	s.SetSpanID(pcommon.SpanID{0x0c, 0x1e, 0x57, 0x2e, 0xe2, 0xe0, 0x0c, 0x1e})
+	s.SetName("cluster-e2e-span")
+	s.SetKind(ptrace.SpanKindServer)
+	s.SetStartTimestamp(pcommon.NewTimestampFromTime(ts))
+	s.SetEndTimestamp(pcommon.NewTimestampFromTime(ts.Add(time.Millisecond)))
+	return td
+}
+
+func checkProm(ctx context.Context, base string) error {
+	// No explicit time: evaluate at the server's "now", which is always at or after the just-pushed
+	// sample (and within the lookback window), so the gauge resolves.
+	q := base + "/api/v1/query?query=" + url.QueryEscape(metricName)
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := getJSON(ctx, q, &resp); err != nil {
+		return err
+	}
+	if resp.Status != "success" || len(resp.Data.Result) == 0 {
+		return fmt.Errorf("no samples for %q (status %q)", metricName, resp.Status)
+	}
+	return nil
+}
+
+func checkLoki(ctx context.Context, base string, start, end time.Time) error {
+	q := base + "/loki/api/v1/query_range?query=" + url.QueryEscape(`{service_name="`+service+`"}`) +
+		"&start=" + strconv.FormatInt(start.UnixNano(), 10) +
+		"&end=" + strconv.FormatInt(end.UnixNano(), 10) + "&limit=5"
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := getJSON(ctx, q, &resp); err != nil {
+		return err
+	}
+	if len(resp.Data.Result) == 0 {
+		return fmt.Errorf("no log streams for service %q", service)
+	}
+	return nil
+}
+
+func checkTempo(ctx context.Context, base string, start, end time.Time) error {
+	q := base + "/api/search?q=" + url.QueryEscape(`{ resource.service.name = "`+service+`" }`) +
+		"&start=" + strconv.FormatInt(start.Unix(), 10) +
+		"&end=" + strconv.FormatInt(end.Unix(), 10) + "&limit=5"
+	var resp struct {
+		Traces []json.RawMessage `json:"traces"`
+	}
+	if err := getJSON(ctx, q, &resp); err != nil {
+		return err
+	}
+	if len(resp.Traces) == 0 {
+		return fmt.Errorf("no traces for service %q", service)
+	}
+	return nil
+}
+
+func getJSON(ctx context.Context, rawURL string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = res.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return json.Unmarshal(body, dst)
+}

--- a/dev/local/storage-cluster/docker-compose.ci.yml
+++ b/dev/local/storage-cluster/docker-compose.ci.yml
@@ -1,0 +1,19 @@
+# CI override for the cluster E2E job (used with docker-compose.yml).
+#
+# The base demo compiles oteldb inside Docker (dev/Dockerfile). In CI we instead build the binaries
+# on the host with the shared Go cache (`task build-deploy`) and bake them into the image via
+# deploy.Dockerfile — an ADD of prebuilt binaries, which is far faster than a cold in-container
+# compile. We also publish a second node's OTLP port so the host verifier can ingest at oteldb-2 and
+# query oteldb-1 / oteldb-3, proving cross-node serving.
+services:
+  oteldb-1:
+    build:
+      dockerfile: ./dev/deploy/deploy.Dockerfile
+  oteldb-2:
+    build:
+      dockerfile: ./dev/deploy/deploy.Dockerfile
+    ports:
+      - "14317:4317" # OTLP gRPC on node-2 (host-side ingest target for the verifier)
+  oteldb-3:
+    build:
+      dockerfile: ./dev/deploy/deploy.Dockerfile

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -1,0 +1,151 @@
+# Clustered oteldb on the embedded storage engine — no ClickHouse, no shared object store.
+#
+# Three oteldb nodes each keep their shards on a LOCAL file backend and replicate writes to each
+# other (RF=2) over an etcd-coordinated rendezvous-hash ring. Ingest into any node and it routes the
+# write to the owning replicas; query any node and it fans out across the ring and merges. The demo
+# ingests at two different nodes to show ingest-anywhere, and Grafana queries a third.
+#
+#   docker compose -f dev/local/storage-cluster/docker-compose.yml up --build
+#
+# Open Grafana at http://localhost:3000. Stop a node (docker compose stop oteldb-2) and data is still
+# served by its replicas.
+version: "3"
+
+volumes:
+  oteldb-1-data:
+  oteldb-2-data:
+  oteldb-3-data:
+  etcd-data:
+
+# Common definition for an oteldb cluster node. Each node runs --embedded (all signals on the
+# storage engine) and joins the cluster via the shared oteldb.yml; its ring id/address come from
+# its hostname, so the three nodes differ only by hostname and data volume.
+x-oteldb-node: &oteldb-node
+  image: ghcr.io/oteldb/oteldb
+  # Always build from local source so the cluster wiring is present (not a stale published image).
+  pull_policy: build
+  build:
+    context: ../../../
+    dockerfile: dev/Dockerfile
+  command:
+    - --embedded
+    - --config=/etc/oteldb/oteldb.yml
+  environment:
+    - OTEL_LOG_LEVEL=info
+    - OTEL_TRACES_EXPORTER=none
+    - OTEL_METRICS_EXPORTER=none
+    - OTEL_LOGS_EXPORTER=stdout
+  restart: unless-stopped
+  depends_on:
+    etcd:
+      condition: service_healthy
+
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.5.17
+    command:
+      - etcd
+      - --name=etcd0
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd:2380
+      - --initial-cluster=etcd0=http://etcd:2380
+    volumes:
+      - etcd-data:/etcd-data
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  oteldb-1:
+    <<: *oteldb-node
+    hostname: oteldb-1
+    volumes:
+      - ./oteldb.yml:/etc/oteldb/oteldb.yml:ro
+      - oteldb-1-data:/data
+    ports:
+      - "9090:9090" # Prometheus / PromQL
+      - "3100:3100" # Loki / LogQL
+      - "3200:3200" # Tempo / TraceQL
+      - "4040:4040" # Pyroscope / ProfileQL
+      - "4317:4317" # OTLP gRPC ingestion
+
+  oteldb-2:
+    <<: *oteldb-node
+    hostname: oteldb-2
+    volumes:
+      - ./oteldb.yml:/etc/oteldb/oteldb.yml:ro
+      - oteldb-2-data:/data
+    ports:
+      - "9091:9090" # this node's PromQL (to show any node answers the full query)
+
+  oteldb-3:
+    <<: *oteldb-node
+    hostname: oteldb-3
+    volumes:
+      - ./oteldb.yml:/etc/oteldb/oteldb.yml:ro
+      - oteldb-3-data:/data
+    ports:
+      - "9092:9090"
+
+  # Handles requests from the client; ingests its telemetry at oteldb-2.
+  server:
+    image: ghcr.io/oteldb/oteldb/oteldemo
+    pull_policy: build
+    build:
+      context: ../../../
+      dockerfile: dev/Dockerfile
+      args:
+        TARGETS: oteldemo
+        ENTRYPOINT_BIN: oteldemo
+    command: ["server"]
+    restart: always
+    environment:
+      - OTEL_LOG_LEVEL=info
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_EXPORTER_OTLP_INSECURE=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://oteldb-2:4317
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=server
+      - OTEL_METRIC_EXPORT_INTERVAL=5000
+    depends_on:
+      - oteldb-2
+
+  # Calls the server once per second; ingests its telemetry at oteldb-1.
+  client:
+    image: ghcr.io/oteldb/oteldb/oteldemo
+    command: ["client"]
+    restart: always
+    environment:
+      - OTEL_LOG_LEVEL=info
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_EXPORTER_OTLP_INSECURE=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://oteldb-1:4317
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=client
+      - OTEL_METRIC_EXPORT_INTERVAL=5000
+    depends_on:
+      - oteldb-1
+      - server
+
+  grafana:
+    image: "grafana/grafana-oss:12.3.1"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor,traceToMetrics
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+    depends_on:
+      - oteldb-1

--- a/dev/local/storage-cluster/grafana/datasources.yml
+++ b/dev/local/storage-cluster/grafana/datasources.yml
@@ -1,0 +1,56 @@
+apiVersion: 1
+
+# All datasources point at a single node (oteldb-1). In cluster mode any node answers the full
+# query by fanning out across the ring and merging replicas, so this one node serves data that was
+# ingested at oteldb-1 and oteldb-2 alike.
+datasources:
+  - name: PromQL
+    type: prometheus
+    access: proxy
+    orgId: 1
+    isDefault: true
+    url: http://oteldb-1:9090
+    uid: prom-oteldb
+    jsonData:
+      prometheusType: Prometheus
+      exemplarTraceIdDestinations:
+        - datasourceUid: tempo-oteldb
+          name: trace_id
+
+  - name: LogQL
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://oteldb-1:3100
+    uid: loki-oteldb
+    jsonData:
+      maxLines: 500
+      derivedFields:
+        - datasourceUid: tempo-oteldb
+          matcherType: label
+          matcherRegex: trace_id
+          name: trace
+          url: "$${__value.raw}"
+          urlDisplayLabel: "View Trace"
+
+  - name: TraceQL
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://oteldb-1:3200
+    uid: tempo-oteldb
+    jsonData:
+      httpMethod: GET
+      tracesToLogsV2:
+        datasourceUid: loki-oteldb
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+        customQuery: true
+        query: '{$${__tags}} |= "$${__span.traceId}"'
+        tags:
+          - key: service.name
+            value: service_name
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prom-oteldb

--- a/dev/local/storage-cluster/oteldb.yml
+++ b/dev/local/storage-cluster/oteldb.yml
@@ -1,0 +1,14 @@
+# Shared config for every node in the storage cluster. Each node serves all signals from its own
+# local file backend (--embedded is passed on the command line) and joins the cluster via etcd. The
+# node's ring identity and replication address default to its hostname, so all three services use
+# this one file unchanged — only their `hostname:` differs in docker-compose.yml.
+storage:
+  backend: file
+  dir: /data
+  cluster:
+    etcd: ["http://etcd:2379"]
+    # id and addr are derived from the container hostname (e.g. oteldb-1 -> addr oteldb-1:7946).
+    port: 7946
+    # Replication factor: each write is stored on 2 of the 3 nodes (tolerates one node down).
+    rf: 2
+    root: /oteldb

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -56,9 +56,9 @@ func WithLogParallelism(n int) Option {
 	return func(b *Backend) { b.logParallelism = n }
 }
 
-// New returns a Backend over store. The query side reads across all tenants and the ingest
-// side derives tenants from each batch's Resource/Scope (via the engine's tenant callback),
-// so the empty tenant id here scopes reads to the federated cross-tenant view.
+// New returns a Backend over store. The ingest side has no tenant callback, so every batch routes
+// to the "default" tenant; the empty tenant id here normalizes to "default" on the read side,
+// keeping reads and writes on the same tenant (which also makes cluster reads owner-aware).
 func New(store *storage.Storage, opts ...Option) *Backend {
 	b := &Backend{store: store}
 	for _, opt := range opts {
@@ -69,8 +69,13 @@ func New(store *storage.Storage, opts ...Option) *Backend {
 
 // queryable builds a fresh Prometheus queryable over the engine's current data. A new
 // fetcher is taken per query so reads observe the latest head and flushed parts.
+//
+// The fetcher is scoped to b.tenant (a named tenant, "" ⇒ "default") rather than the no-arg
+// cross-tenant form: in cluster mode a named tenant is served owner-aware (fanned out to the ring
+// owners), whereas the no-arg form reads only tenants local to this node — so a query node that does
+// not own the tenant would see nothing. The record signals already scope by b.tenant the same way.
 func (b *Backend) queryable() *storagepromql.Queryable {
-	return storagepromql.NewQueryable(b.store.Fetcher(), b.tenant)
+	return storagepromql.NewQueryable(b.store.Fetcher(b.tenant), b.tenant)
 }
 
 // Querier implements storage.Queryable.


### PR DESCRIPTION
## Summary

Wires the embedded storage engine's **distribution layer** into oteldb and ships a runnable **clustered example** that uses **local disk only — no ClickHouse, no shared object store**.

This is the shared-nothing model: each node keeps its shards on its own local file backend and replicates writes to RF peers over an etcd-coordinated rendezvous-hash ring (`github.com/oteldb/storage`'s `cluster` package).

## oteldb wiring

- `StorageConfig` gains a `cluster` block:
  ```yaml
  storage:
    backend: file
    dir: /data
    cluster:
      etcd: ["http://etcd:2379"]
      port: 7946   # replication address is <hostname>:<port>
      rf: 2
      root: /oteldb
  ```
- `setupStorageBackend` maps it to `storage.WithCluster(...)`. The node's ring **id and replication address default to the OS hostname**, so every node in a deployment shares one config file — only the container `hostname` differs.
- The file backend now also sets a WAL directory (`<dir>/wal`), so the unflushed head survives a restart, not just the flushed parts.

## Example: `dev/local/storage-cluster`

A three-node `docker compose` (etcd + 3 oteldb file-backend nodes + OTLP generators + Grafana):

- **Ingest anywhere** — `client` pushes OTLP to `oteldb-1`, `server` to `oteldb-2`; each node routes writes to the ring's owners.
- **Query anywhere** — Grafana queries only `oteldb-1` yet sees data ingested at `oteldb-2`, because a query fans out across the ring and merges replicas.
- **Failure tolerance** — RF=2 keeps every series on two of three nodes; stop one and its data is still served from the replica.

## Testing

- Unit: `clusterOption` mapping (explicit fields, hostname/address defaulting, disabled when no etcd) and cluster-block YAML parsing via the real config loader.
- Manual: ran an embedded etcd plus **two file-backed nodes** through the storage cluster API and confirmed a write to node-1 is replicated and readable from node-2 (RF=2). The storage repo's own multi-node tests cover sharded 3-node routing/replication.
- `go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test -race ./cmd/oteldb/`, `go mod tidy` all clean/stable.

## Notes

- Adds the etcd client (`go.etcd.io/etcd/client/v3`) to oteldb's dependency graph (already transitively present via storage).
- `docker compose ... up --build` needs Docker Hub / quay.io access for the `etcd`, `grafana`, and base images. The oteldb/oteldemo services use `pull_policy: build` so they always build from local source.
