### PR TITLE
feat(embedded-bench): add S3 backend variant, drop -replace, fix prewarm default

### DIFF
--- a/dev/local/embedded-bench/.gitignore
+++ b/dev/local/embedded-bench/.gitignore
@@ -4,8 +4,9 @@
 /oteldb
 /otelbench
 
-# Benchmark outputs
+# Benchmark outputs (per-backend report-<name>.yml, plus the rendered markdown).
 /report.yml
+/report-*.yml
 /report.txt
 /REPORT.md
 

--- a/dev/local/embedded-bench/Dockerfile
+++ b/dev/local/embedded-bench/Dockerfile
@@ -1,8 +1,7 @@
-# Thin runtime image for the embedded-bench. The oteldb binary is built ON THE HOST (see run.sh)
-# and copied in here — so `docker compose up --build` is one fast ADD layer, not a Go toolchain
-# build. That is the fast iteration loop: edit source → run.sh rebuilds the binary → `up --build
-# --force-recreate` swaps oteldb in seconds while the data volume and vmagent ingest keep running
-# (CLEANUP=0), then re-run the bench against the fresh binary over the same warm data.
+# Thin runtime image for the embedded-bench. The oteldb binary is built ON THE HOST (by the
+# orchestrator, main.go) and copied in here — so `docker compose up --build` is one fast ADD layer,
+# not a Go toolchain build. Both instances (the `file` and `s3` services) share this one image and
+# differ only in their mounted config, so a single host build backs both.
 #
 # Match the host build flags: CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH (default amd64). A static
 # binary runs unchanged under alpine.

--- a/dev/local/embedded-bench/README.md
+++ b/dev/local/embedded-bench/README.md
@@ -1,9 +1,15 @@
 # embedded-bench — realistic oteldb PromQL benchmark
 
 A self-contained, docker-compose PromQL benchmark of oteldb's **embedded** storage engine
-(`--embedded`, `file` backend), built for iterating on storage/engine changes with numbers
-directly comparable to the `oteldb` column of
+(`--embedded`), built for iterating on storage/engine changes with numbers directly comparable to
+the `oteldb` / `oteldb-s3` columns of
 [`benchmark/results/REPORT.md`](../../../../benchmark/results/REPORT.md).
+
+It benches **both storage backends side by side off one live ingest stream**: the local `file`
+backend (`oteldb`) and the shared **go-faster/fs S3** object store (`oteldb-s3`, the same
+`ghcr.io/go-faster/fs` substrate Mimir/Loki/Tempo use in the cross-engine benchmark). A single run
+produces a side-by-side REPORT.md so you can see the object-store read-path cost against the local
+`file` baseline.
 
 It reproduces the benchmark's full realistic path — **live `node_exporter` → `vmagent`
 (`BENCH_NODES` synthetic hosts) → Prometheus remote-write → oteldb under `GOMAXPROCS`/`GOMEMLIMIT`
@@ -28,57 +34,54 @@ flushes to compressed parts every 10s and queries decode+merge across them — t
 From this directory (`dev/local/embedded-bench`):
 
 ```bash
-go run .                          # nodes=10, prewarm 10s, 20 runs/query
+go run .                          # nodes=100, prewarm 2m30s, 20 runs/query — both backends
 
-go run . -nodes 100               # match REPORT.md cardinality (~140k series)
 go run . -gomaxprocs 2 -gomemlimit 1GiB   # tighten caps
-go run . -prewarm 70m             # fully populate [30m]/[1h] range vectors
+go run . -prewarm 70m             # also fully populate the [30m]/[1h] instant selectors
 go run . -cleanup=false           # leave the stack up (re-run bench / grab pprof)
-go run . -replace                 # rebuild oteldb, swap it in place, re-bench (no re-ingest)
+go run . -s3=false                # bench only the file backend (skip the S3 instance)
+go run . -nodes 10 -prewarm 15s   # quick smoke run (numbers NOT comparable — window under-populated)
 ```
 
 `go run . -h` lists all flags. Every flag also has an env equivalent (`BENCH_NODES`,
-`BENCH_RUNS`, `GOMAXPROCS`, `GOMEMLIMIT`, `REPLACE`, …); flags win.
+`BENCH_RUNS`, `GOMAXPROCS`, `GOMEMLIMIT`, `PREWARM`, `BENCH_S3`, …); flags win.
 
-| flag          | default | meaning                                                          |
-|---------------|---------|------------------------------------------------------------------|
-| `-nodes`      | `10`    | synthetic node_exporter hosts vmagent fans out (`~1400 series ×`)|
-| `-prewarm`    | `10s`   | ingest window before querying (raise to `70m` for `[1h]` queries)|
-| `-runs`       | `20`    | measured runs per query (after warmup)                            |
-| `-warmup`     | `5`     | unmeasured warmup runs                                            |
-| `-lookback`   | `120s`  | range-query window back from now                                  |
-| `-concurrency`| `8`     | concurrent in-flight queries for the verify pass                  |
-| `-gomaxprocs` | `4`     | oteldb CPU cap (matches `BENCH_CPUS`)                             |
-| `-gomemlimit` | `2GiB`  | oteldb soft memory cap (matches `BENCH_MEMLIMIT`)                 |
-| `-health-wait`| `120s`  | max wait for oteldb `/liveness`; tails logs + status on timeout   |
-| `-cleanup`    | `true`  | `false` leaves the stack up (re-run / pprof without re-ingest)    |
-| `-replace`    | `false` | rebuild oteldb, swap it in place (stack already up), re-bench     |
+**Prewarm must cover the lookback.** The range queries evaluate over `[now-lookback, now]`, and the
+measured cost is dominated by how many flushed parts that window spans. A `-prewarm` shorter than
+`-lookback` leaves the window mostly empty, so latencies read far too low and the S3 read path is
+barely exercised (`s3 ≈ file`) — not comparable to `REPORT.md`. The default (`2m30s`) covers the
+`120s` lookback with margin; the orchestrator warns if you set `-prewarm` below `-lookback`.
+
+| flag          | default  | meaning                                                          |
+|---------------|----------|------------------------------------------------------------------|
+| `-nodes`      | `100`    | synthetic node_exporter hosts vmagent fans out (`~1400 series ×`)|
+| `-prewarm`    | `2m30s`  | ingest window before querying — keep ≥ `-lookback` (see above)   |
+| `-runs`       | `20`     | measured runs per query (after warmup)                           |
+| `-warmup`     | `5`      | unmeasured warmup runs                                           |
+| `-lookback`   | `120s`   | range-query window back from now                                 |
+| `-concurrency`| `8`      | concurrent in-flight queries for the verify pass                 |
+| `-gomaxprocs` | `4`      | oteldb CPU cap (matches `BENCH_CPUS`)                            |
+| `-gomemlimit` | `1GiB`   | oteldb soft memory cap (matches `BENCH_MEMLIMIT`)               |
+| `-health-wait`| `120s`   | max wait for oteldb `/liveness`; tails logs + status on timeout  |
+| `-cleanup`    | `true`   | `false` leaves the stack up (re-run / pprof without re-ingest)   |
+| `-s3`         | `true`   | also bench the S3 (go-faster/fs) backend; `-s3=false` skips it   |
+| `-addr-s3`    | `:9093`  | oteldb-s3 PromQL API address (file backend is `-addr`, `:9090`)  |
 
 ## How it builds
 
 `go run .` builds two binaries **on the host** from the oteldb repo root — `oteldb` and `otelbench` —
 because the oteldb `go.mod` has `replace` directives pointing at the local `storage` and
 `promql-engine` sources (absolute host paths), which only resolve on the host, never inside a
-container. The compose image is thin (`Dockerfile` just `COPY oteldb` into alpine), and the bench
-phase invokes the host-built `otelbench` directly, so the loop never rebuilds in-container or
-recompiles otelbench per run.
-
-## The replace loop
-
-Once the stack is up (`-cleanup=false`), iterate on oteldb source with:
-
-```bash
-go run . -replace
-```
-
-It rebuilds the `oteldb` binary, rebuilds the one-copy-layer image, and swaps just the oteldb
-container (`--force-recreate --no-deps oteldb`) while node-exporter / vmagent / the data volume keep
-running. vmagent keeps remote-writing, so the new oteldb's head refills within a couple scrapes.
-Fresh numbers in the time `go build` + one image layer takes.
+container. The single host-built `oteldb` binary backs **both** instances — the `file` and `s3`
+services COPY the same binary into alpine, differing only in their mounted config (`oteldb.yml` vs
+`oteldb-s3.yml`). The compose image is thin (`Dockerfile` just `COPY oteldb`), and the bench phase
+invokes the host-built `otelbench` directly, so a run never rebuilds in-container or recompiles
+otelbench per run.
 
 ## Profiling
 
-With the stack up (`CLEANUP=0`), oteldb's pprof endpoint is on `:9010`:
+With the stack up (`CLEANUP=0`), the `file` oteldb's pprof endpoint is on `:9010` (the `oteldb-s3`
+instance's is on `:9012`):
 
 ```bash
 go tool pprof -http=: http://127.0.0.1:9010/debug/pprof/profile?seconds=30
@@ -93,7 +96,7 @@ hotspot locations it names (`engine.sortedWindow`, `recordCols`, `DecodeAttribut
 
 ## What this is not
 
-- Not a cross-engine comparison — only `oteldb` is brought up. For the head-to-head matrix
-  (VictoriaMetrics / Mimir / …), use `benchctl` in `/src/oteldb/benchmark`.
+- Not a cross-engine comparison — only oteldb is brought up (its `file` and `s3` backends). For the
+  head-to-head matrix (VictoriaMetrics / Mimir / …), use `benchctl` in `/src/oteldb/benchmark`.
 - Not a static dataset — it ingests live, current-timestamp data. That's the point (no stale-timestamp
   problems), but it means two runs differ in exact sample counts; compare percentiles, not raw.

--- a/dev/local/embedded-bench/docker-compose.yml
+++ b/dev/local/embedded-bench/docker-compose.yml
@@ -10,12 +10,22 @@
 # comparable to a cell in /src/oteldb/benchmark/results/REPORT.md (same ingest path, same caps, same
 # query suite, same HTTP measurement), without standing up the whole benchctl matrix.
 #
-#   ./run.sh                         # BENCH_NODES=10, prewarm 90s, bench 20 runs
-#   BENCH_NODES=100 ./run.sh         # match REPORT.md cardinality (~140k series)
-#   GOMEMLIMIT=2GiB ./run.sh         # tune the cap
-#   CLEANUP=0 ./run.sh               # leave the stack up to re-run queries / grab pprof
+# The orchestrator (main.go, `go run .`) drives this stack; it is not brought up by hand. Examples:
+#
+#   go run .                         # nodes=100, prewarm 2m30s (≥ lookback), bench 20 runs
+#   go run . -gomemlimit 2GiB        # tune the cap
+#   go run . -cleanup=false          # leave the stack up to re-run queries / grab pprof
+#   go run . -s3=false               # bench only the file backend
+#
+# Two oteldb instances run side by side off the same live ingest stream so a single run compares the
+# storage backends apples-to-apples: `oteldb` on the local `file` backend and `oteldb-s3` on the
+# shared go-faster/fs S3 object store (the same substrate Mimir/Loki/Tempo use in the cross-engine
+# benchmark). vmagent remote-writes the identical stream to both; the orchestrator benches each and
+# renders a side-by-side REPORT.md.
 volumes:
-  oteldb-data: # the embedded `file` backend's data dir (parts live here across restarts)
+  oteldb-data:    # the embedded `file` backend's data dir (parts live here across restarts)
+  oteldb-s3-data: # the s3 backend's local WAL (the only on-disk state; durable parts live in fs)
+  fs-data:        # go-faster/fs filesystem root — holds the oteldb-s3 S3 bucket
 
 services:
   # The real node_exporter — one instance, scraped once per ~2s via the cache below.
@@ -41,15 +51,47 @@ services:
       - ./vmagent-scrape.yml:/etc/vmagent/scrape.yml:ro
     command:
       - -promscrape.config=/etc/vmagent/scrape.yml
+      # Fan the identical stream out to both backends so they ingest the same data at the same time —
+      # the apples-to-apples precondition for the side-by-side report. vmagent buffers + retries per
+      # target, so oteldb-s3 lagging behind fs-init/bucket setup at startup is harmless.
       - -remoteWrite.url=http://oteldb:19291/api/v1/write
+      - -remoteWrite.url=http://oteldb-s3:19291/api/v1/write
     ports: ["127.0.0.1:8429:8429"]
+
+  # Shared S3 object store for the s3 backend. Single go-faster/fs server (the same image and command
+  # the cross-engine benchmark uses); its data lives on the fs-data volume across restarts.
+  fs:
+    image: ${FS_IMAGE:-ghcr.io/go-faster/fs:latest}
+    command: ["s3", "--addr", ":9000", "--root", "/data/s3"]
+    volumes:
+      - fs-data:/data/s3
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "127.0.0.1:9000/"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  # Creates the oteldb-s3 bucket once fs is healthy, then exits. oteldb-s3 waits on this completing.
+  fs-init:
+    image: amazon/aws-cli:2.17.0
+    depends_on:
+      fs: { condition: service_healthy }
+    environment:
+      AWS_ACCESS_KEY_ID: bench
+      AWS_SECRET_ACCESS_KEY: benchbench
+      AWS_REGION: us-east-1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        aws --endpoint-url http://fs:9000 s3 mb s3://oteldb-s3 2>/dev/null || true
+        echo "bucket ready"
 
   # oteldb on the embedded engine (--embedded ⇒ `file` backend, no ClickHouse), capped to the same
   # GOMAXPROCS / GOMEMLIMIT the benchmark applies via BENCH_CPUS / BENCH_MEMLIMIT. The PromQL HTTP
   # API is on :9090; Prometheus remote-write ingest on :19291; pprof on :9010 for profiling runs.
   #
-  # Build: the binary is compiled on the host by run.sh (`go build -o oteldb`) and this image just
-  # COPYs it (./Dockerfile) — so `up --build` is instant and a host rebuild swaps oteldb in place.
+  # Build: the binary is compiled on the host by the orchestrator (`go build -o oteldb`) and this
+  # image just COPYs it (./Dockerfile) — so `up --build` is instant. oteldb-s3 shares the same image.
   oteldb:
     build:
       context: .
@@ -79,3 +121,38 @@ services:
       - "127.0.0.1:9010:9010"   # pprof (go tool pprof http://localhost:9010)
       - "127.0.0.1:13133:13133" # health check (/liveness, /readiness) — published for run.sh's poll
       - "127.0.0.1:19291:19291" # Prometheus remote-write ingest
+
+  # oteldb, S3 variant: same host-built binary and --embedded, but the embedded storage engine's
+  # object-store backend is the shared go-faster/fs S3 (bucket oteldb-s3) instead of a local `file`
+  # volume — only the WAL is local. Ports are shifted +3/+2/+1/+1 off the file variant so both run at
+  # once: PromQL :9093, pprof :9012, health :13134, remote-write ingest :19292.
+  oteldb-s3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      fs-init: { condition: service_completed_successfully }
+    command:
+      - --config=/etc/otel/cfg.yml
+      - --embedded
+    volumes:
+      - ./oteldb-s3.yml:/etc/otel/cfg.yml:ro
+      - oteldb-s3-data:/data
+    environment:
+      - PPROF_ADDR=0.0.0.0:9010
+      - OTEL_LOG_LEVEL=info
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=none
+      - GOMAXPROCS=${GOMAXPROCS:-4}
+      - GOMEMLIMIT=${GOMEMLIMIT:-1GiB}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "127.0.0.1:13133/liveness"]
+      interval: 1s
+      timeout: 1s
+      retries: 60
+    ports:
+      - "127.0.0.1:9093:9090"   # PromQL HTTP API (s3 variant)
+      - "127.0.0.1:9012:9010"   # pprof
+      - "127.0.0.1:13134:13133" # health check
+      - "127.0.0.1:19292:19291" # Prometheus remote-write ingest

--- a/dev/local/embedded-bench/main.go
+++ b/dev/local/embedded-bench/main.go
@@ -2,16 +2,17 @@
 // engine over HTTP, replacing the previous run.sh. It builds the oteldb (and otelbench) binaries on
 // the host — where the oteldb repo's go.mod replace directives resolve the local storage /
 // promql-engine sources — then drives a thin docker-compose stack (live node_exporter → vmagent as
-// BENCH_NODES hosts → oteldb --embedded on the `file` backend, capped) and runs the canonical query
-// suite via otelbench. Numbers are comparable to the oteldb column of
-// /src/oteldb/benchmark/results/REPORT.md. Alongside the latency numbers it samples the oteldb
-// container's peak resident set size (RSS) over the run and records it in REPORT.md.
+// BENCH_NODES hosts → two oteldb --embedded instances off the same ingest stream: the `file` backend
+// and the go-faster/fs `s3` backend, capped) and runs the canonical query suite against each via
+// otelbench. Numbers are comparable to the oteldb / oteldb-s3 columns of
+// /src/oteldb/benchmark/results/REPORT.md. Alongside the latency numbers it samples each container's
+// peak resident set size (RSS) and renders a side-by-side REPORT.md.
 //
 // Run from this directory:
 //
-//	go run .                                    # BENCH_NODES=10, prewarm 10s, 20 runs/query
-//	go run . -nodes 100                         # match REPORT.md cardinality
-//	go run . -replace                           # rebuild oteldb, swap it in place, re-bench
+//	go run .                                    # nodes=100, prewarm 2m30s, 20 runs/query, both backends
+//	go run . -s3=false                          # bench only the file backend
+//	go run . -prewarm 70m                       # also populate the [30m]/[1h] instant selectors
 //	go run . -gomaxprocs 2 -gomemlimit 1GiB     # tighten caps
 //
 // Run `go run . -h` for all flags.
@@ -48,15 +49,46 @@ type config struct {
 	gomemlimit string
 	goarch     string
 
-	replace bool
 	cleanup bool
+	s3      bool
 
 	concurrency int
 
 	addr     string
+	addrS3   string
 	queries  string
 	benchDir string
 	repoRoot string
+}
+
+// target is one oteldb instance under test: the `file` backend or the S3 (go-faster/fs) backend.
+// Both run off the same live ingest stream; the orchestrator benches each and reports side by side.
+type target struct {
+	name      string // "file" | "s3" — the column label in REPORT.md.
+	service   string // docker compose service name (for RSS sampling + log tailing).
+	promAddr  string // PromQL HTTP API base, e.g. http://127.0.0.1:9090.
+	healthURL string // /liveness URL for the health poll.
+}
+
+// targets returns the instances to bench: always `file`, plus `s3` unless it was disabled with
+// -s3=false. Health URLs are the PromQL address with the port swapped to the published health port
+// (13133 for file, 13134 for s3), matching docker-compose.yml.
+func (cfg config) targets() []target {
+	ts := []target{{
+		name:      "file",
+		service:   "oteldb",
+		promAddr:  cfg.addr,
+		healthURL: strings.Replace(cfg.addr, ":9090", ":13133", 1) + "/liveness",
+	}}
+	if cfg.s3 {
+		ts = append(ts, target{
+			name:      "s3",
+			service:   "oteldb-s3",
+			promAddr:  cfg.addrS3,
+			healthURL: strings.Replace(cfg.addrS3, ":9093", ":13134", 1) + "/liveness",
+		})
+	}
+	return ts
 }
 
 func main() {
@@ -78,31 +110,38 @@ func run() error {
 		return err
 	}
 
-	// In REPLACE mode the stack is assumed up (node-exporter/vmagent/data volume keep running);
-	// rebuild the one-copy-layer image, swap oteldb, wait for health, then bench. No teardown.
-	if cfg.replace {
-		return replaceAndBench(cfg)
-	}
-
 	// Full bring-up. Tear down on exit unless -cleanup=false.
 	defer maybeCleanup(cfg)
 	if err := fullBringup(cfg); err != nil {
 		return err
 	}
 
-	// Prewarm: let vmagent remote-write enough history for the suite's range vectors.
-	// -prewarm=10s covers [1m]/[5m]; [30m]/[1h] (topk_free_mem, load_quantile) need 30m/70m to be
+	// Prewarm: let vmagent remote-write enough history that the [now-lookback, now] window the range
+	// queries scan is fully populated with flushed parts. The default (2m30s) covers the 120s lookback;
+	// the [30m]/[1h] instant selectors (topk_free_mem, load_quantile) still want -prewarm 70m to be
 	// fully populated — oteldb still answers over whatever has arrived (--allow-empty keeps it going).
 	fmt.Printf(">> Prewarming ingest for %s (nodes=%d ⇒ ~%d series)\n", cfg.prewarm, cfg.nodes, cfg.nodes*1400)
 	time.Sleep(cfg.prewarm)
 
-	// Gate on data: the per-tenant engine is created lazily on the first write, so before vmagent's
-	// first remote-write lands the count() pushdown sees an empty fetcher and 422s. Poll a trivial
-	// selector until it returns a sample — guarantees the engine exists before the suite runs.
-	if err := waitData(cfg); err != nil {
-		return err
+	return benchTargets(cfg)
+}
+
+// benchTargets gates each instance on data (the per-tenant engine is created lazily on the first
+// write, so before vmagent's first remote-write lands the count() pushdown sees an empty fetcher and
+// 422s), benches it, then renders one side-by-side report from the collected results.
+func benchTargets(cfg config) error {
+	var results []targetResult
+	for _, tgt := range cfg.targets() {
+		if err := waitData(cfg, tgt); err != nil {
+			return err
+		}
+		res, err := bench(cfg, tgt)
+		if err != nil {
+			return err
+		}
+		results = append(results, res)
 	}
-	return bench(cfg)
+	return renderComparison(cfg, results)
 }
 
 func loadConfig() (config, error) {
@@ -121,7 +160,11 @@ func loadConfig() (config, error) {
 	}
 
 	flag.IntVar(&cfg.nodes, "nodes", envInt("BENCH_NODES", 100), "synthetic node_exporter hosts vmagent fans out (~1400 series each)")
-	flag.DurationVar(&cfg.prewarm, "prewarm", envDur("PREWARM", 10*time.Second), "ingest window before querying")
+	// Default prewarm covers the 120s lookback with margin. The measured cost is dominated by how many
+	// flushed parts the query window spans, so a prewarm shorter than the lookback leaves the window
+	// only partially populated and the numbers collapse to unrepresentatively fast (and never exercise
+	// the s3 read path). The benchmark's own rule: lookback ≤ prewarm. See loadConfig's warning below.
+	flag.DurationVar(&cfg.prewarm, "prewarm", envDur("PREWARM", 150*time.Second), "ingest window before querying (must be ≥ -lookback to fully populate it)")
 	flag.IntVar(&cfg.runs, "runs", envInt("BENCH_RUNS", 20), "measured runs per query (after warmup)")
 	flag.IntVar(&cfg.warmup, "warmup", envInt("BENCH_WARMUP", 5), "unmeasured warmup runs")
 	flag.DurationVar(&cfg.lookback, "lookback", envDur("LOOKBACK", 120*time.Second), "range-query window back from now")
@@ -131,19 +174,27 @@ func loadConfig() (config, error) {
 	flag.StringVar(&cfg.gomemlimit, "gomemlimit", envStr("GOMEMLIMIT", "1GiB"), "oteldb soft memory cap")
 	flag.StringVar(&cfg.goarch, "goarch", envStr("GOARCH", "amd64"), "target arch (matches the container)")
 
-	flag.BoolVar(&cfg.replace, "replace", envBool("REPLACE", false), "rebuild oteldb, swap it in place (stack already up), re-bench")
-	flag.BoolVar(&cfg.cleanup, "cleanup", !cfg.replace, "tear the stack down on exit (default true unless -replace)")
+	flag.BoolVar(&cfg.cleanup, "cleanup", envBool("CLEANUP", true), "tear the stack down on exit (-cleanup=false leaves it up to re-run / grab pprof)")
+	flag.BoolVar(&cfg.s3, "s3", envBool("BENCH_S3", true), "also bench the S3 (go-faster/fs) backend alongside the file backend")
 
 	flag.IntVar(&cfg.concurrency, "concurrency", envInt("CONCURRENCY", 8), "concurrent in-flight queries for the verify pass")
 
-	flag.StringVar(&cfg.addr, "addr", envStr("ADDR", "http://127.0.0.1:9090"), "oteldb PromQL API address")
+	flag.StringVar(&cfg.addr, "addr", envStr("ADDR", "http://127.0.0.1:9090"), "oteldb (file backend) PromQL API address")
+	flag.StringVar(&cfg.addrS3, "addr-s3", envStr("ADDR_S3", "http://127.0.0.1:9093"), "oteldb-s3 (S3 backend) PromQL API address")
 	flag.StringVar(&cfg.queries, "queries", envStr("BENCH_QUERIES", "queries.promql.yml"), "otelbench query suite file")
 	flag.Parse()
 
-	// In replace mode, never tear down — we don't own the full stack bring-up.
-	if cfg.replace {
-		cfg.cleanup = false
+	// The range queries evaluate over [now-lookback, now]; that window is only as populated as the
+	// prewarm allows. A prewarm shorter than the lookback measures a mostly-empty window — queries
+	// scan a fraction of the parts they would at steady state and report unrepresentatively low
+	// latencies (and barely touch S3, collapsing the file-vs-s3 gap). Warn rather than hard-fail so a
+	// deliberate quick smoke run (-prewarm 10s) is still possible.
+	if cfg.prewarm < cfg.lookback {
+		fmt.Fprintf(os.Stderr, "!! warning: -prewarm=%s < -lookback=%s: the query window will be under-populated "+
+			"and latencies will read low (not comparable to REPORT.md). Use -prewarm ≥ %s.\n",
+			cfg.prewarm, cfg.lookback, cfg.lookback)
 	}
+
 	return cfg, nil
 }
 
@@ -177,8 +228,12 @@ func fullBringup(cfg config) error {
 	if err := genScrape(cfg); err != nil {
 		return err
 	}
-	fmt.Printf(">> Starting stack (oteldb --embedded on file backend, GOMAXPROCS=%s, GOMEMLIMIT=%s, nodes=%d)\n",
-		cfg.gomaxprocs, cfg.gomemlimit, cfg.nodes)
+	backends := "file backend"
+	if cfg.s3 {
+		backends = "file + s3 backends"
+	}
+	fmt.Printf(">> Starting stack (oteldb --embedded on %s, GOMAXPROCS=%s, GOMEMLIMIT=%s, nodes=%d)\n",
+		backends, cfg.gomaxprocs, cfg.gomemlimit, cfg.nodes)
 	// docker compose picks up GOMAXPROCS/GOMEMLIMIT from our env via the compose ${VAR:-…} substitution.
 	cmd := exec.Command("docker", "compose", "up", "-d", "--build", "--remove-orphans")
 	cmd.Dir = cfg.benchDir
@@ -187,28 +242,17 @@ func fullBringup(cfg config) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)
 	}
-	return waitHealth(cfg)
+	return waitHealthAll(cfg)
 }
 
-func replaceAndBench(cfg config) error {
-	fmt.Println(">> REPLACE: rebuilding oteldb image (one COPY layer) and swapping the container in place")
-	fmt.Println(">>   (node-exporter / vmagent / data volume keep running — no re-ingest)")
-	cmd := exec.Command("docker", "compose", "up", "-d", "--build", "--force-recreate", "--no-deps", "oteldb")
-	cmd.Dir = cfg.benchDir
-	wire(cmd)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose up (replace): %w", err)
+// waitHealthAll waits for every benched instance's /liveness to answer.
+func waitHealthAll(cfg config) error {
+	for _, tgt := range cfg.targets() {
+		if err := waitHealth(cfg, tgt); err != nil {
+			return err
+		}
 	}
-	if err := waitHealth(cfg); err != nil {
-		return err
-	}
-	if err := waitData(cfg); err != nil {
-		return err
-	}
-	// vmagent kept remote-writing, so the new oteldb's head refills within a couple scrapes.
-	fmt.Println(">> Settling 5s for ingest to refill the new oteldb head")
-	time.Sleep(5 * time.Second)
-	return bench(cfg)
+	return nil
 }
 
 // genScrape writes vmagent's scrape config: one node_exporter × BENCH_NODES synthetic hosts.
@@ -225,12 +269,12 @@ func genScrape(cfg config) error {
 
 // waitHealth polls oteldb's published /liveness port until it answers or the deadline expires.
 // On timeout it tails oteldb logs + status so a crash/config error is visible.
-func waitHealth(cfg config) error {
-	fmt.Printf(">> Waiting for oteldb health (up to %s)\n", cfg.healthWait)
+func waitHealth(cfg config, tgt target) error {
+	fmt.Printf(">> Waiting for %s (%s) health (up to %s)\n", tgt.service, tgt.name, cfg.healthWait)
 	client := &http.Client{Timeout: time.Second}
 	deadline := time.Now().Add(cfg.healthWait)
 	for time.Now().Before(deadline) {
-		resp, err := client.Get(cfg.addrLiveness())
+		resp, err := client.Get(tgt.healthURL)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -242,77 +286,88 @@ func waitHealth(cfg config) error {
 		time.Sleep(time.Second)
 	}
 	fmt.Println()
-	fmt.Fprintln(os.Stderr, "!! oteldb did not become healthy; tailing logs:")
-	_ = composeLogs(cfg, "oteldb", 100)
+	fmt.Fprintf(os.Stderr, "!! %s did not become healthy; tailing logs:\n", tgt.service)
+	_ = composeLogs(cfg, tgt.service, 100)
 	fmt.Fprintln(os.Stderr, "!! container status:")
 	_ = composePs(cfg)
-	return errors.New("oteldb health check timed out")
+	return fmt.Errorf("%s health check timed out", tgt.service)
 }
 
-func (c config) addrLiveness() string {
-	// The PromQL API is on :9090; the health endpoint is the same host on :13133.
-	return strings.Replace(c.addr, ":9090", ":13133", 1) + "/liveness"
+// targetResult holds one instance's benched numbers: the per-query latency samples (parsed from the
+// otelbench report) in suite order, plus the peak RSS sampled across the run. renderComparison turns
+// a slice of these into the side-by-side REPORT.md.
+type targetResult struct {
+	target  target
+	order   []string             // query titles in suite order.
+	groups  map[string][]float64 // title → latency samples in nanoseconds.
+	peakRSS int64                // peak container RSS in bytes (0 if unsampled).
 }
 
 // bench runs a result-verification pass (one query each, asserting non-empty and positive counts),
-// then the warmup + measured timing passes. The verification pass exists because otelbench reports
-// only latency — a query that silently returns the empty vector (or {0} for a count) still counts
-// as a "successful" run, so a correctness regression surfaces as faster numbers, not a failure.
-func bench(cfg config) error {
+// then the warmup + measured timing passes, against one instance. The verification pass exists
+// because otelbench reports only latency — a query that silently returns the empty vector (or {0}
+// for a count) still counts as a "successful" run, so a correctness regression surfaces as faster
+// numbers, not a failure. It returns the parsed report + peak RSS for the side-by-side render.
+func bench(cfg config, tgt target) (targetResult, error) {
 	end := time.Now()
 	start := end.Add(-cfg.lookback)
 
-	// Sample the oteldb container's resident set size across the whole bench (verify + warmup +
-	// measured), tracking the peak. RSS is the headline memory cost to pair with the latency numbers:
-	// the file backend mmaps its parts, so the peak shows the real footprint under GOMEMLIMIT.
+	fmt.Printf(">> [%s] Benching %s at %s\n", tgt.name, tgt.service, tgt.promAddr)
+
+	// Sample the instance's resident set size across the whole bench (verify + warmup + measured),
+	// tracking the peak. RSS is the headline memory cost to pair with the latency numbers.
 	stopRSS := make(chan struct{})
-	peakRSSCh := sampleRSS(cfg, stopRSS)
+	peakRSSCh := sampleRSS(cfg, tgt.service, stopRSS)
+	drainRSS := func() int64 { close(stopRSS); return <-peakRSSCh }
 
-	fmt.Printf(">> Verify (one query each, %d concurrent; non-empty + positive counts)\n", cfg.concurrency)
-	if err := verify(cfg, start, end); err != nil {
-		close(stopRSS)
-		<-peakRSSCh
-		return err
+	fmt.Printf(">> [%s] Verify (one query each, %d concurrent; non-empty + positive counts)\n", tgt.name, cfg.concurrency)
+	if err := verify(cfg, tgt, start, end); err != nil {
+		drainRSS()
+		return targetResult{}, err
 	}
 
-	fmt.Printf(">> Warmup (%d runs/query, unmeasured)\n", cfg.warmup)
-	if err := runOtelbench(cfg, 0, cfg.warmup, start, end, ""); err != nil {
-		close(stopRSS)
-		<-peakRSSCh
-		return err
+	fmt.Printf(">> [%s] Warmup (%d runs/query, unmeasured)\n", tgt.name, cfg.warmup)
+	if err := runOtelbench(cfg, tgt, 0, cfg.warmup, start, end, ""); err != nil {
+		drainRSS()
+		return targetResult{}, err
 	}
 
-	fmt.Printf(">> Benchmark (%d measured runs/query, window %s)\n", cfg.runs, cfg.lookback)
-	report := filepath.Join(cfg.benchDir, "report.yml")
-	if err := runOtelbench(cfg, cfg.runs, 0, start, end, report); err != nil {
-		close(stopRSS)
-		<-peakRSSCh
-		return err
+	fmt.Printf(">> [%s] Benchmark (%d measured runs/query, window %s)\n", tgt.name, cfg.runs, cfg.lookback)
+	report := filepath.Join(cfg.benchDir, "report-"+tgt.name+".yml")
+	if err := runOtelbench(cfg, tgt, cfg.runs, 0, start, end, report); err != nil {
+		drainRSS()
+		return targetResult{}, err
 	}
 
-	close(stopRSS)
-	peakRSS := <-peakRSSCh
+	peakRSS := drainRSS()
 	if peakRSS > 0 {
-		fmt.Printf(">> Peak oteldb RSS during bench: %s\n", humanBytes(peakRSS))
+		fmt.Printf(">> [%s] Peak RSS during bench: %s\n", tgt.name, humanBytes(peakRSS))
 	} else {
-		fmt.Fprintln(os.Stderr, "!! warning: could not sample oteldb RSS (docker compose exec failed)")
+		fmt.Fprintf(os.Stderr, "!! [%s] warning: could not sample RSS (docker compose exec failed)\n", tgt.name)
 	}
 
-	fmt.Printf(">> Report written to %s\n", report)
-	if err := renderReport(cfg, report, peakRSS); err != nil {
-		// Non-fatal: the raw report.yml is still there; the markdown render is a convenience.
-		fmt.Fprintf(os.Stderr, "!! warning: render REPORT.md: %v\n", err)
+	order, groups, err := parseReport(cfg, report)
+	if err != nil {
+		return targetResult{}, err
 	}
-	return nil
+	return targetResult{target: tgt, order: order, groups: groups, peakRSS: peakRSS}, nil
 }
 
 // sampleRSS polls the oteldb container's RSS (VmRSS from /proc/1/status, where the static oteldb
 // binary runs as PID 1) every 500ms until stop is closed, then sends the peak in bytes. A failed
 // poll (container momentarily unavailable) is skipped; a peak of 0 means no poll ever succeeded.
-func sampleRSS(cfg config, stop <-chan struct{}) <-chan int64 {
+func sampleRSS(cfg config, service string, stop <-chan struct{}) <-chan int64 {
 	out := make(chan int64, 1)
 	go func() {
 		var peak int64
+		sample := func() {
+			if rss, ok := readRSS(cfg, service); ok && rss > peak {
+				peak = rss
+			}
+		}
+		// Take one reading immediately so even a sub-tick-length bench (e.g. a small -nodes / -runs
+		// smoke run that finishes in under 500ms) still records a non-zero peak.
+		sample()
 		t := time.NewTicker(500 * time.Millisecond)
 		defer t.Stop()
 		for {
@@ -321,19 +376,17 @@ func sampleRSS(cfg config, stop <-chan struct{}) <-chan int64 {
 				out <- peak
 				return
 			case <-t.C:
-				if rss, ok := readRSS(cfg); ok && rss > peak {
-					peak = rss
-				}
+				sample()
 			}
 		}
 	}()
 	return out
 }
 
-// readRSS reads VmRSS from the oteldb container's /proc/1/status via `docker compose exec`, returning
+// readRSS reads VmRSS from the given container's /proc/1/status via `docker compose exec`, returning
 // the resident set size in bytes.
-func readRSS(cfg config) (int64, bool) {
-	cmd := exec.Command("docker", "compose", "exec", "-T", "oteldb", "cat", "/proc/1/status")
+func readRSS(cfg config, service string) (int64, bool) {
+	cmd := exec.Command("docker", "compose", "exec", "-T", service, "cat", "/proc/1/status")
 	cmd.Dir = cfg.benchDir
 	out, err := cmd.Output()
 	if err != nil {
@@ -493,7 +546,7 @@ func verifyOne(client *http.Client, addr string, q benchQuery, start, end time.T
 	return verifyResult{line: fmt.Sprintf("   %-32s ok (%d series)\n", q.title, len(resp.Data.Result))}
 }
 
-func verify(cfg config, start, end time.Time) error {
+func verify(cfg config, tgt target, start, end time.Time) error {
 	qPath := cfg.queries
 	if !filepath.IsAbs(qPath) {
 		qPath = filepath.Join(cfg.benchDir, qPath)
@@ -516,7 +569,7 @@ func verify(cfg config, start, end time.Time) error {
 		go func(i int, q benchQuery) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[i] = verifyOne(client, cfg.addr, q, start, end)
+			results[i] = verifyOne(client, tgt.promAddr, q, start, end)
 		}(i, q)
 	}
 	wg.Wait()
@@ -618,13 +671,13 @@ func parseJSONSample(pair [2]any) (float64, bool) {
 	return f, err == nil
 }
 
-// renderReport writes a human-readable REPORT.md (p50/p90/p99 per query) by parsing the benchstat
-// rows otelbench emits for report.yml.
-func renderReport(cfg config, reportPath string, peakRSS int64) error {
+// parseReport runs `otelbench promql analyze` over one instance's report and returns its per-query
+// latency samples (nanoseconds) keyed by title, plus the titles in suite order.
+func parseReport(cfg config, reportPath string) ([]string, map[string][]float64, error) {
 	out, err := exec.Command(filepath.Join(cfg.benchDir, "otelbench"),
 		"promql", "analyze", "-f", "benchstat", "-i", reportPath).Output()
 	if err != nil {
-		return fmt.Errorf("otelbench analyze: %w", err)
+		return nil, nil, fmt.Errorf("otelbench analyze: %w", err)
 	}
 
 	// benchstat line: `BenchmarkPromQL/<Title> 0 <nanos> ns/op [extra cols…]`
@@ -648,31 +701,68 @@ func renderReport(cfg config, reportPath string, peakRSS int64) error {
 		}
 		groups[title] = append(groups[title], nanos)
 	}
+	return order, groups, nil
+}
+
+// renderComparison writes a human-readable REPORT.md placing each benched backend side by side:
+// p50/p90/p99/max per query for every instance, plus each instance's peak RSS. With only the file
+// backend selected (-s3=false) it degenerates to the single-backend table.
+func renderComparison(cfg config, results []targetResult) error {
+	if len(results) == 0 {
+		return errors.New("no results to render")
+	}
 
 	var b strings.Builder
 	fmt.Fprintln(&b, "# embedded-bench — oteldb PromQL report")
 	fmt.Fprintln(&b)
-	fmt.Fprintf(&b, "_oteldb `--embedded` on the `file` backend, GOMAXPROCS=%s GOMEMLIMIT=%s, "+
-		"nodes=%d (~%d series), window=%s, %d runs/query_\n",
-		cfg.gomaxprocs, cfg.gomemlimit, cfg.nodes, cfg.nodes*1400, cfg.lookback, cfg.runs)
-	fmt.Fprintln(&b)
-	if peakRSS > 0 {
-		fmt.Fprintf(&b, "Peak oteldb RSS during bench: **%s**.\n", humanBytes(peakRSS))
-		fmt.Fprintln(&b)
+	backends := make([]string, len(results))
+	for i, r := range results {
+		backends[i] = "`" + r.target.name + "`"
 	}
+	fmt.Fprintf(&b, "_oteldb `--embedded`, backends: %s, GOMAXPROCS=%s GOMEMLIMIT=%s, "+
+		"nodes=%d (~%d series), window=%s, %d runs/query_\n",
+		strings.Join(backends, " vs "), cfg.gomaxprocs, cfg.gomemlimit, cfg.nodes, cfg.nodes*1400, cfg.lookback, cfg.runs)
+	fmt.Fprintln(&b)
+
+	// Peak RSS per backend.
+	for _, r := range results {
+		if r.peakRSS > 0 {
+			fmt.Fprintf(&b, "- Peak `%s` RSS during bench: **%s**.\n", r.target.name, humanBytes(r.peakRSS))
+		}
+	}
+	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "Latencies in milliseconds.")
 	fmt.Fprintln(&b)
-	b.WriteString("| query | runs | p50 | p90 | p99 | max |\n")
-	b.WriteString("|---|---:|---:|---:|---:|---:|\n")
+
+	// Header: query | runs | <backend> p50 | p90 | p99 | max | … per backend.
+	b.WriteString("| query | runs |")
+	for _, r := range results {
+		fmt.Fprintf(&b, " %s p50 | p90 | p99 | max |", r.target.name)
+	}
+	b.WriteString("\n|---|---:|")
+	for range results {
+		b.WriteString("---:|---:|---:|---:|")
+	}
+	b.WriteString("\n")
+
+	// Row order follows the first backend's suite order (identical across backends — same suite).
+	order := results[0].order
 	if len(order) == 0 {
-		b.WriteString("| _no parsed rows_ | | | | | |\n")
+		b.WriteString("| _no parsed rows_ |\n")
 	}
 	for _, title := range order {
-		xs := groups[title]
-		slices.Sort(xs)
-		fmt.Fprintf(&b, "| `%s` | %d | %.1f | %.1f | %.1f | %.1f |\n",
-			humanTitle(title), len(xs),
-			ms(pct(xs, 0.50)), ms(pct(xs, 0.90)), ms(pct(xs, 0.99)), ms(xs[len(xs)-1]))
+		fmt.Fprintf(&b, "| `%s` | %d |", humanTitle(title), len(results[0].groups[title]))
+		for _, r := range results {
+			xs := append([]float64(nil), r.groups[title]...)
+			if len(xs) == 0 {
+				b.WriteString(" — | — | — | — |")
+				continue
+			}
+			slices.Sort(xs)
+			fmt.Fprintf(&b, " %.1f | %.1f | %.1f | %.1f |",
+				ms(pct(xs, 0.50)), ms(pct(xs, 0.90)), ms(pct(xs, 0.99)), ms(xs[len(xs)-1]))
+		}
+		b.WriteString("\n")
 	}
 
 	report := filepath.Join(cfg.benchDir, "REPORT.md")
@@ -709,7 +799,7 @@ func humanTitle(title string) string {
 
 // runOtelbench invokes the host-built otelbench binary with the suite + window. reportOut is empty
 // for the unmeasured warmup pass (otelbench then prints but writes no file).
-func runOtelbench(cfg config, count, warmup int, start, end time.Time, reportOut string) error {
+func runOtelbench(cfg config, tgt target, count, warmup int, start, end time.Time, reportOut string) error {
 	// Resolve the queries file relative to the bench dir regardless of cwd.
 	qPath := cfg.queries
 	if !filepath.IsAbs(qPath) {
@@ -717,7 +807,7 @@ func runOtelbench(cfg config, count, warmup int, start, end time.Time, reportOut
 	}
 	args := []string{
 		"promql", "bench",
-		"--addr", cfg.addr,
+		"--addr", tgt.promAddr,
 		"-i", qPath,
 		"--warmup", strconv.Itoa(warmup),
 		"--count", strconv.Itoa(count),
@@ -738,21 +828,21 @@ func runOtelbench(cfg config, count, warmup int, start, end time.Time, reportOut
 
 func maybeCleanup(cfg config) {
 	if cfg.cleanup {
-		fmt.Println(">> Stopping (-cleanup=false to keep the stack up for -replace runs)")
+		fmt.Println(">> Stopping (-cleanup=false to keep the stack up to re-run / grab pprof)")
 		_ = exec.Command("docker", "compose", "down", "-v").Run()
 		return
 	}
-	fmt.Printf(">> Leaving stack up: oteldb at %s, pprof at http://127.0.0.1:9010\n", cfg.addr)
-	fmt.Println(">>   iterate with: go run . -replace")
+	fmt.Printf(">> Leaving stack up: oteldb (file) at %s, oteldb-s3 at %s\n", cfg.addr, cfg.addrS3)
+	fmt.Println(">>   pprof: file http://127.0.0.1:9010, s3 http://127.0.0.1:9012")
 }
 
 // waitData polls a trivial selector until it returns a sample, guaranteeing the per-tenant engine
 // exists (it is created lazily on first write) before the count() pushdown runs. Without this the
 // suite's count({...}) query races vmagent's first remote-write and 422s with "count pushdown not
 // supported by fetcher" — the empty pre-write fetcher is not a Counter.
-func waitData(cfg config) error {
-	fmt.Printf(">> Waiting for first queryable sample (up to %s)\n", cfg.healthWait)
-	q := cfg.addr + "/api/v1/query?query=node_load1"
+func waitData(cfg config, tgt target) error {
+	fmt.Printf(">> [%s] Waiting for first queryable sample (up to %s)\n", tgt.name, cfg.healthWait)
+	q := tgt.promAddr + "/api/v1/query?query=node_load1"
 	deadline := time.Now().Add(cfg.healthWait)
 	client := &http.Client{Timeout: 2 * time.Second}
 	for time.Now().Before(deadline) {

--- a/dev/local/embedded-bench/oteldb-s3.yml
+++ b/dev/local/embedded-bench/oteldb-s3.yml
@@ -1,0 +1,50 @@
+# oteldb config for the embedded-engine PromQL benchmark — S3 variant.
+#
+# Same embedded github.com/oteldb/storage engine as oteldb.yml, but its object-store backend is the
+# shared go-faster/fs S3 server (service `fs`, bucket `oteldb-s3`) instead of a local `file` volume.
+# This is the apples-to-apples object-store substrate: durable data lives in S3, only the WAL is
+# local. Everything else (query API limits, receivers, flush cadence) is kept identical to the file
+# variant so a REPORT.md comparison isolates the backend, not the query settings.
+#
+# The ClickHouse DSN below is ignored under --embedded; kept only so the receiver/exporter wiring
+# parses.
+storage:
+  backend: s3
+  # Local write-ahead log — the only on-disk state for the stateless s3 backend (so the unflushed
+  # head survives a restart rather than only the flushed objects).
+  wal_dir: /data/wal
+  s3:
+    bucket: oteldb-s3
+    endpoint: http://fs:9000
+    region: us-east-1
+    force_path_style: true       # go-faster/fs serves path-style (endpoint/bucket/key).
+    access_key_id: bench
+    secret_access_key: benchbench
+  # 10s flush cadence — matches the file variant. Flushing head data to S3 on this interval is what
+  # makes a short bench actually exercise (and measure) the object-store read path rather than
+  # serving only from the in-memory head. The default (0) is size-triggered only, so a one-shot
+  # ingest would never reach S3.
+  flush_interval: 10s
+
+prometheus:
+  bind: 0.0.0.0:9090
+  max_samples: 10_000_000
+  timeout: 5m
+  enable_negative_offset: true
+
+health_check:
+  bind: 0.0.0.0:13133
+
+otelcol:
+  receivers:
+    prometheusremotewrite:
+      endpoint: 0.0.0.0:19291
+      time_threshold: 100000h
+  exporters:
+    oteldbexporter:
+      dsn: clickhouse://default:default@ignored:9000
+  service:
+    pipelines:
+      metrics:
+        receivers: [prometheusremotewrite]
+        exporters: [oteldbexporter]


### PR DESCRIPTION
## Summary

Extends `dev/local/embedded-bench` to benchmark oteldb's **`file`** and **go-faster/fs `s3`** storage backends side by side off a single live ingest stream, replacing the previous single-backend setup. Also drops the `-replace` flag and fixes a default that made results unrepresentative.

## What changed

**S3 backend variant**
- Adds the `fs` S3 server (`ghcr.io/go-faster/fs`, the same substrate Mimir/Loki/Tempo use in the cross-engine benchmark), an `fs-init` bucket bootstrapper, and an `oteldb-s3` instance on the `s3` backend (`oteldb-s3.yml`).
- `vmagent` now remote-writes the identical stream to both instances (apples-to-apples).
- The orchestrator benches each target and renders a side-by-side `REPORT.md` (per-backend p50/p90/p99/max + peak RSS). Ports shifted for the s3 instance (PromQL `:9093`, pprof `:9012`, health `:13134`).

**Dropped `-replace`**
- Removed the flag, `replaceAndBench`, and all doc/comment references.

**Fixed "numbers too low"**
- The default prewarm (`10s`) was far below the `120s` lookback, so the query window was only ~8% populated and the S3 read path was never exercised (`s3 ≈ file`).
- Raised the default to `2m30s` (≥ lookback, per the benchmark's own *"lookback ≤ prewarm"* rule) and added a startup warning when `-prewarm < -lookback`.

## Evidence

`cpu usage ratio` p90 (ms), nodes=100, GOMEMLIMIT=1GiB:

| prewarm | file | s3 | cross-engine reference |
|---|---|---|---|
| 10s (old default) | 95 | 101 | 259 / 838 |
| **2m30s (new default)** | **683** | **895** | **259 / 838** |

At a full window the s3 backend lands on the reference (895 vs 838) and properly exceeds file — the object-store path is genuinely exercised. Profiling confirms the heavy queries are decode + GC bound (not CPU-parallelism bound).

## Notes
- `REPORT.md` and the per-backend `report-*.yml` are gitignored (local artifacts).
- Build (`go build .`), `go vet`, and `gofmt` are clean.