### PR TITLE
perf(storage): fit decode-admission budget to GOMEMLIMIT

### DIFF
--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -124,6 +124,12 @@ type StorageConfig struct {
 	// prefetch of a fetch's parts). Enabled by default, sized from available RAM; set to 0 to
 	// disable.
 	DecodeCacheBytes *xbytes.Bytes `json:"decode_cache_bytes" yaml:"decode_cache_bytes"`
+	// DecodeMemoryBytes caps the total in-flight decoded column bytes across concurrent metric
+	// queries (decode admission control, shared across tenants): a query reserves its estimated
+	// decode footprint before reading parts and blocks while the budget is exhausted, so query
+	// concurrency cannot drive the live heap past the process memory limit. Enabled by default,
+	// fitted to the detected memory limit minus the caches and headroom; set to 0 to disable.
+	DecodeMemoryBytes *xbytes.Bytes `json:"decode_memory_bytes" yaml:"decode_memory_bytes"`
 	// AggregateStats writes a per-series aggregate sidecar (count/sum/min/max) alongside each
 	// metric part so range-covering aggregates — and the *_over_time pushdown — can be answered
 	// without decoding. Enabled by default; set to false to disable.

--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -112,6 +112,7 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 		zap.Int("log_query_parallelism", cfg.LogQueryParallelism),
 		zap.Int64("read_cache_bytes", caches.ReadCache),
 		zap.Int64("decode_cache_bytes", caches.DecodeCache),
+		zap.Int64("decode_memory_bytes", caches.DecodeMemory),
 		zap.Bool("aggregate_stats", caches.AggregateStats),
 	)
 	b := storagebackend.New(store,
@@ -214,6 +215,7 @@ func s3Backend(ctx context.Context, cfg *StorageS3Config) (backend.Backend, erro
 type cacheSettings struct {
 	ReadCache      int64
 	DecodeCache    int64
+	DecodeMemory   int64
 	AggregateStats bool
 }
 
@@ -222,11 +224,17 @@ type cacheSettings struct {
 // conservative absolute defaults when no limit is detectable. An explicit zero byte size disables
 // that cache, and an explicit AggregateStats=false disables the sidecar.
 func resolveCacheSettings(cfg StorageConfig) cacheSettings {
-	return cacheSettings{
+	s := cacheSettings{
 		ReadCache:      resolveCacheBytes(cfg.ReadCacheBytes, defaultReadCacheBytes),
 		DecodeCache:    resolveCacheBytes(cfg.DecodeCacheBytes, defaultDecodeCacheBytes),
 		AggregateStats: cfg.AggregateStats == nil || *cfg.AggregateStats,
 	}
+	// The decode-memory default fits around the caches, so it must resolve after them (an explicit
+	// cache size shrinks or grows the remaining budget accordingly).
+	s.DecodeMemory = resolveCacheBytes(cfg.DecodeMemoryBytes, func() int64 {
+		return defaultDecodeMemoryBytes(s.ReadCache, s.DecodeCache)
+	})
+	return s
 }
 
 // cacheOptions builds the storage options for the resolved cache/optimization settings.
@@ -234,6 +242,7 @@ func cacheOptions(s cacheSettings) []storage.Option {
 	opts := []storage.Option{
 		storage.WithReadCache(s.ReadCache),
 		storage.WithDecodeCache(s.DecodeCache),
+		storage.WithDecodeMemory(s.DecodeMemory),
 	}
 	if s.AggregateStats {
 		opts = append(opts, storage.WithAggregateStats())
@@ -260,6 +269,26 @@ func defaultReadCacheBytes() int64 { return defaultCacheBytes(1.0/16, 128<<20) }
 // the working set. Unlike a flat floor this stays RSS-safe: a small box gets ~64 MiB rather than an
 // unconditional 512 MiB, while a large box is capped at the 512 MiB ceiling. See oteldb#1112.
 func defaultDecodeCacheBytes() int64 { return budgetedCacheBytes(1.0/32, 64<<20, 512<<20) }
+
+// defaultDecodeMemoryBytes fits the engine's decode-admission budget to the process memory budget,
+// so query concurrency cannot drive the live heap past GOMEMLIMIT (past the limit the Go pacer runs
+// GC back-to-back and every in-flight query pays continuous mark cost; see oteldb#1124). Half the
+// detected budget is headroom for everything the budget does not meter — the resident baseline
+// (head, WAL, ingest) and per-query eval transients (coalesce/output buffers) — and the caches are
+// subtracted from the metered half since they are sized separately and are just as resident:
+//
+//	decodeMemory = detected/2 − readCache − decodeCache
+//
+// Floored at 64 MiB so a small box still admits a query at a time instead of degenerating (a query
+// larger than the whole budget is admitted alone, so the floor never rejects anything). When no
+// memory is detectable it returns 0 (admission control off), matching the library default.
+func defaultDecodeMemoryBytes(readCache, decodeCache int64) int64 {
+	basis := detectMemoryBytes()
+	if basis <= 0 {
+		return 0
+	}
+	return max(basis/2-readCache-decodeCache, 64<<20)
+}
 
 // defaultCacheBytes sizes a cache as the given fraction of the Go memory limit, floored at minBytes.
 // When no limit is set (the default of math.MaxInt64, meaning unbounded), it returns minBytes so the

--- a/cmd/oteldb/storage_backend_test.go
+++ b/cmd/oteldb/storage_backend_test.go
@@ -298,27 +298,31 @@ storage:
 func TestResolveCacheSettings(t *testing.T) {
 	t.Run("DefaultsEnableAll", func(t *testing.T) {
 		s := resolveCacheSettings(StorageConfig{})
-		// All three are opt-out for oteldb: on by default.
+		// All four are opt-out for oteldb: on by default.
 		require.True(t, s.AggregateStats)
 		require.Greater(t, s.ReadCache, int64(0))
 		require.Greater(t, s.DecodeCache, int64(0))
+		require.Greater(t, s.DecodeMemory, int64(0))
 	})
 
 	t.Run("ExplicitSizesHonored", func(t *testing.T) {
-		rc, dc := xbytes.Bytes(1<<20), xbytes.Bytes(2<<20)
+		rc, dc, dm := xbytes.Bytes(1<<20), xbytes.Bytes(2<<20), xbytes.Bytes(3<<20)
 		s := resolveCacheSettings(StorageConfig{
-			ReadCacheBytes:   &rc,
-			DecodeCacheBytes: &dc,
+			ReadCacheBytes:    &rc,
+			DecodeCacheBytes:  &dc,
+			DecodeMemoryBytes: &dm,
 		})
 		require.Equal(t, int64(1<<20), s.ReadCache)
 		require.Equal(t, int64(2<<20), s.DecodeCache)
+		require.Equal(t, int64(3<<20), s.DecodeMemory)
 	})
 
 	t.Run("ZeroDisablesByteCache", func(t *testing.T) {
 		zero := xbytes.Bytes(0)
-		s := resolveCacheSettings(StorageConfig{ReadCacheBytes: &zero, DecodeCacheBytes: &zero})
+		s := resolveCacheSettings(StorageConfig{ReadCacheBytes: &zero, DecodeCacheBytes: &zero, DecodeMemoryBytes: &zero})
 		require.Equal(t, int64(0), s.ReadCache)
 		require.Equal(t, int64(0), s.DecodeCache)
+		require.Equal(t, int64(0), s.DecodeMemory, "explicit 0 disables decode admission control")
 	})
 
 	t.Run("AggregateStatsFalseDisables", func(t *testing.T) {
@@ -362,6 +366,38 @@ func TestDefaultDecodeCacheBytesRSSSafe(t *testing.T) {
 	require.LessOrEqual(t, got, ceiling)
 }
 
+// TestDefaultDecodeMemoryBytesFitsLimit checks the decode-admission budget default fits the process
+// memory budget: half the detected limit minus the caches, floored at 64 MiB, so under concurrent
+// query load the live heap stays under GOMEMLIMIT instead of tripping the pacer. See oteldb#1124.
+func TestDefaultDecodeMemoryBytesFitsLimit(t *testing.T) {
+	const floor = int64(64 << 20)
+	// The test drives the process memory limit directly (detectMemoryBytes reads it); restore after.
+	orig := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(orig) })
+
+	for _, tc := range []struct {
+		name                   string
+		limit                  int64
+		readCache, decodeCache int64
+		want                   int64
+	}{
+		// The benchmark box (#1124): 1 GiB limit with the default caches leaves 512−128−64.
+		{"1GiB fits around caches", 1 << 30, 128 << 20, 64 << 20, 320 << 20},
+		{"8GiB scales up", 8 << 30, 512 << 20, 256 << 20, 3328 << 20},
+		{"small box floored", 256 << 20, 128 << 20, 64 << 20, floor},
+		{"caches larger than half floored", 1 << 30, 512 << 20, 512 << 20, floor},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			debug.SetMemoryLimit(tc.limit)
+			require.Equal(t, tc.want, defaultDecodeMemoryBytes(tc.readCache, tc.decodeCache))
+		})
+	}
+
+	// With no explicit limit it sizes off detected host RAM: still enabled, still floored.
+	debug.SetMemoryLimit(math.MaxInt64)
+	require.GreaterOrEqual(t, defaultDecodeMemoryBytes(128<<20, 64<<20), floor)
+}
+
 func TestCacheOptions(t *testing.T) {
 	apply := func(t *testing.T, opts []storage.Option) storage.Options {
 		t.Helper()
@@ -373,9 +409,10 @@ func TestCacheOptions(t *testing.T) {
 	}
 
 	t.Run("Enabled", func(t *testing.T) {
-		o := apply(t, cacheOptions(cacheSettings{ReadCache: 100, DecodeCache: 200, AggregateStats: true}))
+		o := apply(t, cacheOptions(cacheSettings{ReadCache: 100, DecodeCache: 200, DecodeMemory: 300, AggregateStats: true}))
 		require.Equal(t, int64(100), o.ReadCacheBytes)
 		require.Equal(t, int64(200), o.DecodeCacheBytes)
+		require.Equal(t, int64(300), o.DecodeMemoryBytes)
 		require.True(t, o.AggregateStats)
 	})
 
@@ -395,6 +432,7 @@ storage:
   dir: /data
   read_cache_bytes: "0"
   decode_cache_bytes: "64MiB"
+  decode_memory_bytes: "256MiB"
   aggregate_stats: false
 `
 	f, err := os.CreateTemp("", "oteldb.yml")
@@ -410,5 +448,6 @@ storage:
 	s := resolveCacheSettings(cfg.Storage)
 	require.Equal(t, int64(0), s.ReadCache, "explicit 0 disables the read cache")
 	require.Equal(t, int64(64<<20), s.DecodeCache)
+	require.Equal(t, int64(256<<20), s.DecodeMemory)
 	require.False(t, s.AggregateStats, "explicit aggregate_stats:false disables the sidecar")
 }

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.155.0
-	github.com/oteldb/promql-engine v0.8.0
+	github.com/oteldb/promql-engine v0.9.0
 	github.com/oteldb/storage v0.24.0
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.155.0
 	github.com/oteldb/promql-engine v0.9.0
-	github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2
+	github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.155.0
 	github.com/oteldb/promql-engine v0.9.0
-	github.com/oteldb/storage v0.24.0
+	github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.155.0
 	github.com/oteldb/promql-engine v0.9.0
-	github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa
+	github.com/oteldb/storage v0.24.1-0.20260702041051-b66843bf3102
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.9.0 h1:UAHLan2fQiq1EEshohePvjcpD/HRdET4xrUrvIyS/Rk=
 github.com/oteldb/promql-engine v0.9.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2 h1:QMysKe5Xq5OXRgxCDOD2bqQsVJ5qvcjItIUw/ulLi0c=
-github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
+github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa h1:darNNJ1IBY6GgHYOjhvABkeMZb8cR9A7uuaHsusad5U=
+github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235/go.mod h1:L49W
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-github.com/oteldb/promql-engine v0.8.0 h1:F1ly0wIZylr7rG7cSZmGl7vkpJ0KunEoz+Qxhr0+FJU=
-github.com/oteldb/promql-engine v0.8.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
+github.com/oteldb/promql-engine v0.9.0 h1:UAHLan2fQiq1EEshohePvjcpD/HRdET4xrUrvIyS/Rk=
+github.com/oteldb/promql-engine v0.9.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
 github.com/oteldb/storage v0.24.0 h1:5zOq53eWbFP+6Yy2CD03E8bb4UhgYL1f31WD7EHIp9k=
 github.com/oteldb/storage v0.24.0/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.9.0 h1:UAHLan2fQiq1EEshohePvjcpD/HRdET4xrUrvIyS/Rk=
 github.com/oteldb/promql-engine v0.9.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.24.0 h1:5zOq53eWbFP+6Yy2CD03E8bb4UhgYL1f31WD7EHIp9k=
-github.com/oteldb/storage v0.24.0/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
+github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2 h1:QMysKe5Xq5OXRgxCDOD2bqQsVJ5qvcjItIUw/ulLi0c=
+github.com/oteldb/storage v0.24.1-0.20260702020458-51b91780bfc2/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.9.0 h1:UAHLan2fQiq1EEshohePvjcpD/HRdET4xrUrvIyS/Rk=
 github.com/oteldb/promql-engine v0.9.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa h1:darNNJ1IBY6GgHYOjhvABkeMZb8cR9A7uuaHsusad5U=
-github.com/oteldb/storage v0.24.1-0.20260702031231-544e987b96fa/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
+github.com/oteldb/storage v0.24.1-0.20260702041051-b66843bf3102 h1:0CsjEPBDrSflykqiDf4bNLt2IZQjQc7TcDkpMJnusYo=
+github.com/oteldb/storage v0.24.1-0.20260702041051-b66843bf3102/go.mod h1:cX9RtwzE1zZ3KYQWEDCD723JYpJZ0+q+2RoMz315kPg=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=


### PR DESCRIPTION
## Summary

Fixes #1124.

Under 8-way concurrent PromQL load (~143k series, `GOMEMLIMIT=1GiB`) the live heap crossed the memory limit (1297 MB inuse vs 1024 MB), putting the Go GC pacer in back-to-back mode where every in-flight query pays continuous mark cost — the collective-slowdown regime in `dev/local/embedded-bench/CROSS-ENGINE-REPORT.md`.

The engine has the right valve — the decode-memory admission budget (oteldb/storage#57) — but it was never wired to the process budget. This PR enables it by default, fitted to the detected memory limit:

```
decode_memory = limit/2 − read_cache − decode_cache   (floor 64 MiB)
```

- Half the limit is the explicit headroom term for what the budget does not meter: the resident baseline (head, WAL, ingest) and per-query eval transients (coalesce/output buffers).
- The caches are subtracted from the metered half — they are sized separately (#1112) and are just as resident.
- The budget is **shared across tenant engines** (`storage.WithDecodeMemory`, oteldb/storage#68), so it is a process-wide cap: N heavy queries queue through it instead of each materializing whole columns at once.
- New `storage.decode_memory_bytes` config: explicit value overrides the fitted default, `0` disables admission control.
- On the 1 GiB benchmark box this yields a 320 MiB decode budget (512 − 128 read cache − 64 decode cache).

At the cap, admission queues (slightly higher p50 under saturation) rather than letting the heap cross the limit (much higher everything under saturation) — behavior 3 from the issue.

## Dependencies

Requires oteldb/storage#68 (`WithDecodeMemory` + shared budget); pinned as a pseudo-version until it merges and is tagged, then `go.mod` should bump to the release.

## Verification

- Unit: `TestDefaultDecodeMemoryBytesFitsLimit` (sizing incl. the 1 GiB bench box), resolve/options/YAML round-trip tests extended.
- E2E acceptance (8-way `otelbench promql bench -c --jobs 8` under `GOMEMLIMIT=1GiB`): live-heap-under-limit numbers to follow in a comment.