### PR TITLE
perf(storagebackend): push range-vector *_over_time down per step

### DIFF
--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -65,12 +65,26 @@ the seam oteldb's pushdown path sits on:
 So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `MatchesAll` re-check →
 `PromLabels` to render the vector — all using the library's own translation.
 
-> **Implemented** in `internal/storagebackend/overtime.go` (`aggregateOverTimeOp`, a
-> `model.VectorOperator`) wired through `scanners.NewMatrixSelector`. It is **instant-only**: a
-> range query keeps the raw matrix selector (its per-step sliding window is a different shape than
-> the sidecar's step-aligned buckets), as do selectors carrying a projection or post-filter.
-> Covered folds: `count`/`sum`/`min`/`max`/`avg`/`present_over_time` (`overTimeFold`); everything
-> else falls back. Toggle with `WithOverTimePushdown` (on by default).
+> **Implemented** for both **instant** and **range** queries, wired through
+> `scanners.NewMatrixSelector`:
+> - Instant: `aggregateOverTimeOp` (`internal/storagebackend/overtime.go`) folds one
+>   `AggregateMetricsNamed` over the single eval window.
+> - Range: `aggregateOverTimeRangeOp` (`internal/storagebackend/overtime_range.go`) folds one
+>   aggregate per `(series, step)` over each step's exact sliding window `(t-range, t]` — the same
+>   window the matrix selector uses — and streams the per-step vectors, so it holds `O(result)`
+>   instead of materializing every raw sample in every window. The storage engine still applies its
+>   own sidecar/decode fast paths (and decode cache) per window; folding one aggregate per part per
+>   step in a single decode pass (rather than re-decoding overlapping windows) is a follow-up.
+>
+> Both paths fall back to the raw matrix selector for selectors carrying a projection, per-series
+> filter, or `@` modifier, and for folds the sidecar cannot answer. Covered folds:
+> `count`/`sum`/`min`/`max`/`avg`/`present_over_time` (`overTimeFold`). Toggle with
+> `WithOverTimePushdown` (on by default). Correctness is pinned by the differential oracle
+> (`TestOverTimePushdownRangeMatchesRaw`): pushdown-on vs the raw fold must produce an identical
+> matrix across folds, matchers, offsets, and window/step combinations.
+>
+> `rate`/`increase` still need a richer sidecar (per-bucket first+last value + counter-reset count)
+> and remain on the matrix selector — tracked as the #1117 follow-up.
 
 ## Other touch points
 

--- a/internal/storagebackend/overtime_range.go
+++ b/internal/storagebackend/overtime_range.go
@@ -1,0 +1,225 @@
+package storagebackend
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/oteldb/promql-engine/execution/model"
+	"github.com/oteldb/promql-engine/extlabels"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/engine"
+	"github.com/oteldb/storage/query/fetch"
+	storagepromql "github.com/oteldb/storage/query/promql"
+	"github.com/oteldb/storage/signal"
+)
+
+// aggregateOverTimeRangeOp answers a range-vector *_over_time query (the reducer family: count/sum/
+// min/max/avg/present) from the aggregate-sidecar pushdown instead of the raw matrix selector. It is
+// the range analog of [aggregateOverTimeOp]: where the matrix selector materializes every raw
+// sample in every step's sliding window (buffering the whole window set live), this folds one
+// [engine.SeriesAgg] per (series, step) via [storage.Storage.AggregateMetricsNamed] and streams the
+// per-step result vectors — holding only O(result) rather than O(all raw samples in range).
+//
+// Each PromQL step t_i is evaluated over its exact sliding window (t_i - offset - range, t_i -
+// offset], the same window the matrix selector uses, so the result is identical; the storage engine
+// applies its own sidecar/decode fast paths (and decode cache) per window.
+//
+// Only pushed down for the sidecar-answerable folds and a plain selector (no projection, per-series
+// filter, or @ modifier); rate/increase/quantile/… and anything else fall back to the matrix
+// selector. See [scanners.NewMatrixSelector].
+type aggregateOverTimeRangeOp struct {
+	store    *storage.Storage
+	tenant   signal.TenantID
+	matchers []*labels.Matcher
+	fold     func(engine.SeriesAgg) float64
+	fnName   string
+
+	// Query grid, in milliseconds. Steps are start, start+step, …, ≤ end.
+	start, end int64
+	step       int64
+	rangeMs    int64
+	offset     int64
+	numSteps   int // per-batch step cap (opts.NumStepsPerBatch()).
+
+	loaded  bool
+	loadErr error
+	// series is the union of series appearing in any step, index-aligned with the SampleIDs emitted
+	// in the step vectors.
+	series []labels.Labels
+	// stepTimes[i] is the i-th step's timestamp; stepVals[i] its (SampleID, value) pairs.
+	stepTimes []int64
+	stepVals  [][]sampleVal
+
+	nextIdx int // emission cursor into stepTimes/stepVals.
+}
+
+// sampleVal is one series' folded value at a step, addressed by its index into series.
+type sampleVal struct {
+	id  uint64
+	val float64
+}
+
+func newAggregateOverTimeRangeOp(
+	store *storage.Storage,
+	tenant signal.TenantID,
+	matchers []*labels.Matcher,
+	fnName string,
+	fold func(engine.SeriesAgg) float64,
+	start, end, step, rangeMs, offset int64,
+	numSteps int,
+) *aggregateOverTimeRangeOp {
+	return &aggregateOverTimeRangeOp{
+		store:    store,
+		tenant:   tenant,
+		matchers: matchers,
+		fold:     fold,
+		fnName:   fnName,
+		start:    start,
+		end:      end,
+		step:     step,
+		rangeMs:  rangeMs,
+		offset:   offset,
+		numSteps: numSteps,
+	}
+}
+
+func (o *aggregateOverTimeRangeOp) String() string {
+	return fmt.Sprintf("[storagebackend.aggregateOverTimeRangeOp] %s({%v}[%s]) step=%s",
+		o.fnName, o.matchers, time.Duration(o.rangeMs)*time.Millisecond, time.Duration(o.step)*time.Millisecond)
+}
+
+func (o *aggregateOverTimeRangeOp) Explain() []model.VectorOperator { return nil }
+
+func (o *aggregateOverTimeRangeOp) Series(ctx context.Context) ([]labels.Labels, error) {
+	if err := o.load(ctx); err != nil {
+		return nil, err
+	}
+
+	return o.series, nil
+}
+
+func (o *aggregateOverTimeRangeOp) Next(ctx context.Context, buf []model.StepVector) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
+	if err := o.load(ctx); err != nil {
+		return 0, err
+	}
+
+	if o.nextIdx >= len(o.stepTimes) || len(buf) == 0 {
+		return 0, nil
+	}
+
+	maxSteps := len(buf)
+	if o.numSteps > 0 && o.numSteps < maxSteps {
+		maxSteps = o.numSteps
+	}
+
+	n := 0
+	for n < maxSteps && o.nextIdx < len(o.stepTimes) {
+		buf[n].Reset(o.stepTimes[o.nextIdx])
+		vals := o.stepVals[o.nextIdx]
+		for _, sv := range vals {
+			buf[n].AppendSampleWithSizeHint(sv.id, sv.val, len(vals))
+		}
+		n++
+		o.nextIdx++
+	}
+
+	return n, nil
+}
+
+// load folds every step's window once, building the union series set and the per-step values. It
+// runs at most once; the [model.VectorOperator] contract calls Series before Next, and Next may be
+// called concurrently only after Series, so a plain guard (not sync.Once) suffices as the engine
+// drives a single operator sequentially.
+func (o *aggregateOverTimeRangeOp) load(ctx context.Context) error {
+	if o.loaded {
+		return o.loadErr
+	}
+	o.loadErr = o.doLoad(ctx)
+	o.loaded = true
+
+	return o.loadErr
+}
+
+func (o *aggregateOverTimeRangeOp) doLoad(ctx context.Context) error {
+	const nsPerMs = int64(time.Millisecond)
+
+	// index maps a storage series identity to its stable SampleID (index into o.series). Keying by
+	// content-addressed id — not the projected label set — keeps two series that project to the same
+	// PromQL labels distinct, matching the matrix selector (one scanner per storage series).
+	index := make(map[signal.SeriesID]uint64)
+	var b labels.ScratchBuilder
+
+	// Pre-size the step slices; the number of eval steps is fixed by the query grid.
+	if o.step > 0 && o.end >= o.start {
+		steps := int((o.end-o.start)/o.step) + 1
+		o.stepTimes = make([]int64, 0, steps)
+		o.stepVals = make([][]sampleVal, 0, steps)
+	}
+
+	for evalT := o.start; evalT <= o.end; evalT += o.step {
+		// PromQL evaluates the range vector over (maxt-range, maxt], the same window the matrix
+		// selector uses; storage's fetch window is the inclusive [start, end] ns range, so the
+		// exclusive lower bound is mint+1 ms.
+		maxt := evalT - o.offset
+		mint := maxt - o.rangeMs
+
+		aggs, err := o.store.AggregateMetricsNamed(ctx, o.tenant, fetch.Request{
+			Tenant:   o.tenant,
+			Start:    (mint + 1) * nsPerMs,
+			End:      maxt * nsPerMs,
+			Matchers: storagepromql.PushableMatchers(o.matchers),
+		})
+		if err != nil {
+			return errors.Wrap(err, "aggregate metrics")
+		}
+
+		var vals []sampleVal
+		for i := range aggs {
+			la := &aggs[i]
+
+			lset := storagepromql.PromLabels(la.Series)
+			if !storagepromql.MatchesAll(lset, o.matchers) {
+				continue
+			}
+
+			v := o.fold(la.SeriesAgg)
+			if math.IsNaN(v) {
+				continue
+			}
+
+			key := la.Series.Hash()
+			id, ok := index[key]
+			if !ok {
+				id = uint64(len(o.series))
+				index[key] = id
+
+				// Range-vector functions drop the metric name (and the other schema metadata labels).
+				dropped := extlabels.DropReserved(lset, b)
+				b.Reset()
+				o.series = append(o.series, dropped)
+			}
+
+			vals = append(vals, sampleVal{id: id, val: v})
+		}
+
+		o.stepTimes = append(o.stepTimes, evalT)
+		o.stepVals = append(o.stepVals, vals)
+
+		if o.step <= 0 { // instant guard: avoid an infinite loop if misconstructed.
+			break
+		}
+	}
+
+	return nil
+}

--- a/internal/storagebackend/overtime_test.go
+++ b/internal/storagebackend/overtime_test.go
@@ -2,6 +2,7 @@ package storagebackend_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"slices"
 	"sort"
@@ -352,6 +353,11 @@ func instantPlan(
 // query plan (see aggregateOverTimeOp.String).
 const planOpName = "aggregateOverTimeOp"
 
+// rangePlanOpName is the operator-name fragment the range aggregate-pushdown operator reports (see
+// aggregateOverTimeRangeOp.String). It is distinct from planOpName ("aggregateOverTimeOp" is not a
+// substring of "aggregateOverTimeRangeOp"), so the two paths are matched independently.
+const rangePlanOpName = "aggregateOverTimeRangeOp"
+
 func explainContains(node *promqlengine.ExplainOutputNode, substr string) bool {
 	if node == nil {
 		return false
@@ -419,14 +425,37 @@ func TestOverTimePushdownPlanRouting(t *testing.T) {
 		}
 	})
 
-	t.Run("RangeQueryFallsBack", func(t *testing.T) {
-		// Range queries re-evaluate over a sliding window the sidecar's step buckets don't model.
-		q, err := engOn.NewRangeQuery(ctx, on, nil, "count_over_time(ot_gauge[30s])", evalT, evalT.Add(time.Minute), 15*time.Second)
+	t.Run("RangeQueryUsesSidecar", func(t *testing.T) {
+		// Range queries push the reducer folds down per step; @ / projection / unsupported folds fall back.
+		for _, tt := range []struct {
+			query string
+			push  bool
+		}{
+			{"count_over_time(ot_gauge[30s])", true},
+			{"sum_over_time(ot_gauge[30s])", true},
+			{"avg_over_time(ot_gauge[30s])", true},
+			{"present_over_time(ot_gauge[30s])", true},
+			{"count_over_time(ot_gauge[30s] offset 10s)", true},
+			{"rate(ot_gauge[30s])", false},
+			{"last_over_time(ot_gauge[30s])", false},
+			{"count_over_time(ot_gauge[30s] @ 2000000)", false},
+		} {
+			q, err := engOn.NewRangeQuery(ctx, on, nil, tt.query, evalT, evalT.Add(time.Minute), 15*time.Second)
+			require.NoError(t, err)
+			t.Cleanup(q.Close)
+			exp, ok := q.(promqlengine.ExplainableQuery)
+			require.True(t, ok)
+			assert.Equalf(t, tt.push, explainContains(exp.Explain(), rangePlanOpName), "range routing for %s", tt.query)
+		}
+	})
+
+	t.Run("RangeQueryDisabledFallsBack", func(t *testing.T) {
+		q, err := engOff.NewRangeQuery(ctx, off, nil, "count_over_time(ot_gauge[30s])", evalT, evalT.Add(time.Minute), 15*time.Second)
 		require.NoError(t, err)
 		t.Cleanup(q.Close)
 		exp, ok := q.(promqlengine.ExplainableQuery)
 		require.True(t, ok)
-		assert.False(t, explainContains(exp.Explain(), planOpName), "range query must use the matrix selector")
+		assert.False(t, explainContains(exp.Explain(), rangePlanOpName), "WithOverTimePushdown(false) must not use the sidecar")
 	})
 }
 
@@ -512,9 +541,11 @@ func TestOverTimePushdownUnsupportedMatchesRaw(t *testing.T) {
 	}
 }
 
-// TestOverTimePushdownRangeMatchesRaw confirms that range queries — which always take the raw path,
-// since the sidecar models instant evaluation only — are unaffected by enabling the pushdown: a
-// pushdown-on backend returns the same matrix as a vanilla one across every step.
+// TestOverTimePushdownRangeMatchesRaw is the differential oracle for the range pushdown
+// (aggregateOverTimeRangeOp): for every supported fold, matcher subset, offset, and window/step
+// combination — including windows that overlap (range > step), tile with gaps (range < step), and
+// straddle each series' sample edges — the per-step aggregate pushdown must produce exactly the
+// matrix the raw matrix-selector fold produces: same series, same labels, same value at every step.
 func TestOverTimePushdownRangeMatchesRaw(t *testing.T) {
 	ctx := context.Background()
 	base := time.Unix(2_000_000, 0).UTC()
@@ -522,18 +553,41 @@ func TestOverTimePushdownRangeMatchesRaw(t *testing.T) {
 	store := ingestGaugeSeries(ctx, t, base, []gaugeSeries{
 		{foo: "a", samples: rampSamples(-120*time.Second, 0, 10*time.Second, 1)},
 		{foo: "b", samples: rampSamples(-120*time.Second, 0, 20*time.Second, 50)},
+		// c starts late, so it is absent from the earliest steps' windows — exercising a series that
+		// joins the union set partway through the range.
+		{foo: "c", samples: rampSamples(-40*time.Second, 0, 10*time.Second, 100)},
 	})
 	t.Cleanup(func() { _ = store.Close(ctx) })
 
 	d := newDiffBackends(ctx, t, store)
 
-	start, end, step := base.Add(-90*time.Second), base, 15*time.Second
-	for _, q := range []string{
-		"count_over_time(ot_gauge[30s])",
-		"sum_over_time(ot_gauge[40s])",
-		"avg_over_time(ot_gauge[30s])",
-		"sum by (foo) (max_over_time(ot_gauge[40s]))",
-	} {
-		t.Run(q, func(t *testing.T) { d.assertRange(t, q, start, end, step) })
+	start, end := base.Add(-90*time.Second), base
+	for _, step := range []time.Duration{15 * time.Second, 30 * time.Second, 45 * time.Second} {
+		for _, q := range []string{
+			// Every supported fold.
+			"count_over_time(ot_gauge[30s])",
+			"sum_over_time(ot_gauge[30s])",
+			"min_over_time(ot_gauge[30s])",
+			"max_over_time(ot_gauge[30s])",
+			"avg_over_time(ot_gauge[30s])",
+			"present_over_time(ot_gauge[30s])",
+			// range > step (overlapping windows), range == step, range < step (windows with gaps).
+			"sum_over_time(ot_gauge[60s])",
+			"count_over_time(ot_gauge[10s])",
+			// Matcher subsets and an offset.
+			`sum_over_time(ot_gauge{foo=~"a|c"}[30s])`,
+			`count_over_time(ot_gauge{foo!="b"}[60s])`,
+			"count_over_time(ot_gauge[30s] offset 15s)",
+			// Downstream aggregation and arithmetic compose with the per-step operator.
+			"sum by (foo) (max_over_time(ot_gauge[40s]))",
+			"sum(count_over_time(ot_gauge[30s]))",
+			"avg_over_time(ot_gauge[30s]) * 2",
+			// Empty result.
+			`sum_over_time(ot_gauge{foo="zzz"}[30s])`,
+		} {
+			t.Run(fmt.Sprintf("step=%s/%s", step, q), func(t *testing.T) {
+				d.assertRange(t, q, start, end, step)
+			})
+		}
 	}
 }

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -218,17 +218,31 @@ func (s scanners) NewMatrixSelector(
 	node logicalplan.MatrixSelector,
 	call logicalplan.FunctionCall,
 ) (model.VectorOperator, error) {
-	// Instant *_over_time over a supported function: answer from the aggregate sidecar instead of a
-	// raw fetch-and-fold. Range queries keep the matrix selector (their per-step sliding window is a
-	// different shape than the sidecar's step-aligned buckets), and anything with a projection or
-	// post-filter falls back too.
-	if s.b.overTimePushdown && opts.IsInstantQuery() && node.Range > 0 {
+	// *_over_time over a sidecar-answerable function (count/sum/min/max/avg/present): answer from the
+	// aggregate pushdown instead of a raw fetch-and-fold, for both instant and range queries. Anything
+	// with a projection, per-series filter, or @ modifier falls back to the matrix selector, as do the
+	// folds the sidecar cannot answer (rate/increase/quantile/…).
+	if s.b.overTimePushdown && node.Range > 0 {
 		if fold, ok := overTimeFold[call.Func.Name]; ok {
 			vs := node.VectorSelector
-			if vs.Projection == nil && len(vs.Filters) == 0 {
-				return newAggregateOverTimeOp(
+			plainInstant := vs.Projection == nil && len(vs.Filters) == 0
+			switch {
+			case opts.IsInstantQuery():
+				if plainInstant {
+					return newAggregateOverTimeOp(
+						s.b.store, s.b.tenant, vs.LabelMatchers, call.Func.Name, fold,
+						opts.Start.UnixMilli(), node.Range.Milliseconds(), vs.Offset.Milliseconds(),
+					), nil
+				}
+			// Range queries evaluate the fold over each step's sliding window (t-range, t]; the range op
+			// folds one aggregate per (series, step) instead of materializing the raw windows. The @
+			// modifier pins the eval timestamp (a shape the plain per-step offset does not model), so
+			// only push down its absence.
+			case opts.Step > 0 && plainInstant && vs.Timestamp == nil && !vs.SelectTimestamp:
+				return newAggregateOverTimeRangeOp(
 					s.b.store, s.b.tenant, vs.LabelMatchers, call.Func.Name, fold,
-					opts.Start.UnixMilli(), node.Range.Milliseconds(), vs.Offset.Milliseconds(),
+					opts.Start.UnixMilli(), opts.End.UnixMilli(), opts.Step.Milliseconds(),
+					node.Range.Milliseconds(), vs.Offset.Milliseconds(), opts.NumStepsPerBatch(),
 				), nil
 			}
 		}


### PR DESCRIPTION
Range `*_over_time` queries fell back to the raw matrix selector, which materializes every raw sample in every step's sliding window (~213 MB live under concurrent load, #1117) and folds in the engine.

This adds `aggregateOverTimeRangeOp` — the range analog of the instant `aggregateOverTimeOp`. For each PromQL step it folds one `engine.SeriesAgg` per series over that step's exact `(t-range, t]` window via `AggregateMetricsNamed`, and streams the per-step vectors, holding `O(result)` instead of `O(all raw samples in range)`. The storage engine still applies its sidecar/decode fast paths (and decode cache) per window.

**Scope (reducers now):** pushed down for the sidecar-answerable folds — `count`/`sum`/`min`/`max`/`avg`/`present_over_time` — on a plain selector. Projection, per-series filter, `@` modifier, and folds the sidecar can't answer (`rate`/`increase`/`quantile_over_time`/…) fall back to the matrix selector.

**Correctness** is pinned by the differential oracle `TestOverTimePushdownRangeMatchesRaw`: pushdown-on must equal the raw matrix-selector fold across every fold, matcher subset, offset, and overlapping/tiling/gapped window–step combination. Plan-routing is asserted by `TestOverTimePushdownPlanRouting`.

**Follow-ups:** (1) fold one aggregate per part per step in a single decode pass instead of re-decoding overlapping windows (CPU); (2) `rate`/`increase`, which need a richer first/last + counter-reset sidecar — the larger storage-format change deferred out of this scope.

> Note: stacked on #1119 (`claude/1118-label-intern-cache`) since both touch `storagebackend.go`; rebase onto main once that merges.

Refs #1117