### PR TITLE
ci(deploy): only push images on manual workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           context: .
           file: ./dev/deploy/deploy.Dockerfile
-          push: true
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           tags: "${{ env.IMAGE_TAG }}:${{ env.sha }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -86,7 +86,7 @@ jobs:
         with:
           context: .
           file: ./dev/deploy/deploy.generic.Dockerfile
-          push: true
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           tags: "${{ env.IMAGE_TAG }}/proxy:${{ env.sha }}"
           build-args: |
             BINARY=otelproxy
@@ -98,7 +98,7 @@ jobs:
         with:
           context: .
           file: ./dev/deploy/deploy.generic.Dockerfile
-          push: true
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           tags: "${{ env.IMAGE_TAG }}/chotel:${{ env.sha }}"
           build-args: |
             BINARY=chotel


### PR DESCRIPTION
## Problem

The `deploy` workflow triggers on every push to `main` and pushes three images (base, proxy, chotel) to ghcr.io on each commit — even though the actual Kubernetes rollout is disabled (`DEPLOY_BROKEN: true`). This churns the registry on every main push for no benefit.

## Change

Gate the three `docker/build-push-action` steps with `push: ${{ github.event_name == 'workflow_dispatch' }}`. Now:

- **Push to main**: images still build (validating the Dockerfiles) but are **not** pushed.
- **Manual `workflow_dispatch`**: images build and push as before.

`release.yml` (tag-triggered `v*`) is unchanged — release image pushes still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)