### PR TITLE
feat(oteldb): allow configuring S3 backend for embedded storage

### DIFF
--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -97,10 +97,18 @@ const (
 // StorageConfig configures the embedded storage engine (used when
 // [Config.MetricsBackend] is "storage").
 type StorageConfig struct {
-	// Backend is the engine backend: "memory" (default, ephemeral) or "file".
+	// Backend is the engine backend: "memory" (default, ephemeral), "file", or "s3".
 	Backend string `json:"backend" yaml:"backend"`
 	// Dir is the data directory for the file backend (parts and WAL).
 	Dir string `json:"dir" yaml:"dir"`
+	// WALDir is the local directory for the write-ahead log when the backend is the (stateless) "s3"
+	// object store, so unflushed head data survives a restart. Empty ⇒ no WAL (recent, unflushed
+	// writes are lost on an unclean restart). Ignored for the "file" backend, which keeps its WAL
+	// alongside the parts in Dir.
+	WALDir string `json:"wal_dir" yaml:"wal_dir"`
+	// S3 configures the "s3" object-store backend. Required (with a non-empty Bucket) when Backend is
+	// "s3"; ignored otherwise.
+	S3 *StorageS3Config `json:"s3" yaml:"s3"`
 	// FlushInterval is the max age of unflushed head data before it is flushed to a part.
 	// Zero uses the engine default. Ignored for the ephemeral memory backend.
 	FlushInterval time.Duration `json:"flush_interval" yaml:"flush_interval"`
@@ -151,6 +159,34 @@ type StorageClusterConfig struct {
 	ShardsPerTenant int `json:"shards_per_tenant" yaml:"shards_per_tenant"`
 	// Root is the etcd key prefix for this cluster's state. Empty ⇒ "/oteldb".
 	Root string `json:"root" yaml:"root"`
+}
+
+// StorageS3Config configures the embedded storage engine's "s3" backend: an S3-compatible object
+// store as the durable, stateless tier (the read path is reconstructed from objects). It maps onto
+// storage's backend/s3.
+type StorageS3Config struct {
+	// Bucket is the S3 bucket holding the data. Required for the s3 backend.
+	Bucket string `json:"bucket" yaml:"bucket"`
+	// Prefix is an optional root key prefix (e.g. "oteldb/") so several datasets can share one
+	// bucket. Empty ⇒ keys live at the bucket root.
+	Prefix string `json:"prefix" yaml:"prefix"`
+	// Region is the AWS region. Empty ⇒ resolved from the environment/credential chain.
+	Region string `json:"region" yaml:"region"`
+	// Endpoint overrides the S3 endpoint URL for S3-compatible stores (e.g. MinIO,
+	// "http://minio:9000"). Empty ⇒ the AWS default endpoint for the region.
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	// ForcePathStyle addresses objects as endpoint/bucket/key instead of the virtual-host style.
+	// Required by most S3-compatible stores (MinIO, Ceph).
+	ForcePathStyle bool `json:"force_path_style" yaml:"force_path_style"`
+	// AccessKeyID and SecretAccessKey are static credentials. When both are empty, the default AWS
+	// credential chain (environment, shared config, IAM role) is used instead.
+	AccessKeyID     string `json:"access_key_id" yaml:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key" yaml:"secret_access_key"`
+	// SessionToken is an optional token for temporary static credentials.
+	SessionToken string `json:"session_token" yaml:"session_token"`
+	// Retry selects the resilience profile for an unreliable endpoint (per-attempt timeouts, bounded
+	// retries, hedged GETs): "" or "none" (the AWS SDK's own retryer only), "default", or "lossy".
+	Retry string `json:"retry" yaml:"retry"`
 }
 
 func (cfg *StorageConfig) setDefaults() {

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -10,6 +10,10 @@ import (
 	"runtime/debug"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/app"
 	"go.uber.org/zap"
@@ -17,8 +21,10 @@ import (
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/backend"
 	backendfile "github.com/oteldb/storage/backend/file"
+	backends3 "github.com/oteldb/storage/backend/s3"
 	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/cluster/etcd"
+	"github.com/oteldb/storage/reliability"
 
 	"github.com/oteldb/oteldb/internal/storagebackend"
 	"github.com/oteldb/oteldb/internal/xbytes"
@@ -54,6 +60,20 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 			storage.WithBackend(fb),
 			storage.WithWALDir(filepath.Join(cfg.Dir, "wal")),
 		)
+		if cfg.FlushInterval > 0 {
+			opts = append(opts, storage.WithFlushInterval(int64(cfg.FlushInterval)))
+		}
+	case "s3":
+		sb, err := s3Backend(ctx, cfg.S3)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "open s3 backend")
+		}
+		opts = append(opts, storage.WithBackend(sb))
+		// The object store is stateless; keep an optional local WAL so the unflushed head survives a
+		// restart rather than only the flushed objects.
+		if cfg.WALDir != "" {
+			opts = append(opts, storage.WithWALDir(cfg.WALDir))
+		}
 		if cfg.FlushInterval > 0 {
 			opts = append(opts, storage.WithFlushInterval(int64(cfg.FlushInterval)))
 		}
@@ -140,6 +160,51 @@ func clusterOption(cfg *StorageClusterConfig, lg *zap.Logger) (storage.Option, e
 		ShardsPerTenant: cfg.ShardsPerTenant,
 		Root:            cfg.Root,
 	}), nil
+}
+
+// s3Backend builds the embedded storage engine's S3 object-store backend from the config. It uses
+// static credentials when both keys are set, otherwise the default AWS credential chain
+// (environment, shared config, IAM role), and applies the requested resilience profile.
+func s3Backend(ctx context.Context, cfg *StorageS3Config) (backend.Backend, error) {
+	if cfg == nil || cfg.Bucket == "" {
+		return nil, errors.New("storage.s3.bucket is required for the s3 backend")
+	}
+
+	o := awss3.Options{
+		Region:       cfg.Region,
+		UsePathStyle: cfg.ForcePathStyle,
+	}
+	if cfg.Endpoint != "" {
+		o.BaseEndpoint = aws.String(cfg.Endpoint)
+	}
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		o.Credentials = credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken)
+	} else {
+		// Fall back to the default chain (env, shared config, IAM role); resolved lazily on first use.
+		awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "load aws config")
+		}
+		o.Credentials = awsCfg.Credentials
+		if o.Region == "" {
+			o.Region = awsCfg.Region
+		}
+	}
+
+	var s3Opts []backends3.Option
+	switch cfg.Retry {
+	case "", "none":
+		// No extra resilience layer; the AWS SDK's own retryer still applies.
+	case "default":
+		s3Opts = append(s3Opts, backends3.WithRetry(reliability.Default()))
+	case "lossy":
+		s3Opts = append(s3Opts, backends3.WithRetry(reliability.LossyEnvironment()))
+	default:
+		return nil, errors.Errorf("unknown s3 retry profile %q", cfg.Retry)
+	}
+
+	store := backends3.NewAWS(awss3.New(o), cfg.Bucket)
+	return backends3.New(store, cfg.Prefix, s3Opts...), nil
 }
 
 // cacheSettings is the resolved, effective cache/optimization configuration that oteldb applies to

--- a/cmd/oteldb/storage_backend_test.go
+++ b/cmd/oteldb/storage_backend_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -208,6 +209,88 @@ storage:
 	require.Equal(t, signal.AggAvg, p.Downsample.Tiers[0].Agg)
 	require.Equal(t, 336*time.Hour, p.Recompress.After)
 	require.Equal(t, 9, p.Recompress.Level)
+}
+
+func TestS3Backend(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("RequiresBucket", func(t *testing.T) {
+		_, err := s3Backend(ctx, nil)
+		require.Error(t, err)
+
+		_, err = s3Backend(ctx, &StorageS3Config{Region: "us-east-1"}) // no bucket
+		require.Error(t, err)
+	})
+
+	t.Run("StaticCredentials", func(t *testing.T) {
+		b, err := s3Backend(ctx, &StorageS3Config{
+			Bucket:          "oteldb",
+			Prefix:          "data/",
+			Region:          "us-east-1",
+			Endpoint:        "http://minio:9000",
+			ForcePathStyle:  true,
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		require.False(t, b.IsEphemeral())
+	})
+
+	t.Run("UnknownRetryProfile", func(t *testing.T) {
+		_, err := s3Backend(ctx, &StorageS3Config{Bucket: "oteldb", AccessKeyID: "k", SecretAccessKey: "s", Retry: "bogus"})
+		require.Error(t, err)
+	})
+
+	t.Run("RetryProfiles", func(t *testing.T) {
+		for _, profile := range []string{"", "none", "default", "lossy"} {
+			b, err := s3Backend(ctx, &StorageS3Config{Bucket: "oteldb", AccessKeyID: "k", SecretAccessKey: "s", Retry: profile})
+			require.NoError(t, err, "profile %q", profile)
+			require.NotNil(t, b)
+		}
+	})
+}
+
+// TestStorageS3ConfigYAML checks the s3 block parses from the documented YAML shape via the real
+// config loader.
+func TestStorageS3ConfigYAML(t *testing.T) {
+	const data = `
+storage:
+  backend: s3
+  wal_dir: /var/lib/oteldb/wal
+  s3:
+    bucket: oteldb
+    prefix: data/
+    region: us-east-1
+    endpoint: http://minio:9000
+    force_path_style: true
+    access_key_id: key
+    secret_access_key: secret
+    session_token: token
+    retry: lossy
+`
+	f, err := os.CreateTemp("", "oteldb.yml")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(f.Name()) }()
+	_, err = f.WriteString(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cfg, err := loadConfig(f.Name())
+	require.NoError(t, err)
+
+	require.Equal(t, "s3", cfg.Storage.Backend)
+	require.Equal(t, "/var/lib/oteldb/wal", cfg.Storage.WALDir)
+	require.NotNil(t, cfg.Storage.S3)
+	require.Equal(t, "oteldb", cfg.Storage.S3.Bucket)
+	require.Equal(t, "data/", cfg.Storage.S3.Prefix)
+	require.Equal(t, "us-east-1", cfg.Storage.S3.Region)
+	require.Equal(t, "http://minio:9000", cfg.Storage.S3.Endpoint)
+	require.True(t, cfg.Storage.S3.ForcePathStyle)
+	require.Equal(t, "key", cfg.Storage.S3.AccessKeyID)
+	require.Equal(t, "secret", cfg.Storage.S3.SecretAccessKey)
+	require.Equal(t, "token", cfg.Storage.S3.SessionToken)
+	require.Equal(t, "lossy", cfg.Storage.S3.Retry)
 }
 
 func TestResolveCacheSettings(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/VictoriaMetrics/VictoriaMetrics v1.141.0
 	github.com/VictoriaMetrics/easyproto v1.2.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cheggaaa/pb/v3 v3.1.7
@@ -159,6 +160,9 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic v0.7.1 // indirect
@@ -219,9 +223,9 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.25
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect


### PR DESCRIPTION
## Summary

Exposes the `github.com/oteldb/storage` library's S3 object-store backend through oteldb's config. The storage library already shipped a complete `backend/s3` implementation; this wires it into oteldb so the embedded engine can use an S3-compatible object store as its durable, stateless tier (the read path is reconstructed from objects).

Set `storage.backend: s3` with a `storage.s3` block:

```yaml
storage:
  backend: s3
  wal_dir: /var/lib/oteldb/wal   # optional local WAL so the unflushed head survives a restart
  s3:
    bucket: oteldb
    region: us-east-1
    endpoint: http://minio:9000   # optional, for S3-compatible stores (MinIO/Ceph)
    force_path_style: true
    access_key_id: ...            # optional; omit to use the default AWS credential chain
    secret_access_key: ...
    retry: lossy                  # "" / none / default / lossy
```

## Changes

- **`config.go`** — `Backend` now accepts `"s3"`; new optional `WALDir` (stateless object store keeps no local state, so a local WAL preserves unflushed writes across restarts) and `S3 *StorageS3Config` block (`bucket`, `prefix`, `region`, `endpoint`, `force_path_style`, `access_key_id`/`secret_access_key`/`session_token`, `retry`).
- **`storage_backend.go`** — `case "s3"` in the backend switch; new `s3Backend(ctx, cfg)` builds an aws-sdk-go-v2 S3 client. Uses static credentials when both keys are set, otherwise the default AWS credential chain (env / shared config / IAM role). Maps the retry profile onto `reliability.Default()` / `LossyEnvironment()`, then composes `s3.NewAWS` + `s3.New`.
- **`storage_backend_test.go`** — `TestS3Backend` (bucket validation, static-cred construction, unknown-retry error, all retry profiles) and `TestStorageS3ConfigYAML` (round-trips the documented YAML through the real config loader).
- **`go.mod`** — promotes `aws-sdk-go-v2`, `.../config`, `.../credentials`, `.../service/s3` to direct deps.

## Testing

- `go build ./cmd/oteldb/` ✅
- `go vet ./cmd/oteldb/` ✅
- `go test ./cmd/oteldb/` ✅
- `golangci-lint run ./cmd/oteldb/` — 0 issues ✅

## Notes

No issue number was provided, so the branch is named descriptively. Documentation lives in the struct doc comments, consistent with the existing `file` / `cluster` / `policy` blocks.