### PR TITLE
perf(storagebackend): intern series labels for the Backend lifetime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.155.0
 	github.com/oteldb/promql-engine v0.8.0
-	github.com/oteldb/storage v0.22.0
+	github.com/oteldb/storage v0.24.0
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0
@@ -626,5 +626,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-replace github.com/oteldb/storage => /src/oteldb/storage

--- a/go.sum
+++ b/go.sum
@@ -1022,6 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.8.0 h1:F1ly0wIZylr7rG7cSZmGl7vkpJ0KunEoz+Qxhr0+FJU=
 github.com/oteldb/promql-engine v0.8.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
+github.com/oteldb/storage v0.24.0 h1:5zOq53eWbFP+6Yy2CD03E8bb4UhgYL1f31WD7EHIp9k=
+github.com/oteldb/storage v0.24.0/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/storagebackend/labelcache_internal_test.go
+++ b/internal/storagebackend/labelcache_internal_test.go
@@ -1,0 +1,69 @@
+package storagebackend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/storage"
+)
+
+// TestBackendLabelCacheSharedAcrossQueries is a white-box check that the Backend-lifetime label
+// cache (b.labels) interns each series' projection once and reuses it on later queries, instead of
+// rebuilding it per query. It guards the fix for the per-query labelCache churn (#1118).
+func TestBackendLabelCacheSharedAcrossQueries(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := New(store)
+	require.Zero(t, b.labels.Len(), "cache starts empty")
+
+	ts := time.Now().Truncate(time.Second)
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "test")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	for _, route := range []string{"a", "b", "c"} {
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("test_metric")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		dp.SetDoubleValue(1)
+		dp.Attributes().PutStr("route", route)
+	}
+	require.NoError(t, b.ConsumeMetrics(ctx, md))
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric")
+	require.NoError(t, err)
+
+	// selectAll drives one query through a fresh querier (fresh fetcher) sharing b.labels.
+	selectAll := func() int {
+		q, err := b.Querier(ts.Add(-time.Hour).UnixMilli(), ts.Add(time.Hour).UnixMilli())
+		require.NoError(t, err)
+		defer func() { _ = q.Close() }()
+
+		ss := q.Select(ctx, true, nil, matcher)
+		n := 0
+		for ss.Next() {
+			ss.At().Labels() // force projection through the cache.
+			n++
+		}
+		require.NoError(t, ss.Err())
+
+		return n
+	}
+
+	require.Equal(t, 3, selectAll(), "three series match")
+	require.Equal(t, 3, b.labels.Len(), "each series interned once")
+
+	require.Equal(t, 3, selectAll(), "second query, same series")
+	require.Equal(t, 3, b.labels.Len(), "no rebuild: cache reused across queries")
+}

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -48,6 +48,12 @@ type Backend struct {
 	// ([storage.Storage.AggregateMetricsNamed]) instead of a raw fetch-and-fold. True by default;
 	// see [WithOverTimePushdown].
 	overTimePushdown bool
+	// labels interns series→Prometheus-label projections for the Backend's lifetime. Each query takes
+	// a fresh fetcher (to observe the latest head) but shares this cache, so the pointer-rich
+	// labels.Labels set is built once per series and reused across queries instead of rebuilt and
+	// re-scanned by GC every query. The cache is keyed by content-addressed series id, so an entry is
+	// valid for the life of the series; it is bounded by resident cardinality.
+	labels *storagepromql.LabelCache
 }
 
 // Option configures a [Backend].
@@ -72,7 +78,7 @@ func WithOverTimePushdown(enabled bool) Option {
 // to the "default" tenant; the empty tenant id here normalizes to "default" on the read side,
 // keeping reads and writes on the same tenant (which also makes cluster reads owner-aware).
 func New(store *storage.Storage, opts ...Option) *Backend {
-	b := &Backend{store: store, overTimePushdown: true}
+	b := &Backend{store: store, overTimePushdown: true, labels: storagepromql.NewLabelCache()}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -80,14 +86,16 @@ func New(store *storage.Storage, opts ...Option) *Backend {
 }
 
 // queryable builds a fresh Prometheus queryable over the engine's current data. A new
-// fetcher is taken per query so reads observe the latest head and flushed parts.
+// fetcher is taken per query so reads observe the latest head and flushed parts, but the
+// Backend-lifetime label cache (b.labels) is shared across queries so series label projections are
+// interned once instead of rebuilt and GC-rescanned every query.
 //
 // The fetcher is scoped to b.tenant (a named tenant, "" ⇒ "default") rather than the no-arg
 // cross-tenant form: in cluster mode a named tenant is served owner-aware (fanned out to the ring
 // owners), whereas the no-arg form reads only tenants local to this node — so a query node that does
 // not own the tenant would see nothing. The record signals already scope by b.tenant the same way.
 func (b *Backend) queryable() *storagepromql.Queryable {
-	return storagepromql.NewQueryable(b.store.Fetcher(b.tenant), b.tenant)
+	return storagepromql.NewQueryableWithCache(b.store.Fetcher(b.tenant), b.tenant, b.labels)
 }
 
 // Querier implements storage.Queryable.


### PR DESCRIPTION
`Backend.queryable()` built a fresh `storagepromql.Queryable` per query, so its label cache was discarded every query and ~140k pointer-rich `labels.Labels` were rebuilt and re-scanned by GC on each PromQL request — pure tax under `GOMEMLIMIT=1GiB`, where the process is already ~80% GC.

This holds a Backend-lifetime `storagepromql.LabelCache` and injects it into each per-query Queryable via `NewQueryableWithCache`: a fresh fetcher still observes the latest head, but label projections are built once per series and reused across queries. The cache is keyed by content-addressed series id, so entries stay valid; it is bounded by resident cardinality.

Builds on the storage-side API (`NewQueryableWithCache`), merged in oteldb/storage#65 and **released as v0.24.0** — this PR bumps the dependency and drops the local `replace` directive.

White-box test `TestBackendLabelCacheSharedAcrossQueries` asserts the cache interns once and is reused across queries.

Closes #1118