### PR TITLE
fix(goreleaser): build odbmigrate binary for release images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,21 @@ builds:
     flags:
       - -trimpath
 
+  - id: odbmigrate
+    binary: "odbmigrate{{ .Ext }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - riscv64
+    main: ./cmd/odbmigrate
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+
   - id: odbagent
     binary: "odbagent{{ .Ext }}"
     env:
@@ -329,6 +344,7 @@ nfpms:
       - chotel
       - odbbackup
       - odbrestore
+      - odbmigrate
       - odbagent
     homepage: https://github.com/oteldb/oteldb
     maintainer: Aleksandr Razumov <ernado@go-faster.org>


### PR DESCRIPTION
## Problem

The latest release pipeline failed in the `goreleaser-release` job:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/linux/arm64/odbmigrate": not found
```

`release.Dockerfile` copies the `odbmigrate` binary into the image:

```dockerfile
COPY $TARGETPLATFORM/odbmigrate /usr/local/bin/odbmigrate
```

but `.goreleaser.yaml` never defined a build for it, so goreleaser produced no `linux/arm64/odbmigrate` artifact and the Docker build failed.

## Fix

- Add the missing `odbmigrate` build entry (linux amd64/arm64/riscv64), matching the other CLI tools.
- Include `odbmigrate` in the `oteldb` nfpms package `ids` so it ships in the deb/rpm/apk packages.

## Verification

- `goreleaser check` passes.
- Cross-compile build for `linux/arm64` succeeds.