### PR TITLE
feat(storagebackend): bump storage to v0.7.0 + fix unbounded label/metadata queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -454,7 +454,7 @@ require (
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
-	github.com/oteldb/storage v0.5.0
+	github.com/oteldb/storage v0.7.0
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.7.0-alpha.0 h1:od3skf7eTPMv+3zR6G3WZl7YVzWJUa8b8yP3XpfIgI4=
 github.com/oteldb/promql-engine v0.7.0-alpha.0/go.mod h1:j3kBzxEWSsdIinLTl7ogVolJbI2GC/fa1GU4/NpOr0k=
-github.com/oteldb/storage v0.5.0 h1:Txdm78ZTR2Ib0Nk6zksPlaWWmGvgQxH/ac5jwyzrVVw=
-github.com/oteldb/storage v0.5.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
+github.com/oteldb/storage v0.7.0 h1:Q1PO05oZjYKW+dW+IbZzK12D2X3NG+v6986TZ16P/p0=
+github.com/oteldb/storage v0.7.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -13,6 +13,7 @@ package storagebackend
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/go-faster/errors"
@@ -80,7 +81,24 @@ func (b *Backend) queryable() *storagepromql.Queryable {
 
 // Querier implements storage.Queryable.
 func (b *Backend) Querier(mint, maxt int64) (promstorage.Querier, error) {
-	return b.queryable().Querier(mint, maxt)
+	return b.queryable().Querier(clampQueryMs(mint), clampQueryMs(maxt))
+}
+
+// clampQueryMs clamps a Prometheus millisecond bound to the open-ended sentinels the storage
+// querier recognizes. Unbounded label/metadata queries arrive with Prometheus' MinTime/MaxTime,
+// whose millisecond magnitude overflows int64 when the storage querier multiplies by 1e6 to reach
+// nanoseconds; that yielded a garbage window and empty results (e.g. /api/v1/labels with no range).
+// math.MinInt64/MaxInt64 are passed through verbatim by the storage querier as "unbounded".
+func clampQueryMs(ms int64) int64 {
+	const maxMs = math.MaxInt64 / int64(time.Millisecond) // ms whose *1e6 still fits in int64.
+	switch {
+	case ms < -maxMs:
+		return math.MinInt64
+	case ms > maxMs:
+		return math.MaxInt64
+	default:
+		return ms
+	}
 }
 
 // ExemplarQuerier implements storage.ExemplarQueryable. The storage engine does not store

--- a/internal/storagebackend/storagebackend_test.go
+++ b/internal/storagebackend/storagebackend_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oteldb/storage"
 
+	"github.com/oteldb/oteldb/internal/promapi"
 	"github.com/oteldb/oteldb/internal/promql"
 	"github.com/oteldb/oteldb/internal/storagebackend"
 )
@@ -62,6 +63,44 @@ func TestBackendMetricsRoundtrip(t *testing.T) {
 	require.Equal(t, float64(42), vec[0].F)
 	require.Equal(t, "test_metric", vec[0].Metric.Get("__name__"))
 	require.Equal(t, "bar", vec[0].Metric.Get("foo"))
+}
+
+// TestBackendLabelMetadataUnbounded ingests a metric and lists label names/values over the
+// unbounded window the label API uses when start/end are omitted (promapi.MinTime/MaxTime). Their
+// millisecond magnitude overflows the storage querier's ms→ns conversion unless clamped, which used
+// to make /api/v1/labels and the metric browser return nothing despite data being present.
+func TestBackendLabelMetadataUnbounded(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := storagebackend.New(store)
+
+	ts := time.Now().Truncate(time.Second)
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "test")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test_metric")
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	dp.SetDoubleValue(1)
+	require.NoError(t, b.ConsumeMetrics(ctx, md))
+
+	q, err := b.Querier(promapi.MinTime.UnixMilli(), promapi.MaxTime.UnixMilli())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	names, _, err := q.LabelNames(ctx, nil)
+	require.NoError(t, err)
+	require.Contains(t, names, "__name__")
+	require.Contains(t, names, "service.name")
+
+	vals, _, err := q.LabelValues(ctx, "__name__", nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"test_metric"}, vals)
 }
 
 // TestBackendEmpty verifies a query over an empty engine returns no series rather than


### PR DESCRIPTION
## Summary

Bumps `github.com/oteldb/storage` **v0.5.0 → v0.7.0** and fixes the embedded backend's "zero metrics" in Grafana.

## Why metrics looked empty

Metrics were ingested fine (a demo showed 107 series, all queryable by name). The problem was metric/label **discovery**:

1. The storage PromQL adapter **stubbed `LabelNames`/`LabelValues` to return empty**, so `/api/v1/labels`, `/api/v1/label/__name__/values`, and every `/api/v1/label/<x>/values` returned `[]` — exactly what Grafana's metric/label browser calls. v0.7.0 implements them.

2. Even with v0.7.0, **unbounded** label queries were still empty: when `start`/`end` are omitted the API uses Prometheus' `MinTime`/`MaxTime`, whose millisecond magnitude **overflows** the storage querier's `ms×1e6` ns conversion (it only special-cases the exact `math.MinInt64`/`MaxInt64` sentinels) → garbage window → no results. `Backend.Querier` now clamps out-of-range bounds to those sentinels (the storage querier's "open-ended" markers).

## Verification

On `oteldb --embedded`, after ingesting a gauge + a cumulative counter:

| Endpoint | Before | After |
|---|---|---|
| `/api/v1/labels` (no range) | `[]` | `["__name__","service.name"]` |
| `/api/v1/label/__name__/values` (no range) | `[]` | `["oteldemo.client.sent_requests","probe.gauge"]` |
| with explicit range | `[]` | populated |

Adds `TestBackendLabelMetadataUnbounded` (ingest → `Querier(MinTime, MaxTime)` → `LabelNames`/`LabelValues` non-empty). `go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test -race ./internal/storagebackend/... ./cmd/oteldb/...`, and `go mod tidy` are all clean/stable.

## Notes

- This is the canonical bump on `main`. The open demo branches (#1092 embedded-demo, #1093 cluster) still pin v0.5.0; once this merges they can be rebased to pick up v0.7.0 + this fix, which is what makes the embedded-demo's Grafana metric browser populate.
- `go.mod` change is just the storage version (no other dep churn on this branch).
