### PR TITLE
chore(deps): bump oteldb/storage to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -454,7 +454,7 @@ require (
 	github.com/openshift/api v0.0.0-20251015095338-264e80a2b6e7 // indirect
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
-	github.com/oteldb/storage v0.9.0
+	github.com/oteldb/storage v0.10.0
 	github.com/outscale/osc-sdk-go/v2 v2.34.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.7.0-alpha.0 h1:od3skf7eTPMv+3zR6G3WZl7YVzWJUa8b8yP3XpfIgI4=
 github.com/oteldb/promql-engine v0.7.0-alpha.0/go.mod h1:j3kBzxEWSsdIinLTl7ogVolJbI2GC/fa1GU4/NpOr0k=
-github.com/oteldb/storage v0.9.0 h1:YjP/MpsZnibnx/3WmhvCjssmVcepKD7GmwmFM5yBJkE=
-github.com/oteldb/storage v0.9.0/go.mod h1:Op/tbqwo6j2BKK5ItmVu7I5NB44I+ojpz7wh7VAQNvM=
+github.com/oteldb/storage v0.10.0 h1:zvIy78JksJFFg/vddYuyNiHtyrbCbcHUO6jXwHwEtnU=
+github.com/oteldb/storage v0.10.0/go.mod h1:uQ+1YV7qxR3YX9LTSD9p4Ro/UIeDK/Jrqw3UVuxcNv4=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=


### PR DESCRIPTION
Bumps `github.com/oteldb/storage` from v0.9.0 to v0.10.0.

`go build ./cmd/oteldb` passes and `go mod tidy` is clean.