### PR TITLE
feat(storage): exploit embedded storage perf features (caches, *_over_time pushdown, tenancy)

### DIFF
--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -107,6 +107,22 @@ type StorageConfig struct {
 	// LogQueryParallelism enables concurrent materialization of LogQL query results across up to
 	// this many workers. Zero or one (default) keeps the sequential path. Opt-in.
 	LogQueryParallelism int `json:"log_query_parallelism" yaml:"log_query_parallelism"`
+	// ReadCacheBytes sizes the in-memory LRU object cache over the backend (the object-store read
+	// cache for the cold tier). The storage library keeps this opt-in; oteldb flips the polarity and
+	// enables it by default, sized from available RAM. Set to 0 to disable. No effect for the
+	// ephemeral memory backend.
+	ReadCacheBytes *xbytes.Bytes `json:"read_cache_bytes" yaml:"read_cache_bytes"`
+	// DecodeCacheBytes sizes the per-tenant LRU cache of decoded part columns (plus concurrent
+	// prefetch of a fetch's parts). Enabled by default, sized from available RAM; set to 0 to
+	// disable.
+	DecodeCacheBytes *xbytes.Bytes `json:"decode_cache_bytes" yaml:"decode_cache_bytes"`
+	// AggregateStats writes a per-series aggregate sidecar (count/sum/min/max) alongside each
+	// metric part so range-covering aggregates — and the *_over_time pushdown — can be answered
+	// without decoding. Enabled by default; set to false to disable.
+	AggregateStats *bool `json:"aggregate_stats" yaml:"aggregate_stats"`
+	// Policy configures the per-tenant merge-time storage policy: age-tiered lossy float precision,
+	// downsampling, and cold-data recompression. Empty ⇒ the library default (lossless, no rollup).
+	Policy *StoragePolicyConfig `json:"policy" yaml:"policy"`
 	// Cluster, when set with a non-empty Etcd endpoint list, joins this node to a storage cluster:
 	// nodes coordinate through etcd, form a rendezvous-hash ring, and replicate writes across each
 	// other's local backends. Unset (or empty Etcd) ⇒ a single-node engine.

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -3,9 +3,11 @@ package main
 import (
 	"cmp"
 	"context"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 
 	"github.com/go-faster/errors"
@@ -19,6 +21,7 @@ import (
 	"github.com/oteldb/storage/cluster/etcd"
 
 	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/xbytes"
 )
 
 // setupStorageBackend constructs the embedded storage engine and an adapter implementing
@@ -64,6 +67,20 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 		opts = append(opts, clusterOpt)
 	}
 
+	if tenancyOpt, err := tenancyOption(cfg.Policy); err != nil {
+		return nil, nil, errors.Wrap(err, "storage policy")
+	} else if tenancyOpt != nil {
+		opts = append(opts, tenancyOpt)
+		lg.Info("Applying embedded storage tenancy policy",
+			zap.Int("precision_tiers", len(cfg.Policy.Precision)),
+			zap.Int("downsample_tiers", len(cfg.Policy.Downsample)),
+			zap.Bool("recompress", cfg.Policy.Recompress != nil),
+		)
+	}
+
+	caches := resolveCacheSettings(cfg)
+	opts = append(opts, cacheOptions(caches)...)
+
 	store, err := storage.Open(ctx, storage.Options{}, opts...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "open storage")
@@ -72,6 +89,9 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 	lg.Info("Using embedded storage engine for metrics",
 		zap.String("backend", cmp.Or(cfg.Backend, "memory")),
 		zap.Int("log_query_parallelism", cfg.LogQueryParallelism),
+		zap.Int64("read_cache_bytes", caches.ReadCache),
+		zap.Int64("decode_cache_bytes", caches.DecodeCache),
+		zap.Bool("aggregate_stats", caches.AggregateStats),
 	)
 	b := storagebackend.New(store,
 		storagebackend.WithLogParallelism(cfg.LogQueryParallelism),
@@ -120,4 +140,66 @@ func clusterOption(cfg *StorageClusterConfig, lg *zap.Logger) (storage.Option, e
 		ShardsPerTenant: cfg.ShardsPerTenant,
 		Root:            cfg.Root,
 	}), nil
+}
+
+// cacheSettings is the resolved, effective cache/optimization configuration that oteldb applies to
+// the storage engine. Unlike the storage library (where these are opt-in), oteldb enables all three
+// by default and treats them as opt-out.
+type cacheSettings struct {
+	ReadCache      int64
+	DecodeCache    int64
+	AggregateStats bool
+}
+
+// resolveCacheSettings resolves the cache/optimization settings from config. Unset fields are sized
+// from the Go memory limit (e.g. a cgroup limit applied by automemlimit), falling back to
+// conservative absolute defaults when no limit is detectable. An explicit zero byte size disables
+// that cache, and an explicit AggregateStats=false disables the sidecar.
+func resolveCacheSettings(cfg StorageConfig) cacheSettings {
+	return cacheSettings{
+		ReadCache:      resolveCacheBytes(cfg.ReadCacheBytes, defaultReadCacheBytes),
+		DecodeCache:    resolveCacheBytes(cfg.DecodeCacheBytes, defaultDecodeCacheBytes),
+		AggregateStats: cfg.AggregateStats == nil || *cfg.AggregateStats,
+	}
+}
+
+// cacheOptions builds the storage options for the resolved cache/optimization settings.
+func cacheOptions(s cacheSettings) []storage.Option {
+	opts := []storage.Option{
+		storage.WithReadCache(s.ReadCache),
+		storage.WithDecodeCache(s.DecodeCache),
+	}
+	if s.AggregateStats {
+		opts = append(opts, storage.WithAggregateStats())
+	}
+	return opts
+}
+
+// resolveCacheBytes returns an explicit configured byte size (including 0 to disable) or, when
+// unset, the default returned by def.
+func resolveCacheBytes(cfg *xbytes.Bytes, def func() int64) int64 {
+	if cfg != nil {
+		return int64(*cfg)
+	}
+	return def()
+}
+
+// defaultReadCacheBytes sizes the backend object read cache (~1/16 of RAM, floor 128 MiB).
+func defaultReadCacheBytes() int64 { return defaultCacheBytes(1.0/16, 128<<20) }
+
+// defaultDecodeCacheBytes sizes the per-tenant decoded-column cache (~1/32 of RAM, floor 64 MiB).
+func defaultDecodeCacheBytes() int64 { return defaultCacheBytes(1.0/32, 64<<20) }
+
+// defaultCacheBytes sizes a cache as the given fraction of the Go memory limit, floored at minBytes.
+// When no limit is set (the default of math.MaxInt64, meaning unbounded), it returns minBytes so the
+// cache gets a sane absolute size rather than a RAM-proportional blow-up.
+func defaultCacheBytes(fraction float64, minBytes int64) int64 {
+	limit := debug.SetMemoryLimit(-1)
+	if limit <= 0 || limit == math.MaxInt64 {
+		return minBytes
+	}
+	if v := int64(float64(limit) * fraction); v > minBytes {
+		return v
+	}
+	return minBytes
 }

--- a/cmd/oteldb/storage_backend_test.go
+++ b/cmd/oteldb/storage_backend_test.go
@@ -3,11 +3,15 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/xbytes"
 )
 
 // applyOption applies a storage.Option to a fresh Options and returns it, so tests can inspect what
@@ -108,4 +112,183 @@ storage:
 	require.Equal(t, 3, cfg.Storage.Cluster.RF)
 	require.Equal(t, 8, cfg.Storage.Cluster.ShardsPerTenant)
 	require.Equal(t, "/oteldb", cfg.Storage.Cluster.Root)
+}
+
+func TestTenancyOption(t *testing.T) {
+	t.Run("DisabledWhenEmpty", func(t *testing.T) {
+		opt, err := tenancyOption(nil)
+		require.NoError(t, err)
+		require.Nil(t, opt)
+
+		opt, err = tenancyOption(&StoragePolicyConfig{}) // no tiers, no recompress
+		require.NoError(t, err)
+		require.Nil(t, opt)
+	})
+
+	t.Run("ResolvesPolicyForEveryTenant", func(t *testing.T) {
+		opt, err := tenancyOption(&StoragePolicyConfig{
+			Precision: []PrecisionTierConfig{
+				{After: 7 * 24 * time.Hour, Bits: 32},
+				{After: 30 * 24 * time.Hour, Bits: 16},
+			},
+			Downsample: []DownsampleTierConfig{
+				{After: 24 * time.Hour, Interval: 5 * time.Minute, Agg: "avg"},
+				{After: 7 * 24 * time.Hour, Interval: time.Hour}, // Agg defaults to last.
+			},
+			Recompress: &RecompressConfig{After: 14 * 24 * time.Hour, Level: 9},
+		})
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.NotNil(t, o.Tenancy)
+
+		// The static resolver returns the same policy regardless of tenant.
+		p := o.Tenancy.Resolve(signal.TenantID("any"))
+
+		require.Len(t, p.Precision.Tiers, 2)
+		require.Equal(t, 7*24*time.Hour, p.Precision.Tiers[0].After)
+		require.Equal(t, uint8(32), p.Precision.Tiers[0].Bits)
+		require.Equal(t, uint8(16), p.Precision.Tiers[1].Bits)
+
+		require.Len(t, p.Downsample.Tiers, 2)
+		require.Equal(t, 5*time.Minute, p.Downsample.Tiers[0].Interval)
+		require.Equal(t, signal.AggAvg, p.Downsample.Tiers[0].Agg)
+		require.Equal(t, signal.AggLast, p.Downsample.Tiers[1].Agg, "empty agg defaults to last")
+
+		require.Equal(t, 14*24*time.Hour, p.Recompress.After)
+		require.Equal(t, 9, p.Recompress.Level)
+	})
+
+	t.Run("UnknownAggIsAnError", func(t *testing.T) {
+		_, err := tenancyOption(&StoragePolicyConfig{
+			Downsample: []DownsampleTierConfig{{Interval: time.Minute, Agg: "median"}},
+		})
+		require.Error(t, err)
+	})
+}
+
+// TestStoragePolicyConfigYAML checks the policy block parses from the documented YAML shape and
+// resolves into the storage tenancy policy.
+func TestStoragePolicyConfigYAML(t *testing.T) {
+	const data = `
+storage:
+  backend: file
+  dir: /data
+  policy:
+    precision:
+      - after: 168h
+        bits: 32
+    downsample:
+      - after: 24h
+        interval: 5m
+        agg: avg
+    recompress:
+      after: 336h
+      level: 9
+`
+	f, err := os.CreateTemp("", "oteldb.yml")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(f.Name()) }()
+	_, err = f.WriteString(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cfg, err := loadConfig(f.Name())
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Storage.Policy)
+	opt, err := tenancyOption(cfg.Storage.Policy)
+	require.NoError(t, err)
+	o := applyOption(t, opt)
+
+	p := o.Tenancy.Resolve("default")
+	require.Len(t, p.Precision.Tiers, 1)
+	require.Equal(t, 168*time.Hour, p.Precision.Tiers[0].After)
+	require.Equal(t, uint8(32), p.Precision.Tiers[0].Bits)
+	require.Len(t, p.Downsample.Tiers, 1)
+	require.Equal(t, signal.AggAvg, p.Downsample.Tiers[0].Agg)
+	require.Equal(t, 336*time.Hour, p.Recompress.After)
+	require.Equal(t, 9, p.Recompress.Level)
+}
+
+func TestResolveCacheSettings(t *testing.T) {
+	t.Run("DefaultsEnableAll", func(t *testing.T) {
+		s := resolveCacheSettings(StorageConfig{})
+		// All three are opt-out for oteldb: on by default.
+		require.True(t, s.AggregateStats)
+		require.Greater(t, s.ReadCache, int64(0))
+		require.Greater(t, s.DecodeCache, int64(0))
+	})
+
+	t.Run("ExplicitSizesHonored", func(t *testing.T) {
+		rc, dc := xbytes.Bytes(1<<20), xbytes.Bytes(2<<20)
+		s := resolveCacheSettings(StorageConfig{
+			ReadCacheBytes:   &rc,
+			DecodeCacheBytes: &dc,
+		})
+		require.Equal(t, int64(1<<20), s.ReadCache)
+		require.Equal(t, int64(2<<20), s.DecodeCache)
+	})
+
+	t.Run("ZeroDisablesByteCache", func(t *testing.T) {
+		zero := xbytes.Bytes(0)
+		s := resolveCacheSettings(StorageConfig{ReadCacheBytes: &zero, DecodeCacheBytes: &zero})
+		require.Equal(t, int64(0), s.ReadCache)
+		require.Equal(t, int64(0), s.DecodeCache)
+	})
+
+	t.Run("AggregateStatsFalseDisables", func(t *testing.T) {
+		s := resolveCacheSettings(StorageConfig{AggregateStats: new(bool)})
+		require.False(t, s.AggregateStats)
+	})
+}
+
+func TestCacheOptions(t *testing.T) {
+	apply := func(t *testing.T, opts []storage.Option) storage.Options {
+		t.Helper()
+		var o storage.Options
+		for _, opt := range opts {
+			opt(&o)
+		}
+		return o
+	}
+
+	t.Run("Enabled", func(t *testing.T) {
+		o := apply(t, cacheOptions(cacheSettings{ReadCache: 100, DecodeCache: 200, AggregateStats: true}))
+		require.Equal(t, int64(100), o.ReadCacheBytes)
+		require.Equal(t, int64(200), o.DecodeCacheBytes)
+		require.True(t, o.AggregateStats)
+	})
+
+	t.Run("AggregateStatsOffOmitsSidecar", func(t *testing.T) {
+		o := apply(t, cacheOptions(cacheSettings{AggregateStats: false}))
+		require.False(t, o.AggregateStats, "AggregateStats stays the library default when disabled")
+	})
+}
+
+// TestStorageCacheConfigYAML checks the cache block parses from the documented YAML shape, including
+// the opt-out semantics (an explicit 0 disables a byte cache, aggregate_stats: false disables the
+// sidecar).
+func TestStorageCacheConfigYAML(t *testing.T) {
+	const data = `
+storage:
+  backend: file
+  dir: /data
+  read_cache_bytes: "0"
+  decode_cache_bytes: "64MiB"
+  aggregate_stats: false
+`
+	f, err := os.CreateTemp("", "oteldb.yml")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(f.Name()) }()
+	_, err = f.WriteString(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cfg, err := loadConfig(f.Name())
+	require.NoError(t, err)
+
+	s := resolveCacheSettings(cfg.Storage)
+	require.Equal(t, int64(0), s.ReadCache, "explicit 0 disables the read cache")
+	require.Equal(t, int64(64<<20), s.DecodeCache)
+	require.False(t, s.AggregateStats, "explicit aggregate_stats:false disables the sidecar")
 }

--- a/cmd/oteldb/storage_policy.go
+++ b/cmd/oteldb/storage_policy.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"time"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/tenant"
+)
+
+// StoragePolicyConfig configures the per-tenant storage policy applied to the embedded engine's
+// background merges: age-tiered lossy float precision, downsampling, and cold-data recompression.
+// The storage library resolves these per-tenant via a [tenant.Resolver] callback; oteldb runs the
+// embedded engine single-tenant (every signal routes to the "default" tenant), so this one policy
+// is resolved for every tenant. Empty ⇒ no tenancy resolver is installed (the library default:
+// lossless, no rollup, no recompression).
+type StoragePolicyConfig struct {
+	// Precision is the age-tiered lossy float-compression policy: each tier re-encodes, at merge,
+	// the value column of parts older than After to retain only Bits significant mantissa bits, so
+	// recent data stays lossless and only old data trades accuracy for size. Empty ⇒ lossless.
+	Precision []PrecisionTierConfig `json:"precision" yaml:"precision"`
+	// Downsample is the age-tiered merge-time rollup: each tier replaces samples older than After
+	// with one representative per Interval-wide bucket, the bucket combined by Agg. Empty ⇒ raw.
+	Downsample []DownsampleTierConfig `json:"downsample" yaml:"downsample"`
+	// Recompress rewrites fully-cold parts (older than After) with a higher-ratio Zstandard profile
+	// at merge, trading merge CPU for storage. It is decode-transparent. Nil ⇒ disabled.
+	Recompress *RecompressConfig `json:"recompress" yaml:"recompress"`
+}
+
+// PrecisionTierConfig is one age band of the lossy float-precision policy.
+type PrecisionTierConfig struct {
+	// After is the age past which this tier applies (relative to now at merge time).
+	After time.Duration `json:"after" yaml:"after"`
+	// Bits is the significant mantissa bits retained (1..63). 0 or ≥64 ⇒ lossless (ignored).
+	Bits uint8 `json:"bits" yaml:"bits"`
+}
+
+// DownsampleTierConfig is one age band of the downsampling policy.
+type DownsampleTierConfig struct {
+	// After is the age past which this tier applies (relative to now at merge time).
+	After time.Duration `json:"after" yaml:"after"`
+	// Interval is the rollup bucket width. Zero ⇒ the tier is disabled.
+	Interval time.Duration `json:"interval" yaml:"interval"`
+	// Agg combines a bucket's samples: "last" (default), "first", "min", "max", "sum", "avg",
+	// "count". Empty ⇒ "last".
+	Agg string `json:"agg" yaml:"agg"`
+}
+
+// RecompressConfig configures cold-data recompression.
+type RecompressConfig struct {
+	// After is the age past which a fully-cold part is recompressed at merge. Zero is invalid here
+	// (a Recompress block is present only to enable it); use a positive age.
+	After time.Duration `json:"after" yaml:"after"`
+	// Level is the Zstandard level (1 fastest … 19 best ratio). Zero ⇒ the best-ratio default.
+	Level int `json:"level" yaml:"level"`
+}
+
+// empty reports whether the policy configures nothing, in which case no resolver is installed.
+func (cfg *StoragePolicyConfig) empty() bool {
+	return cfg == nil || (len(cfg.Precision) == 0 && len(cfg.Downsample) == 0 && cfg.Recompress == nil)
+}
+
+// tenancyOption builds the storage tenancy option from the policy config, or returns (nil, nil)
+// when no policy is configured. The resolved policy is applied to every tenant — oteldb runs the
+// embedded engine single-tenant, so a static resolver suffices.
+func tenancyOption(cfg *StoragePolicyConfig) (storage.Option, error) {
+	if cfg.empty() {
+		return nil, nil
+	}
+
+	policy, err := cfg.policy()
+	if err != nil {
+		return nil, err
+	}
+
+	return storage.WithTenancy(tenant.ResolverFunc(func(signal.TenantID) tenant.Policy {
+		return policy
+	})), nil
+}
+
+// policy translates the config into a [tenant.Policy]. It validates the downsample aggregation
+// names so a typo is a startup error rather than a silently-ignored tier.
+func (cfg *StoragePolicyConfig) policy() (tenant.Policy, error) {
+	var p tenant.Policy
+
+	for _, t := range cfg.Precision {
+		p.Precision.Tiers = append(p.Precision.Tiers, tenant.PrecisionTier{
+			After: t.After,
+			Bits:  t.Bits,
+		})
+	}
+
+	for i, t := range cfg.Downsample {
+		agg := signal.AggLast
+		if t.Agg != "" {
+			parsed, err := signal.ParseAggregation(t.Agg)
+			if err != nil {
+				return tenant.Policy{}, errors.Wrapf(err, "downsample tier %d", i)
+			}
+			agg = parsed
+		}
+		p.Downsample.Tiers = append(p.Downsample.Tiers, tenant.DownsampleTier{
+			After:    t.After,
+			Interval: t.Interval,
+			Agg:      agg,
+		})
+	}
+
+	if r := cfg.Recompress; r != nil {
+		p.Recompress = tenant.Recompress{After: r.After, Level: r.Level}
+	}
+
+	return p, nil
+}

--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -1,0 +1,93 @@
+# Storage library integration
+
+Integration work for `go-faster/oteldb` to exploit the `github.com/oteldb/storage`
+library's improvements: caches, aggregate pushdown, and lossy precision.
+
+## Caches / optimizations are opt-out for oteldb
+
+The storage library keeps these opt-in (it's a general-purpose library whose default is the
+in-memory test backend):
+
+- `Options.ReadCacheBytes` — `0` = off
+- `Options.DecodeCacheBytes` — `0` = off
+- `Options.AggregateStats` — `false` = off
+
+**oteldb must flip the polarity: enable all three by default**, sized from available RAM,
+exposing flags/env to disable them (e.g. `--storage.read-cache-bytes=0`).
+
+Optionally, add a `storage.RecommendedOptions(backend, ramBytes)` helper to the library so the
+sane-sizing logic lives there and oteldb just opts into the bundle.
+
+> **Implemented** in `cmd/oteldb/storage_backend.go` (`resolveCacheSettings` / `cacheOptions`):
+> all three default on. `read_cache_bytes` / `decode_cache_bytes` size to a fraction of the Go
+> memory limit (floors 128 MiB / 64 MiB); an explicit `0` disables a byte cache and
+> `aggregate_stats: false` disables the sidecar. Config block: `storage.{read_cache_bytes,
+> decode_cache_bytes,aggregate_stats}`.
+
+## Aggregate pushdown for `*_over_time` (headline integration)
+
+Call the facade instead of raw-fetch-and-fold:
+
+- `Storage.AggregateMetricsStep(ctx, tenant, req, stepNs)` — range vectors (per-step buckets)
+- `Storage.AggregateMetrics(ctx, tenant, req)` — whole range; `map[SeriesID]SeriesAgg` (unlabeled)
+
+Returns `engine.BucketAgg{Start, SeriesAgg{Count, Sum, Min, Max}}` per series.
+
+**Labeled variant (use this for rendering):** `Storage.AggregateMetricsNamed(ctx, tenant, req)`
+returns `[]storage.SeriesAggregate`, each pairing a `signal.Series` identity with its whole-range
+`engine.SeriesAgg`. This is what oteldb wants for the `*_over_time` path: the identity rides along
+from the same sidecar pass, so oteldb renders the result as a PromQL vector (labels + value)
+**without a second, value-decoding fetch**. Use the unlabeled `AggregateMetrics` only when the
+aggregate alone is needed. Series with no sample in the window are omitted. Cluster fan-out is
+labeled-aware (`clusterAggregateNamedFor` re-checks the full matcher set per shard and unions).
+
+**Covered:** `count`, `sum`, `min`, `max`, `avg`, `present_over_time`.
+
+**Not covered:**
+- `rate` / `increase` — need per-bucket first+last value + counter-reset count. A richer sidecar
+  is the future enhancement; high value since `rate` is the most common function.
+- `last_over_time` / `first_over_time` / `quantile_over_time`.
+
+The Prometheus engine has **no `*_over_time` pushdown hook**, so oteldb needs a pushdown-aware
+eval path that recognises aggregation-over-time and delegates to the facade; other functions fall
+back to the existing `Queryable` (raw fetch).
+
+**Reuse the adapter's Prom↔storage translation — do not duplicate it.** The `query/promql` package
+now exports the projection helpers the `Queryable` uses, which are the single source of truth for
+the seam oteldb's pushdown path sits on:
+
+- `promql.PushableMatchers(ms)` — lower a Prometheus matcher set to the index-safe `fetch.Matcher`
+  subset (matchers that match `""` are not pushed; they stay for the post-fetch re-check).
+- `promql.MatchesAll(lset, ms)` — the post-fetch full-set re-check (absent label = `""`).
+- `promql.PromLabels(series)` — project a `signal.Series` identity (e.g. the one carried on a
+  `SeriesAggregate`) to a Prometheus label set, with reserved labels hidden.
+
+So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `MatchesAll` re-check →
+`PromLabels` to render the vector — all using the library's own translation.
+
+> **Implemented** in `internal/storagebackend/overtime.go` (`aggregateOverTimeOp`, a
+> `model.VectorOperator`) wired through `scanners.NewMatrixSelector`. It is **instant-only**: a
+> range query keeps the raw matrix selector (its per-step sliding window is a different shape than
+> the sidecar's step-aligned buckets), as do selectors carrying a projection or post-filter.
+> Covered folds: `count`/`sum`/`min`/`max`/`avg`/`present_over_time` (`overTimeFold`); everything
+> else falls back. Toggle with `WithOverTimePushdown` (on by default).
+
+## Other touch points
+
+- **Lossy precision:** expose `tenant.Precision{Tiers: []{After, Bits}}` (age-tiered lossy float
+  compression) through oteldb's per-tenant resolver, alongside Downsample/Recompress.
+  **Implemented** in `cmd/oteldb/storage_policy.go` (`tenancyOption` → `storage.WithTenancy`):
+  the `storage.policy` config block exposes `precision[]{after,bits}`,
+  `downsample[]{after,interval,agg}`, and `recompress{after,level}`. oteldb runs the embedded
+  engine single-tenant, so a static `tenant.ResolverFunc` returns one policy for every tenant.
+- **Sampling weights:** honour `fetch.Batch.ScaleFactors` in PromQL `sum`/`rate`/`count` for
+  sampled tenants. The aggregate sidecar is skipped for sampled parts, so those fall back to a
+  weighted raw fold. **Not implemented.** oteldb does not yet expose a `tenant.Sampling` policy,
+  so ingest is always lossless and every `ScaleFactor` is `1` — honouring weights is a no-op
+  until sampling is configured. It is also not a pure sample-level transform (the weight folds
+  differently for `count` vs `sum` vs `rate`), so the correct home is either a weight-aware fold
+  in the library `query/promql` queryable or a dedicated pushdown — a design decision deferred
+  with sampling itself.
+- **Cluster:** aggregate fan-out is automatic — just call the facade per tenant.
+- **Metadata:** querier `LabelValues` / `LabelNames` are implemented in the promql `Queryable`
+  adapter.

--- a/go.mod
+++ b/go.mod
@@ -454,7 +454,7 @@ require (
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
-	github.com/oteldb/storage v0.7.0
+	github.com/oteldb/storage v0.9.0
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.7.0-alpha.0 h1:od3skf7eTPMv+3zR6G3WZl7YVzWJUa8b8yP3XpfIgI4=
 github.com/oteldb/promql-engine v0.7.0-alpha.0/go.mod h1:j3kBzxEWSsdIinLTl7ogVolJbI2GC/fa1GU4/NpOr0k=
-github.com/oteldb/storage v0.7.0 h1:Q1PO05oZjYKW+dW+IbZzK12D2X3NG+v6986TZ16P/p0=
-github.com/oteldb/storage v0.7.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
+github.com/oteldb/storage v0.9.0 h1:YjP/MpsZnibnx/3WmhvCjssmVcepKD7GmwmFM5yBJkE=
+github.com/oteldb/storage v0.9.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/storagebackend/overtime.go
+++ b/internal/storagebackend/overtime.go
@@ -1,0 +1,202 @@
+package storagebackend
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/oteldb/promql-engine/execution/model"
+	"github.com/oteldb/promql-engine/extlabels"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/engine"
+	"github.com/oteldb/storage/query/fetch"
+	storagepromql "github.com/oteldb/storage/query/promql"
+	"github.com/oteldb/storage/signal"
+)
+
+// overTimeFold folds a per-series [engine.SeriesAgg] into the value of one PromQL *_over_time
+// function. These are the functions the aggregate sidecar (count/sum/min/max) answers without
+// decoding: avg is sum/count, present_over_time is "1 if any sample" (the facade omits empty
+// series, so every returned series is present). rate/increase, quantile_over_time,
+// last/first_over_time, stddev/stdvar_over_time, and friends need more than the sidecar and are
+// not pushable — they fall back to the raw matrix selector.
+var overTimeFold = map[string]func(engine.SeriesAgg) float64{
+	"count_over_time":   func(a engine.SeriesAgg) float64 { return float64(a.Count) },
+	"sum_over_time":     func(a engine.SeriesAgg) float64 { return a.Sum },
+	"min_over_time":     func(a engine.SeriesAgg) float64 { return a.Min },
+	"max_over_time":     func(a engine.SeriesAgg) float64 { return a.Max },
+	"avg_over_time":     func(a engine.SeriesAgg) float64 { return a.Sum / float64(a.Count) },
+	"present_over_time": func(engine.SeriesAgg) float64 { return 1 },
+}
+
+// aggregateOverTimeOp is a [model.VectorOperator] that answers an instant *_over_time query by
+// folding [storage.Storage.AggregateMetricsNamed] (the stats-sidecar pushdown) instead of a raw
+// fetch-and-fold. It is a drop-in replacement for the matrix selector plus its ringbuffer fold:
+// its output is the function value per series, with the metric name dropped as PromQL does for
+// range-vector functions.
+//
+// It is instant-only. A range query re-evaluates the function at each step over a sliding
+// (t-range, t] window, which the storage library exposes only as step-aligned buckets (a different
+// shape); the raw matrix selector stays correct there and is used instead. See
+// docs/storage-integration.md.
+type aggregateOverTimeOp struct {
+	store    *storage.Storage
+	tenant   signal.TenantID
+	matchers []*labels.Matcher
+	fold     func(engine.SeriesAgg) float64
+	fnName   string
+
+	evalT   int64 // milliseconds — the single evaluation timestamp
+	rangeMs int64
+	offset  int64
+
+	once    sync.Once
+	series  []labels.Labels // index-aligned with values; the StepVector SampleID is this index
+	values  []float64
+	loadErr error
+
+	emitted bool
+}
+
+func newAggregateOverTimeOp(
+	store *storage.Storage,
+	tenant signal.TenantID,
+	matchers []*labels.Matcher,
+	fnName string,
+	fold func(engine.SeriesAgg) float64,
+	evalT, rangeMs, offsetMs int64,
+) *aggregateOverTimeOp {
+	return &aggregateOverTimeOp{
+		store:    store,
+		tenant:   tenant,
+		matchers: matchers,
+		fold:     fold,
+		fnName:   fnName,
+		evalT:    evalT,
+		rangeMs:  rangeMs,
+		offset:   offsetMs,
+	}
+}
+
+func (o *aggregateOverTimeOp) String() string {
+	return fmt.Sprintf("[storagebackend.aggregateOverTimeOp] %s({%v}[%s])", o.fnName, o.matchers, time.Duration(o.rangeMs)*time.Millisecond)
+}
+
+func (o *aggregateOverTimeOp) Explain() []model.VectorOperator { return nil }
+
+func (o *aggregateOverTimeOp) Series(ctx context.Context) ([]labels.Labels, error) {
+	if err := o.load(ctx); err != nil {
+		return nil, err
+	}
+
+	return o.series, nil
+}
+
+func (o *aggregateOverTimeOp) Next(ctx context.Context, buf []model.StepVector) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
+	if o.emitted {
+		return 0, nil
+	}
+
+	if err := o.load(ctx); err != nil {
+		return 0, err
+	}
+
+	o.emitted = true
+	if len(o.series) == 0 || len(buf) == 0 {
+		return 0, nil
+	}
+
+	buf[0].Reset(o.evalT)
+	hint := len(o.values)
+	for i, v := range o.values {
+		buf[0].AppendSampleWithSizeHint(uint64(i), v, hint)
+	}
+
+	return 1, nil
+}
+
+// load runs the pushdown once: it asks the storage facade for the labeled whole-range aggregate
+// over the PromQL window, drops the metric name (as range-vector functions do), and re-checks the
+// full matcher set (the facade, like the Queryable, pushes only the index-safe subset).
+func (o *aggregateOverTimeOp) load(ctx context.Context) error {
+	o.once.Do(func() { o.loadErr = o.doLoad(ctx) })
+
+	return o.loadErr
+}
+
+func (o *aggregateOverTimeOp) doLoad(ctx context.Context) error {
+	// PromQL evaluates the range vector at (evalT - offset] over a (range] window: the included
+	// samples are (mint, maxt]. Storage's fetch window is inclusive [start, end] in nanoseconds,
+	// so mint is exclusive (start = mint+1 ms) and maxt inclusive.
+	maxt := o.evalT - o.offset
+	mint := maxt - o.rangeMs
+
+	const nsPerMs = int64(time.Millisecond)
+
+	aggs, err := o.store.AggregateMetricsNamed(ctx, o.tenant, fetch.Request{
+		Tenant:   o.tenant,
+		Start:    (mint + 1) * nsPerMs, // PromQL's (mint, maxt] ⇒ storage's inclusive [mint+1, maxt].
+		End:      maxt * nsPerMs,
+		Matchers: storagepromql.PushableMatchers(o.matchers),
+	})
+	if err != nil {
+		return errors.Wrap(err, "aggregate metrics")
+	}
+
+	o.series = make([]labels.Labels, 0, len(aggs))
+	o.values = make([]float64, 0, len(aggs))
+
+	var b labels.ScratchBuilder
+	for i := range aggs {
+		la := &aggs[i]
+
+		lset := storagepromql.PromLabels(la.Series)
+		if !storagepromql.MatchesAll(lset, o.matchers) {
+			continue
+		}
+
+		// Range-vector functions drop the metric name (and the other schema metadata labels).
+		lset = extlabels.DropReserved(lset, b)
+		b.Reset()
+
+		v := o.fold(la.SeriesAgg)
+		if math.IsNaN(v) {
+			continue
+		}
+
+		o.series = append(o.series, lset)
+		o.values = append(o.values, v)
+	}
+
+	// Sort both slices in lockstep by label set, for deterministic output (Prometheus returns
+	// vectors sorted by labels).
+	order := make([]int, len(o.series))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, c int) bool {
+		return labels.Compare(o.series[order[a]], o.series[order[c]]) < 0
+	})
+	sortedSeries := make([]labels.Labels, len(order))
+	sortedVals := make([]float64, len(order))
+	for i, idx := range order {
+		sortedSeries[i] = o.series[idx]
+		sortedVals[i] = o.values[idx]
+	}
+	o.series = sortedSeries
+	o.values = sortedVals
+
+	return nil
+}

--- a/internal/storagebackend/overtime_test.go
+++ b/internal/storagebackend/overtime_test.go
@@ -2,10 +2,14 @@ package storagebackend_test
 
 import (
 	"context"
+	"math"
 	"slices"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	promqlengine "github.com/oteldb/promql-engine/engine"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
@@ -184,4 +188,352 @@ func execInstant(
 	require.NoError(t, err)
 
 	return vec
+}
+
+// gaugeSeries is one labeled series of the multi-series gauge fixture: a "foo" label value and the
+// (offset-from-evalT, value) samples that series carries.
+type gaugeSeries struct {
+	foo     string
+	samples []timeSample
+}
+
+// ingestGaugeSeries writes the "ot_gauge" gauge with one series per entry (distinguished by the
+// label foo=<entry.foo>), each carrying its own samples, and returns the populated store. It is the
+// multi-series analog of [ingestGauge], so a test can exercise per-series folding, label
+// rendering, matcher subsetting, and result ordering — not just a single series.
+func ingestGaugeSeries(ctx context.Context, t *testing.T, evalT time.Time, series []gaugeSeries) *storage.Storage {
+	t.Helper()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "test")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("ot_gauge")
+	g := m.SetEmptyGauge()
+	for _, s := range series {
+		for _, smp := range s.samples {
+			dp := g.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.Timestamp(evalT.Add(smp.offset).UnixNano()))
+			dp.SetDoubleValue(smp.value)
+			dp.Attributes().PutStr("foo", s.foo)
+		}
+	}
+
+	b := storagebackend.New(store)
+	require.NoError(t, b.ConsumeMetrics(ctx, md))
+
+	return store
+}
+
+// rampSamples builds samples at every step in [start, end] (offsets from evalT, typically negative),
+// with values base, base+1, … so each series carries a distinct, monotonic curve.
+func rampSamples(start, end, step time.Duration, base float64) []timeSample {
+	var out []timeSample
+	v := base
+	for off := start; off <= end; off += step {
+		out = append(out, timeSample{offset: off, value: v})
+		v++
+	}
+	return out
+}
+
+func newOverTimeEngine(t *testing.T, b *storagebackend.Backend) otelpromql.Engine {
+	t.Helper()
+	eng, err := otelpromql.New(b, otelpromql.EngineOpts{
+		MaxSamples: 1_000_000, Timeout: time.Minute, LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	return eng
+}
+
+// diffBackends pairs a pushdown-on and a pushdown-off backend over the same store, each with its own
+// engine, so a query can be evaluated both ways and the results compared. The pushdown-off path is
+// the standard Prometheus matrix-selector fold — the oracle the sidecar pushdown must match.
+type diffBackends struct {
+	ctx    context.Context
+	pB, rB *storagebackend.Backend
+	pE, rE otelpromql.Engine
+}
+
+func newDiffBackends(ctx context.Context, t *testing.T, store *storage.Storage) diffBackends {
+	t.Helper()
+	pB := storagebackend.New(store)                                             // pushdown on (default)
+	rB := storagebackend.New(store, storagebackend.WithOverTimePushdown(false)) // raw fold (oracle)
+	return diffBackends{ctx: ctx, pB: pB, rB: rB, pE: newOverTimeEngine(t, pB), rE: newOverTimeEngine(t, rB)}
+}
+
+func (d diffBackends) assertInstant(t *testing.T, query string, ts time.Time) {
+	t.Helper()
+	got := execInstant(d.ctx, t, d.pE, d.pB, query, ts)
+	want := execInstant(d.ctx, t, d.rE, d.rB, query, ts)
+	assertVectorEqual(t, query, got, want)
+}
+
+func (d diffBackends) assertRange(t *testing.T, query string, start, end time.Time, step time.Duration) {
+	t.Helper()
+	got := execRange(d.ctx, t, d.pE, d.pB, query, start, end, step)
+	want := execRange(d.ctx, t, d.rE, d.rB, query, start, end, step)
+	assertMatrixEqual(t, query, got, want)
+}
+
+func execRange(
+	ctx context.Context, t *testing.T, eng otelpromql.Engine,
+	b *storagebackend.Backend, query string, start, end time.Time, step time.Duration,
+) promql.Matrix {
+	t.Helper()
+
+	q, err := eng.NewRangeQuery(ctx, b, nil, query, start, end, step)
+	require.NoError(t, err)
+	t.Cleanup(q.Close)
+
+	res := q.Exec(ctx)
+	require.NoError(t, res.Err)
+
+	m, err := res.Matrix()
+	require.NoError(t, err)
+
+	return m
+}
+
+func assertVectorEqual(t *testing.T, query string, got, want promql.Vector) {
+	t.Helper()
+	sortVector(got)
+	sortVector(want)
+	require.Lenf(t, got, len(want), "%s: series count", query)
+	for i := range got {
+		assert.Equalf(t, want[i].Metric, got[i].Metric, "%s: series labels", query)
+		assertFloatEqual(t, query, got[i].Metric, want[i].F, got[i].F)
+	}
+}
+
+func assertMatrixEqual(t *testing.T, query string, got, want promql.Matrix) {
+	t.Helper()
+	sort.Sort(got)
+	sort.Sort(want)
+	require.Lenf(t, got, len(want), "%s: series count", query)
+	for i := range got {
+		assert.Equalf(t, want[i].Metric, got[i].Metric, "%s: series labels", query)
+		require.Lenf(t, got[i].Floats, len(want[i].Floats), "%s: point count for %s", query, got[i].Metric)
+		for j := range got[i].Floats {
+			assert.Equalf(t, want[i].Floats[j].T, got[i].Floats[j].T, "%s: step timestamp for %s", query, got[i].Metric)
+			assertFloatEqual(t, query, got[i].Metric, want[i].Floats[j].F, got[i].Floats[j].F)
+		}
+	}
+}
+
+func assertFloatEqual(t *testing.T, query string, lset labels.Labels, want, got float64) {
+	t.Helper()
+	if math.IsNaN(want) {
+		assert.Truef(t, math.IsNaN(got), "%s: want NaN, got %v for %s", query, got, lset)
+		return
+	}
+	assert.InDeltaf(t, want, got, 1e-9, "%s: value for %s", query, lset)
+}
+
+// instantPlan returns the execution plan of an instant query, for asserting whether the aggregate
+// pushdown operator was selected.
+func instantPlan(
+	ctx context.Context, t *testing.T, eng otelpromql.Engine,
+	b *storagebackend.Backend, query string, ts time.Time,
+) *promqlengine.ExplainOutputNode {
+	t.Helper()
+	q, err := eng.NewInstantQuery(ctx, b, nil, query, ts)
+	require.NoError(t, err)
+	t.Cleanup(q.Close)
+	exp, ok := q.(promqlengine.ExplainableQuery)
+	require.True(t, ok, "query must implement ExplainableQuery to inspect its plan")
+	return exp.Explain()
+}
+
+// planOpName is the operator-name fragment the aggregate-pushdown vector operator reports in the
+// query plan (see aggregateOverTimeOp.String).
+const planOpName = "aggregateOverTimeOp"
+
+func explainContains(node *promqlengine.ExplainOutputNode, substr string) bool {
+	if node == nil {
+		return false
+	}
+	if strings.Contains(node.OperatorName, substr) {
+		return true
+	}
+	for i := range node.Children {
+		if explainContains(&node.Children[i], substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOverTimePushdownPlanRouting proves the pushdown is actually exercised where it should be and
+// — just as important for validity — that it cleanly steps aside everywhere it must. Without this,
+// the differential tests could pass trivially by never pushing down at all.
+func TestOverTimePushdownPlanRouting(t *testing.T) {
+	ctx := context.Background()
+	evalT := time.Unix(2_000_000, 0).UTC()
+
+	store := ingestGaugeSeries(ctx, t, evalT, []gaugeSeries{
+		{foo: "a", samples: []timeSample{{-10 * time.Second, 1}, {-5 * time.Second, 2}}},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	on := storagebackend.New(store)
+	off := storagebackend.New(store, storagebackend.WithOverTimePushdown(false))
+	engOn := newOverTimeEngine(t, on)
+	engOff := newOverTimeEngine(t, off)
+
+	t.Run("SupportedInstantUsesSidecar", func(t *testing.T) {
+		for _, q := range []string{
+			"count_over_time(ot_gauge[30s])",
+			"sum_over_time(ot_gauge[30s])",
+			"min_over_time(ot_gauge[30s])",
+			"max_over_time(ot_gauge[30s])",
+			"avg_over_time(ot_gauge[30s])",
+			"present_over_time(ot_gauge[30s])",
+			`max_over_time(ot_gauge{foo="a"}[30s])`,
+			"count_over_time(ot_gauge[30s] offset 10s)",
+		} {
+			plan := instantPlan(ctx, t, engOn, on, q, evalT)
+			assert.Truef(t, explainContains(plan, planOpName), "%s should push down to the sidecar", q)
+		}
+	})
+
+	t.Run("DisabledFallsBack", func(t *testing.T) {
+		plan := instantPlan(ctx, t, engOff, off, "count_over_time(ot_gauge[30s])", evalT)
+		assert.False(t, explainContains(plan, planOpName), "WithOverTimePushdown(false) must not use the sidecar")
+	})
+
+	t.Run("UnsupportedFunctionFallsBack", func(t *testing.T) {
+		// Functions the sidecar (count/sum/min/max) cannot answer must keep the raw matrix selector.
+		for _, q := range []string{
+			"last_over_time(ot_gauge[30s])",
+			"stddev_over_time(ot_gauge[30s])",
+			"quantile_over_time(0.5, ot_gauge[30s])",
+			"changes(ot_gauge[30s])",
+			"rate(ot_gauge[30s])",
+		} {
+			plan := instantPlan(ctx, t, engOn, on, q, evalT)
+			assert.Falsef(t, explainContains(plan, planOpName), "%s must fall back to the matrix selector", q)
+		}
+	})
+
+	t.Run("RangeQueryFallsBack", func(t *testing.T) {
+		// Range queries re-evaluate over a sliding window the sidecar's step buckets don't model.
+		q, err := engOn.NewRangeQuery(ctx, on, nil, "count_over_time(ot_gauge[30s])", evalT, evalT.Add(time.Minute), 15*time.Second)
+		require.NoError(t, err)
+		t.Cleanup(q.Close)
+		exp, ok := q.(promqlengine.ExplainableQuery)
+		require.True(t, ok)
+		assert.False(t, explainContains(exp.Explain(), planOpName), "range query must use the matrix selector")
+	})
+}
+
+// TestOverTimePushdownMultiSeriesMatchesRaw is the differential oracle over a multi-series fixture:
+// for a broad query matrix (every supported fold, matcher subsets, offsets, downstream aggregation,
+// arithmetic, and an empty result) the pushdown must produce exactly what the raw matrix-selector
+// fold produces — same series, same labels, same values. This exercises per-series folding, label
+// rendering, post-fetch matcher re-checks, window-edge inclusion, and result ordering at once.
+func TestOverTimePushdownMultiSeriesMatchesRaw(t *testing.T) {
+	ctx := context.Background()
+	evalT := time.Unix(2_000_000, 0).UTC()
+
+	store := ingestGaugeSeries(ctx, t, evalT, []gaugeSeries{
+		// a: -30s sample is excluded by a 30s window (exclusive lower bound), included by 60s.
+		{foo: "a", samples: []timeSample{{-30 * time.Second, 10}, {-20 * time.Second, 20}, {-10 * time.Second, 30}}},
+		{foo: "b", samples: []timeSample{{-25 * time.Second, 5}, {-5 * time.Second, 7}}},
+		// c: only sample sits outside a 30s window, so c is present only for wider windows.
+		{foo: "c", samples: []timeSample{{-45 * time.Second, 100}}},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	d := newDiffBackends(ctx, t, store)
+
+	for _, q := range []string{
+		// Per-series folds, narrow window (c absent, a drops its -30s sample).
+		"count_over_time(ot_gauge[30s])",
+		"sum_over_time(ot_gauge[30s])",
+		"min_over_time(ot_gauge[30s])",
+		"max_over_time(ot_gauge[30s])",
+		"avg_over_time(ot_gauge[30s])",
+		"present_over_time(ot_gauge[30s])",
+		// Wider window pulls c in and a's boundary sample.
+		"count_over_time(ot_gauge[60s])",
+		"sum_over_time(ot_gauge[60s])",
+		"avg_over_time(ot_gauge[60s])",
+		// Matcher subsets: equality, negation, regex, negated regex — index-safe and re-checked.
+		`count_over_time(ot_gauge{foo="a"}[30s])`,
+		`count_over_time(ot_gauge{foo!="a"}[30s])`,
+		`sum_over_time(ot_gauge{foo=~"a|b"}[30s])`,
+		`sum_over_time(ot_gauge{foo!~"a"}[60s])`,
+		// Offset shifts the evaluated window back in time.
+		"count_over_time(ot_gauge[30s] offset 10s)",
+		"sum_over_time(ot_gauge[30s] offset 20s)",
+		// Downstream aggregation composes with the pushdown operator.
+		"sum(sum_over_time(ot_gauge[30s]))",
+		"sum by (foo) (count_over_time(ot_gauge[60s]))",
+		"count(present_over_time(ot_gauge[60s]))",
+		"max(max_over_time(ot_gauge[60s]))",
+		"avg(avg_over_time(ot_gauge[60s]))",
+		// Arithmetic on top of the range-vector function.
+		"avg_over_time(ot_gauge[60s]) * 2",
+		// Empty result (no series matches).
+		`count_over_time(ot_gauge{foo="zzz"}[30s])`,
+	} {
+		t.Run(q, func(t *testing.T) { d.assertInstant(t, q, evalT) })
+	}
+}
+
+// TestOverTimePushdownUnsupportedMatchesRaw checks that functions the pushdown does not cover still
+// produce the correct result through the fallback path on a pushdown-enabled backend — i.e. routing
+// them away from the sidecar does not perturb their values.
+func TestOverTimePushdownUnsupportedMatchesRaw(t *testing.T) {
+	ctx := context.Background()
+	evalT := time.Unix(2_000_000, 0).UTC()
+
+	store := ingestGaugeSeries(ctx, t, evalT, []gaugeSeries{
+		{foo: "a", samples: []timeSample{{-50 * time.Second, 4}, {-30 * time.Second, 9}, {-10 * time.Second, 2}}},
+		{foo: "b", samples: []timeSample{{-40 * time.Second, 1}, {-20 * time.Second, 8}}},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	d := newDiffBackends(ctx, t, store)
+
+	for _, q := range []string{
+		"last_over_time(ot_gauge[60s])",
+		"stddev_over_time(ot_gauge[60s])",
+		"stdvar_over_time(ot_gauge[60s])",
+		"quantile_over_time(0.9, ot_gauge[60s])",
+		"changes(ot_gauge[60s])",
+		"delta(ot_gauge[60s])",
+	} {
+		t.Run(q, func(t *testing.T) { d.assertInstant(t, q, evalT) })
+	}
+}
+
+// TestOverTimePushdownRangeMatchesRaw confirms that range queries — which always take the raw path,
+// since the sidecar models instant evaluation only — are unaffected by enabling the pushdown: a
+// pushdown-on backend returns the same matrix as a vanilla one across every step.
+func TestOverTimePushdownRangeMatchesRaw(t *testing.T) {
+	ctx := context.Background()
+	base := time.Unix(2_000_000, 0).UTC()
+
+	store := ingestGaugeSeries(ctx, t, base, []gaugeSeries{
+		{foo: "a", samples: rampSamples(-120*time.Second, 0, 10*time.Second, 1)},
+		{foo: "b", samples: rampSamples(-120*time.Second, 0, 20*time.Second, 50)},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	d := newDiffBackends(ctx, t, store)
+
+	start, end, step := base.Add(-90*time.Second), base, 15*time.Second
+	for _, q := range []string{
+		"count_over_time(ot_gauge[30s])",
+		"sum_over_time(ot_gauge[40s])",
+		"avg_over_time(ot_gauge[30s])",
+		"sum by (foo) (max_over_time(ot_gauge[40s]))",
+	} {
+		t.Run(q, func(t *testing.T) { d.assertRange(t, q, start, end, step) })
+	}
 }

--- a/internal/storagebackend/overtime_test.go
+++ b/internal/storagebackend/overtime_test.go
@@ -1,0 +1,187 @@
+package storagebackend_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/storage"
+
+	otelpromql "github.com/oteldb/oteldb/internal/promql"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// ingestGauge writes a gauge metric "ot_gauge" with one series (foo="bar") carrying the given
+// (offset-from-evalT, value) samples, returning the populated store.
+func ingestGauge(ctx context.Context, t *testing.T, evalT time.Time, samples []timeSample) *storage.Storage {
+	t.Helper()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "test")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("ot_gauge")
+	g := m.SetEmptyGauge()
+	for _, s := range samples {
+		dp := g.DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(evalT.Add(s.offset).UnixNano()))
+		dp.SetDoubleValue(s.value)
+		dp.Attributes().PutStr("foo", "bar")
+	}
+
+	b := storagebackend.New(store)
+	require.NoError(t, b.ConsumeMetrics(ctx, md))
+
+	return store
+}
+
+type timeSample struct {
+	offset time.Duration
+	value  float64
+}
+
+// vecLabels is the sortable label set of a PromQL sample (minus the empty __name__ a range-vector
+// function drops), for deterministic comparison.
+func sortVector(vec promql.Vector) {
+	slices.SortFunc(vec, func(a, b promql.Sample) int {
+		return labels.Compare(a.Metric, b.Metric)
+	})
+}
+
+// TestOverTimePushdownMatchesRaw is the differential oracle for the aggregate pushdown: for every
+// supported *_over_time function, the instant query answered from the aggregate sidecar
+// (WithOverTimePushdown(true), the default) must equal the raw matrix-selector fold
+// (WithOverTimePushdown(false)), including at the window boundary where a sample sits exactly on
+// mint (PromQL's exclusive lower bound).
+func TestOverTimePushdownMatchesRaw(t *testing.T) {
+	ctx := context.Background()
+	evalT := time.Unix(2_000_000, 0).UTC()
+
+	// Samples at -30s, -20s, -10s from evalT. With a 30s range the window is (evalT-30s, evalT],
+	// so the -30s sample is excluded; with a 40s range all three are in.
+	store := ingestGauge(ctx, t, evalT, []timeSample{
+		{-30 * time.Second, 10},
+		{-20 * time.Second, 20},
+		{-10 * time.Second, 30},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	pushdown := storagebackend.New(store)                                        // default: pushdown on
+	raw := storagebackend.New(store, storagebackend.WithOverTimePushdown(false)) // raw fold
+
+	engPushdown, err := otelpromql.New(pushdown, otelpromql.EngineOpts{
+		MaxSamples: 1_000_000, Timeout: time.Minute, LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	engRaw, err := otelpromql.New(raw, otelpromql.EngineOpts{
+		MaxSamples: 1_000_000, Timeout: time.Minute, LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"Count", "count_over_time(ot_gauge[30s])"},
+		{"CountFull", "count_over_time(ot_gauge[40s])"},
+		{"Sum", "sum_over_time(ot_gauge[30s])"},
+		{"Min", "min_over_time(ot_gauge[30s])"},
+		{"Max", "max_over_time(ot_gauge[30s])"},
+		{"Avg", "avg_over_time(ot_gauge[30s])"},
+		{"Present", "present_over_time(ot_gauge[30s])"},
+		{"Filtered", `count_over_time(ot_gauge{foo="bar"}[30s])`},
+		{"NegatedFilter", `count_over_time(ot_gauge{foo!="x"}[30s])`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			a := require.New(t)
+
+			got := execInstant(ctx, t, engPushdown, pushdown, tt.query, evalT)
+			want := execInstant(ctx, t, engRaw, raw, tt.query, evalT)
+
+			sortVector(got)
+			sortVector(want)
+			a.Len(got, len(want), "pushdown and raw must return the same series count")
+			for i := range got {
+				assert.Equal(t, want[i].Metric, got[i].Metric, "series labels mismatch")
+				assert.InDelta(t, want[i].F, got[i].F, 1e-9, "value mismatch for %s", got[i].Metric)
+			}
+		})
+	}
+}
+
+// TestOverTimePushdownExactValues checks the pushdown computes the documented aggregates for known
+// samples, including the exclusive lower-bound window edge (the -30s sample is outside a [30s]
+// window) and the name-drop a range-vector function applies.
+func TestOverTimePushdownExactValues(t *testing.T) {
+	ctx := context.Background()
+	evalT := time.Unix(2_000_000, 0).UTC()
+
+	store := ingestGauge(ctx, t, evalT, []timeSample{
+		{-30 * time.Second, 10},
+		{-20 * time.Second, 20},
+		{-10 * time.Second, 30},
+	})
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := storagebackend.New(store) // pushdown on
+	eng, err := otelpromql.New(b, otelpromql.EngineOpts{
+		MaxSamples: 1_000_000, Timeout: time.Minute, LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		// 30s window excludes the -30s (value 10) sample: in-window values are {20, 30}.
+		{"Count", "count_over_time(ot_gauge[30s])", 2},
+		{"Sum", "sum_over_time(ot_gauge[30s])", 50},
+		{"Min", "min_over_time(ot_gauge[30s])", 20},
+		{"Max", "max_over_time(ot_gauge[30s])", 30},
+		{"Avg", "avg_over_time(ot_gauge[30s])", 25},
+		{"Present", "present_over_time(ot_gauge[30s])", 1},
+		// 40s window includes all three: {10, 20, 30}.
+		{"CountFull", "count_over_time(ot_gauge[40s])", 3},
+		{"SumFull", "sum_over_time(ot_gauge[40s])", 60},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			a := require.New(t)
+
+			vec := execInstant(ctx, t, eng, b, tt.query, evalT)
+			a.Len(vec, 1, "one series")
+			a.Equal(tt.want, vec[0].F)
+			a.Empty(vec[0].Metric.Get("__name__"), "range-vector functions drop the metric name")
+		})
+	}
+}
+
+func execInstant(
+	ctx context.Context, t *testing.T, eng otelpromql.Engine,
+	b *storagebackend.Backend, query string, ts time.Time,
+) promql.Vector {
+	t.Helper()
+
+	q, err := eng.NewInstantQuery(ctx, b, nil, query, ts)
+	require.NoError(t, err)
+	t.Cleanup(q.Close)
+
+	res := q.Exec(ctx)
+	require.NoError(t, res.Err)
+
+	vec, err := res.Vector()
+	require.NoError(t, err)
+
+	return vec
+}

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -44,6 +44,10 @@ type Backend struct {
 	// logParallelism is the max number of workers used to materialize log query results across the
 	// fetched record set. <= 1 keeps the sequential path (the default). See [WithLogParallelism].
 	logParallelism int
+	// overTimePushdown routes instant *_over_time queries through the aggregate-sidecar pushdown
+	// ([storage.Storage.AggregateMetricsNamed]) instead of a raw fetch-and-fold. True by default;
+	// see [WithOverTimePushdown].
+	overTimePushdown bool
 }
 
 // Option configures a [Backend].
@@ -57,11 +61,18 @@ func WithLogParallelism(n int) Option {
 	return func(b *Backend) { b.logParallelism = n }
 }
 
+// WithOverTimePushdown toggles the instant *_over_time aggregate pushdown. It is on by default
+// (the sidecar path is faster and correct); passing false restores the raw matrix-selector path
+// (useful as a fallback or for differential testing).
+func WithOverTimePushdown(enabled bool) Option {
+	return func(b *Backend) { b.overTimePushdown = enabled }
+}
+
 // New returns a Backend over store. The ingest side has no tenant callback, so every batch routes
 // to the "default" tenant; the empty tenant id here normalizes to "default" on the read side,
 // keeping reads and writes on the same tenant (which also makes cluster reads owner-aware).
 func New(store *storage.Storage, opts ...Option) *Backend {
-	b := &Backend{store: store}
+	b := &Backend{store: store, overTimePushdown: true}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -172,6 +183,22 @@ func (s scanners) NewMatrixSelector(
 	node logicalplan.MatrixSelector,
 	call logicalplan.FunctionCall,
 ) (model.VectorOperator, error) {
+	// Instant *_over_time over a supported function: answer from the aggregate sidecar instead of a
+	// raw fetch-and-fold. Range queries keep the matrix selector (their per-step sliding window is a
+	// different shape than the sidecar's step-aligned buckets), and anything with a projection or
+	// post-filter falls back too.
+	if s.b.overTimePushdown && opts.IsInstantQuery() && node.Range > 0 {
+		if fold, ok := overTimeFold[call.Func.Name]; ok {
+			vs := node.VectorSelector
+			if vs.Projection == nil && len(vs.Filters) == 0 {
+				return newAggregateOverTimeOp(
+					s.b.store, s.b.tenant, vs.LabelMatchers, call.Func.Name, fold,
+					opts.Start.UnixMilli(), node.Range.Milliseconds(), vs.Offset.Milliseconds(),
+				), nil
+			}
+		}
+	}
+
 	inner, err := s.windowed(opts, hints)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Implements `docs/storage-integration.md`: wires oteldb to exploit the embedded `github.com/oteldb/storage` engine's performance features. Companion to storage **v0.9.0** (labeled aggregate facade + exported promql projection helpers), which this branch depends on.

## What's in it (commit by commit)

- **`chore(deps)`** — bump `oteldb/storage` to `v0.9.0`, drop the local `replace` directive.
- **`feat(storagebackend)`** — instant `*_over_time` aggregate-sidecar pushdown. Answers `count`/`sum`/`min`/`max`/`avg`/`present_over_time` from the per-series stats sidecar (`Storage.AggregateMetricsNamed`) instead of a raw fetch-and-fold, so a range-covering aggregate costs ~one row per series. Instant-only; range queries, projections/filters, and unsupported functions (rate/increase, quantile/last/first/stddev) fall back to the raw matrix selector. Toggle via `WithOverTimePushdown` (on by default).
- **`feat(oteldb)`** — flip storage caches to **opt-out**: read cache, decode cache, and aggregate-stats sidecar default on, byte caches sized from the Go memory limit, disable via `storage.{read_cache_bytes,decode_cache_bytes,aggregate_stats}`. Add a per-tenant **merge policy** (`storage.policy`): age-tiered lossy float precision, downsampling, and cold-data recompression, resolved for the single embedded tenant via `storage.WithTenancy`.
- **`docs`** — the integration plan + per-section implementation status.
- **`test(storagebackend)`** — validity tests for the pushdown: plan-routing assertions (proving the sidecar operator is actually selected, and falls back where it must) plus a multi-series differential oracle vs. the raw fold across folds, matcher subsets, offsets, downstream aggregation, range queries, and unsupported functions.

## Not included (deferred)

**Sampling weights** (`fetch.Batch.ScaleFactors`): oteldb exposes no `tenant.Sampling` policy yet, so ingest is lossless and every scale factor is `1` — honouring it is a no-op until sampling is configured, and the weight folds differently per function (count vs sum vs rate), so it needs a weight-aware fold rather than a sample-level transform. Tracked in the doc.

## Testing

- `go build ./...`, `golangci-lint run` clean.
- `go test ./cmd/oteldb/ ./internal/storagebackend/` pass, including `-race`.
- Every commit builds independently (verified for bisect/per-commit CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)