### PR TITLE
feat(traceql): implement descendant (>>) spanset operator

### DIFF
--- a/internal/traceql/traceqlengine/spanset_op.go
+++ b/internal/traceql/traceqlengine/spanset_op.go
@@ -1,8 +1,6 @@
 package traceqlengine
 
 import (
-	"fmt"
-
 	"github.com/go-faster/errors"
 
 	"github.com/oteldb/oteldb/internal/otelstorage"
@@ -76,7 +74,15 @@ func buildSpansetOp(op traceql.SpansetOp) (SpansetOp, error) {
 			return siblingSpans(a[0], b[0]), nil
 		}, nil
 	case traceql.SpansetOpDescendant:
-		return nil, &UnsupportedError{Msg: fmt.Sprintf("unsupported spanset op %q", op)}
+		return func(a, b []Spanset) (result []tracestorage.Span, _ error) {
+			if len(a) == 0 && len(b) == 0 {
+				return nil, nil
+			}
+			if len(a) != 1 && len(b) != 1 {
+				return nil, errors.New("can't find descendant spans of multiple spansets at once, try to use coalesce()")
+			}
+			return descendantSpans(a[0], b[0]), nil
+		}, nil
 	default:
 		return nil, errors.Errorf("unexpected spanset op %q", op)
 	}
@@ -127,6 +133,47 @@ func mergeSpans(left, right []Spanset) []tracestorage.Span {
 	}
 
 	return m.result
+}
+
+// descendantSpans returns the spans of right that are transitive descendants of
+// any span in left — the `>>` operator, the transitive closure of childSpans. It
+// walks each right span's parent chain (resolved from the parent links of the
+// spans available in left+right) until it reaches a left span or the root.
+func descendantSpans(left, right Spanset) []tracestorage.Span {
+	leftIDs := map[otelstorage.SpanID]struct{}{}
+	for _, span := range left.Spans {
+		leftIDs[span.SpanID] = struct{}{}
+	}
+	// Parent links of every span we can see, to walk ancestor chains across
+	// intermediate spans that may sit between a left ancestor and a right span.
+	parentOf := make(map[otelstorage.SpanID]otelstorage.SpanID, len(left.Spans)+len(right.Spans))
+	for _, span := range left.Spans {
+		parentOf[span.SpanID] = span.ParentSpanID
+	}
+	for _, span := range right.Spans {
+		parentOf[span.SpanID] = span.ParentSpanID
+	}
+
+	m := spanMerger{}
+	for _, span := range right.Spans {
+		seen := map[otelstorage.SpanID]struct{}{}
+		for cur := span.ParentSpanID; !cur.IsEmpty(); {
+			if _, ok := seen[cur]; ok {
+				break // guard against malformed cyclic parent links
+			}
+			seen[cur] = struct{}{}
+			if _, ok := leftIDs[cur]; ok {
+				m.Add(span)
+				break
+			}
+			next, ok := parentOf[cur]
+			if !ok {
+				break
+			}
+			cur = next
+		}
+	}
+	return m.Result()
 }
 
 func childSpans(left, right Spanset) []tracestorage.Span {

--- a/internal/traceql/traceqlengine/spanset_op_test.go
+++ b/internal/traceql/traceqlengine/spanset_op_test.go
@@ -106,6 +106,87 @@ func TestChildSpans(t *testing.T) {
 	}
 }
 
+func TestDescendantSpans(t *testing.T) {
+	tests := []struct {
+		left, right []spanIDs
+		wantResult  []uint64
+	}{
+		{
+			nil,
+			nil,
+			nil,
+		},
+		// Transitive: grandchildren count too. 6's parent (4) is not in left, but 4
+		// descends from 2, so 6 is a descendant of 2 — unlike `>` (childSpans), which
+		// would omit 6.
+		{
+			[]spanIDs{
+				{id: 1},
+				{id: 2},
+				{id: 3},
+			},
+			[]spanIDs{
+				{id: 1},
+				{id: 4, parent: 2},
+				{id: 5, parent: 3},
+				{id: 6, parent: 4},
+				{id: 7, parent: 3},
+			},
+			[]uint64{
+				4, 5, 6, 7,
+			},
+		},
+		// A deep chain whose intermediate spans live only in right: every link descends
+		// from the single left ancestor.
+		{
+			[]spanIDs{
+				{id: 1},
+			},
+			[]spanIDs{
+				{id: 2, parent: 1},
+				{id: 3, parent: 2},
+				{id: 4, parent: 3},
+			},
+			[]uint64{
+				2, 3, 4,
+			},
+		},
+		// No span descends from any left span.
+		{
+			[]spanIDs{
+				{id: 1},
+				{id: 2},
+				{id: 3},
+			},
+			[]spanIDs{
+				{id: 4, parent: 11},
+				{id: 5, parent: 12},
+				{id: 6, parent: 13},
+			},
+			nil,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {
+			result := descendantSpans(
+				Spanset{
+					Spans: generateSpans(tt.left, "left"),
+				},
+				Spanset{
+					Spans: generateSpans(tt.right, "right"),
+				},
+			)
+
+			var got []uint64
+			for _, span := range result {
+				got = append(got, span.SpanID.AsUint64())
+			}
+			slices.Sort(got)
+			require.Equal(t, tt.wantResult, got)
+		})
+	}
+}
+
 func TestSiblingSpans(t *testing.T) {
 	tests := []struct {
 		left, right []spanIDs


### PR DESCRIPTION
## Summary

Implements the TraceQL structural **descendant operator `>>`**, which previously returned `UnsupportedError`.

`a >> b` selects spans in `b` that are transitive descendants of any span in `a` — the transitive closure of the child operator `>`. `descendantSpans` walks each right span's parent chain (resolved from the parent links of spans available across `left + right`) until it reaches a left span (match) or the root (no match), with a guard against malformed cyclic parent links.

This complements the existing `>` (child), `~` (sibling), and `&&`/`||`/`!` spanset operators.

## Changes

- `internal/traceql/traceqlengine/spanset_op.go` — wire the `SpansetOpDescendant` case to a new `descendantSpans` helper (and drop the now-unused `fmt` import).
- `internal/traceql/traceqlengine/spanset_op_test.go` — `TestDescendantSpans` covering:
  - transitive grandchildren (a case `>` would omit),
  - a deep chain whose intermediate spans live only in the right spanset,
  - the no-common-ancestor case.

## Testing

- `go test ./internal/traceql/traceqlengine/` ✅ (new + existing spanset-op tests pass)
- `golangci-lint run ./internal/traceql/traceqlengine/` — 0 issues ✅