### PR TITLE
fix(traceql): only propagate query-referenced attributes in search results

### DIFF
--- a/integration/tempoe2e/common_test.go
+++ b/integration/tempoe2e/common_test.go
@@ -594,10 +594,11 @@ func runTest(
 			a.Equal(int64(expectSpan.StartTimestamp()), start)
 			a.Equal(int64(expectSpan.EndTimestamp()), end)
 
-			a.Equal(
-				getRawMapFromAPI(gotSpan.Attributes),
-				expectSpan.Attributes().AsRaw(),
-			)
+			// TraceQL search only propagates attributes referenced by the
+			// query, so the API response is a subset of the raw span
+			// attributes (unlike logfmt tag search, which returns full
+			// span attributes and is thus an exact match).
+			assertAttrsSubset(a, expectSpan.Attributes().AsRaw(), getRawMapFromAPI(gotSpan.Attributes))
 		}
 	}
 
@@ -881,6 +882,16 @@ func runTest(
 			a.Empty(r.Traces)
 		})
 	})
+}
+
+// assertAttrsSubset asserts that every key/value pair in got is present
+// with the same value in want.
+func assertAttrsSubset(a *require.Assertions, want, got map[string]any) {
+	for k, gotVal := range got {
+		wantVal, ok := want[k]
+		a.Truef(ok, "unexpected attribute %q", k)
+		a.Equalf(wantVal, gotVal, "attribute %q", k)
+	}
 }
 
 func getRawMapFromAPI(obj []tempoapi.KeyValue) map[string]any {

--- a/internal/traceql/traceqlengine/attrs.go
+++ b/internal/traceql/traceqlengine/attrs.go
@@ -1,0 +1,77 @@
+package traceqlengine
+
+import "github.com/oteldb/oteldb/internal/traceql"
+
+// referencedAttributes collects span/resource/instrumentation/event/link
+// attribute names referenced by filter, aggregate, group and select
+// expressions in expr.
+//
+// Tempo's search API only ever echoes attributes bound by the query itself
+// (filter/select conditions), not the whole span/resource attribute set.
+// This is used to match that behavior: propagating every attribute
+// regardless of relevance can blow up response size (e.g. large payload
+// attributes) and produce a different, unstable set of columns per row,
+// which some Tempo API consumers (e.g. Grafana's TraceQL search table) do
+// not handle well.
+func referencedAttributes(expr traceql.Expr) map[string]struct{} {
+	set := make(map[string]struct{})
+	collectExprAttrs(expr, set)
+	return set
+}
+
+func collectExprAttrs(expr traceql.Expr, set map[string]struct{}) {
+	switch expr := expr.(type) {
+	case *traceql.BinaryExpr:
+		collectExprAttrs(expr.Left, set)
+		collectExprAttrs(expr.Right, set)
+	case *traceql.SpansetPipeline:
+		for _, stage := range expr.Pipeline {
+			collectStageAttrs(stage, set)
+		}
+	}
+}
+
+func collectStageAttrs(stage traceql.PipelineStage, set map[string]struct{}) {
+	switch stage := stage.(type) {
+	case *traceql.BinarySpansetExpr:
+		collectStageAttrs(stage.Left, set)
+		collectStageAttrs(stage.Right, set)
+	case *traceql.SpansetFilter:
+		collectFieldExprAttrs(stage.Expr, set)
+	case *traceql.ScalarFilter:
+		collectScalarExprAttrs(stage.Left, set)
+		collectScalarExprAttrs(stage.Right, set)
+	case *traceql.GroupOperation:
+		collectFieldExprAttrs(stage.By, set)
+	case *traceql.SelectOperation:
+		for _, arg := range stage.Args {
+			collectFieldExprAttrs(arg, set)
+		}
+	}
+}
+
+func collectFieldExprAttrs(expr traceql.FieldExpr, set map[string]struct{}) {
+	switch expr := expr.(type) {
+	case *traceql.BinaryFieldExpr:
+		collectFieldExprAttrs(expr.Left, set)
+		collectFieldExprAttrs(expr.Right, set)
+	case *traceql.UnaryFieldExpr:
+		collectFieldExprAttrs(expr.Expr, set)
+	case *traceql.Attribute:
+		if expr.Prop == traceql.SpanAttribute {
+			set[expr.Name] = struct{}{}
+		}
+	}
+}
+
+func collectScalarExprAttrs(expr traceql.ScalarExpr, set map[string]struct{}) {
+	switch expr := expr.(type) {
+	case *traceql.BinaryScalarExpr:
+		collectScalarExprAttrs(expr.Left, set)
+		collectScalarExprAttrs(expr.Right, set)
+	case *traceql.AggregateScalarExpr:
+		if expr.Field != nil {
+			collectFieldExprAttrs(expr.Field, set)
+		}
+	}
+}

--- a/internal/traceql/traceqlengine/attrs_test.go
+++ b/internal/traceql/traceqlengine/attrs_test.go
@@ -1,0 +1,48 @@
+package traceqlengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/traceql"
+)
+
+func TestReferencedAttributes(t *testing.T) {
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{`{}`, nil},
+		{`{ name = "Span #1" }`, nil},
+		{`{ .service.name = "openrouter" }`, []string{"service.name"}},
+		{`{ span.http.status_code = 200 }`, []string{"http.status_code"}},
+		{
+			`{ span.http.status_code = 200 && resource.service.name = "foo" }`,
+			[]string{"http.status_code", "service.name"},
+		},
+		{
+			`{ span.a = "x" } && { span.b = "y" }`,
+			[]string{"a", "b"},
+		},
+		{
+			`{ span.a = "x" } | avg(span.b) > 1`,
+			[]string{"a", "b"},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			expr, err := traceql.Parse(tt.query)
+			require.NoError(t, err)
+
+			got := referencedAttributes(expr)
+			gotNames := make([]string, 0, len(got))
+			for name := range got {
+				gotNames = append(gotNames, name)
+			}
+
+			require.ElementsMatch(t, tt.want, gotNames)
+		})
+	}
+}

--- a/internal/traceql/traceqlengine/engine.go
+++ b/internal/traceql/traceqlengine/engine.go
@@ -98,6 +98,9 @@ func (e *Engine) evalExpr(ctx context.Context, expr traceql.Expr, params EvalPar
 	if err != nil {
 		return nil, errors.Wrap(err, "build pipeline")
 	}
+	// Only propagate attributes actually referenced by the query, matching
+	// Tempo's search API behavior. See [referencedAttributes].
+	allowedAttrs := referencedAttributes(expr)
 
 	iter, err := e.querier.SelectSpansets(
 		ctx,
@@ -184,12 +187,12 @@ func (e *Engine) evalExpr(ctx context.Context, expr traceql.Expr, params EvalPar
 
 			var spans tempoapi.TempoSpanSet
 			for _, span := range s.Spans {
-				spans.Spans = append(spans.Spans, span.AsTempoSpan())
+				spans.Spans = append(spans.Spans, span.AsTempoSpanFiltered(allowedAttrs))
 			}
 
-			// Add attributes from root.
-			tracestorage.ConvertToTempoAttrs(&spans.Attributes, root.ScopeAttrs)
-			tracestorage.ConvertToTempoAttrs(&spans.Attributes, root.ResourceAttrs)
+			// Add attributes from root, referenced by the query only.
+			tracestorage.ConvertToTempoAttrsFiltered(&spans.Attributes, root.ScopeAttrs, allowedAttrs)
+			tracestorage.ConvertToTempoAttrsFiltered(&spans.Attributes, root.ResourceAttrs, allowedAttrs)
 			result = append(result, tempoapi.TraceSearchMetadata{
 				TraceID:           s.TraceID.Hex(),
 				RootServiceName:   tempoapi.NewOptString(s.RootServiceName),

--- a/internal/tracestorage/schema_tempo.go
+++ b/internal/tracestorage/schema_tempo.go
@@ -46,6 +46,20 @@ func (span Span) AsTempoSpan() (s tempoapi.TempoSpan) {
 	return s
 }
 
+// AsTempoSpanFiltered is like [Span.AsTempoSpan], but only attributes whose
+// key is in allowed are converted.
+func (span Span) AsTempoSpanFiltered(allowed map[string]struct{}) (s tempoapi.TempoSpan) {
+	s = tempoapi.TempoSpan{
+		SpanID:            span.SpanID.Hex(),
+		Name:              tempoapi.NewOptString(span.Name),
+		StartTimeUnixNano: time.Unix(0, int64(span.Start)),
+		DurationNanos:     int64(span.End - span.Start),
+		Attributes:        nil,
+	}
+	ConvertToTempoAttrsFiltered(&s.Attributes, span.Attrs, allowed)
+	return s
+}
+
 // ConvertToTempoAttrs converts [otelstorage.Attrs] to Tempo API attributes.
 func ConvertToTempoAttrs(to *tempoapi.Attributes, from otelstorage.Attrs) {
 	if from.IsZero() {
@@ -54,6 +68,25 @@ func ConvertToTempoAttrs(to *tempoapi.Attributes, from otelstorage.Attrs) {
 	m := from.AsMap()
 	*to = slices.Grow(*to, m.Len())
 	m.Range(func(k string, v pcommon.Value) bool {
+		*to = append(*to, tempoapi.KeyValue{
+			Key:   k,
+			Value: otelToTempoValue(v),
+		})
+		return true
+	})
+}
+
+// ConvertToTempoAttrsFiltered is like [ConvertToTempoAttrs], but only
+// attributes whose key is in allowed are converted.
+func ConvertToTempoAttrsFiltered(to *tempoapi.Attributes, from otelstorage.Attrs, allowed map[string]struct{}) {
+	if from.IsZero() || len(allowed) == 0 {
+		return
+	}
+	m := from.AsMap()
+	m.Range(func(k string, v pcommon.Value) bool {
+		if _, ok := allowed[k]; !ok {
+			return true
+		}
 		*to = append(*to, tempoapi.KeyValue{
 			Key:   k,
 			Value: otelToTempoValue(v),


### PR DESCRIPTION
## Summary
- TraceQL search attached every span/resource/scope attribute to result spansets regardless of the query, unlike real Tempo (which only echoes attributes bound by filter/select expressions).
- This could balloon response size (e.g. large payload attributes like `gen_ai.prompt`) and vary the attribute set per row, which broke Grafana's TraceQL search table rendering (`TypeError: Cannot read properties of undefined (reading '0')`).
- `internal/traceql/traceqlengine/engine.go` now only propagates attributes referenced by the query's filter/scalar-filter/group/select expressions (via new `referencedAttributes` helper in `attrs.go`).
- `internal/tracestorage/schema_tempo.go` gained filtered variants (`ConvertToTempoAttrsFiltered`, `Span.AsTempoSpanFiltered`); the unfiltered helpers are unchanged and still used by the tag-search path in `internal/tempohandler/collector.go`.

## Test plan
- [x] `go build ./...`
- [x] `go test --timeout 10m -race ./internal/traceql/... ./internal/tracestorage/...`
- [x] `golangci-lint run ./internal/traceql/... ./internal/tracestorage/...`
- [ ] Re-verify against the live Grafana Tempo datasource that the TraceQL search table no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)