### PR TITLE
feat(storagebackend): push regexp stream selectors to the postings index

### DIFF
--- a/integration/lokie2e/bench_stream_offload_storage_test.go
+++ b/integration/lokie2e/bench_stream_offload_storage_test.go
@@ -18,8 +18,13 @@ import (
 )
 
 // BenchmarkLogQLStreamSelector measures a resource-label stream selector over a high-cardinality
-// dataset (many services). The embedded querier offloads the equality matcher to the postings index,
-// so only the selected stream's records are fetched and materialized instead of every service's.
+// dataset (many services). The embedded querier offloads the matcher to the postings index, so only
+// the selected streams' records are fetched and materialized instead of every service's.
+//
+// The cases vary how much the selector prunes. Equality and a regexp selecting one service leave a
+// single stream; an alternation leaves two; a match-all regexp leaves every stream, so it measures
+// the pushdown when there is nothing to prune. MatchAllUnpushable (`!=` on a label no stream has)
+// matches the empty string, so it cannot be pushed and is resolved after the fetch.
 func BenchmarkLogQLStreamSelector(b *testing.B) {
 	ctx := context.Background()
 
@@ -57,14 +62,26 @@ func BenchmarkLogQLStreamSelector(b *testing.B) {
 		Direction: logqlengine.DirectionForward,
 		Limit:     10000,
 	}
-	query, err := engine.NewQuery(ctx, `{service_name="svc-07"}`)
-	require.NoError(b, err)
+	for _, tt := range []struct {
+		name, query string
+	}{
+		{"Equality", `{service_name="svc-07"}`},
+		{"Regexp", `{service_name=~"svc-07"}`},
+		{"RegexpAlternation", `{service_name=~"svc-0(7|8)"}`},
+		{"RegexpMatchAll", `{service_name=~"svc-.+"}`},
+		{"MatchAllUnpushable", `{service_name=~"svc-.+", missing!="x"}`},
+	} {
+		query, err := engine.NewQuery(ctx, tt.query)
+		require.NoError(b, err)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := query.Eval(ctx, params); err != nil {
-			b.Fatal(err)
-		}
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := query.Eval(ctx, params); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -220,41 +220,57 @@ func (n *logStreamNode) materializeRange(batches []*fetch.Batch, offsets []int, 
 	return out
 }
 
-// streamFilters resolves the selector's equality matchers to storage fetch filters so the storage
-// drops data before any record is materialized into an entry with a label set (the expensive part of
-// the scan). The in-memory matchSelector still re-checks every surviving record, so this only ever
-// skips work.
+// streamFilters resolves the selector's label matchers to storage fetch filters so the storage drops
+// data before any record is materialized into an entry with a label set (the expensive part of the
+// scan). The in-memory matchSelector still re-checks every surviving record, so this only ever skips
+// work.
 //
 // Resolution uses the engine's key index (LogKeys), which reports every attribute key in the window
 // together with the scope(s) it was observed in (resource/scope = stream identity, record = the
-// per-record attrs column). For an equality (`=`) on a non-empty value, the normalized label is
-// matched back to its raw key(s):
+// per-record attrs column). The normalized label is matched back to its raw key(s):
 //   - a single raw key seen only in stream scope becomes a postings Matcher that prunes whole streams;
 //   - a single raw key seen only in record scope becomes a per-record Condition that drops
 //     non-matching records — this resolves dotted labels too (http_method ← http.method).
+//
+// Every matcher shape is pushed, not just equality: the filters carry a predicate over the typed
+// value, which the postings layer applies to a label's distinct values, so a regexp selector prunes
+// streams instead of being resolved by matchSelector after the fact. The one exception is a matcher
+// that also matches the empty string (`=~".*"`, `!="x"`): LogQL reads an absent label as "", so such
+// a matcher matches streams that lack the label entirely, while the index only knows streams that
+// have it — pushing it would drop them. Those stay with matchSelector, and the label is then only
+// partially applied.
 //
 // Absent labels, collisions (a label mapping to multiple raw keys), and mixed-scope keys (resource on
 // some streams, record on others — soundly pushable as neither) are left to matchSelector.
 // Record-attribute Conditions carry only an exact Match (no bloom Equal hint): the value may be
 // non-string, and a typed value bloom token could wrongly part-prune; the Match still drops rows at
 // the fetch layer.
-// streamFilters resolves the selector (and offloaded pipeline labels) to fetch Matchers/Conditions.
+//
 // selectorPushed reports whether every selector matcher is applied exactly by the returned filters,
 // so a fetched record needs no in-memory matchSelector re-check (used by the bucketed sampling fast
 // path). It shares the single LogKeys lookup.
 func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matchers []fetch.Matcher, conditions []fetch.Condition, selectorPushed bool) {
-	wanted := map[string]string{}
-	addEq := func(matchers []logql.LabelMatcher) {
-		for _, m := range matchers {
-			if m.Op == logql.OpEq && m.Value != "" {
-				wanted[string(m.Label)] = m.Value
+	var (
+		// wanted holds the pushable matchers per label; a label may carry several, which AND.
+		wanted = map[string][]logql.LabelMatcher{}
+		// partial marks a label with a matcher we could not push, so it is never fully applied.
+		partial = map[string]bool{}
+	)
+	add := func(ms []logql.LabelMatcher) {
+		for _, m := range ms {
+			label := string(m.Label)
+			if matchLabel(m, "") {
+				// Matches an absent label too — see above; not soundly pushable.
+				partial[label] = true
+				continue
 			}
+			wanted[label] = append(wanted[label], m)
 		}
 	}
-	addEq(n.selector)       // stream selector labels
-	addEq(n.pipelineLabels) // offloaded pipeline label filters (| L="v")
+	add(n.selector)       // stream selector labels
+	add(n.pipelineLabels) // offloaded pipeline label filters (| L="v")
 	if len(wanted) == 0 {
-		// No equality labels to push: fully pushed only when the selector is empty (match-all).
+		// Nothing to push: fully pushed only when the selector is empty (match-all).
 		return nil, nil, len(n.selector) == 0
 	}
 
@@ -279,43 +295,57 @@ func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matche
 		byLabel[label] = append(byLabel[label], resolved{rawKey: string(ki.Key), scope: ki.Scope})
 	}
 
-	pushed := map[string]bool{}
-	for label, value := range wanted {
+	// applied marks a label whose every selector matcher is enforced by a pushed filter, so
+	// matchSelector need not re-check it.
+	applied := map[string]bool{}
+	for label, ms := range wanted {
 		cands := byLabel[label]
 		if len(cands) != 1 {
 			// Absent (label not stored) or ambiguous (collision): leave it to matchSelector.
 			continue
 		}
-		c, want := cands[0], value
+		c := cands[0]
+		// Render the value exactly as the label set does, so this matches matchSelector.
+		match := func(v signal.Value) bool {
+			s := labelValueString(v)
+			for _, m := range ms {
+				if !matchLabel(m, s) {
+					return false
+				}
+			}
+			return true
+		}
+		// Equality is serializable and exact, so the cluster fan-out can push it to peers; a regexp
+		// predicate cannot cross the wire, and falls back to the requester's re-check.
+		var spec *fetch.EqualMatcher
+		if len(ms) == 1 && ms[0].Op == logql.OpEq {
+			spec = &fetch.EqualMatcher{Name: c.rawKey, Value: ms[0].Value}
+		}
+
 		stream := c.scope&(storage.KeyScopeResource|storage.KeyScopeScope) != 0
 		record := c.scope&storage.KeyScopeRecord != 0
 		switch {
 		case stream && !record:
 			// A resource/scope label: prune whole streams via the postings index.
-			matchers = append(matchers, fetch.Matcher{
-				Name: []byte(c.rawKey),
-				// Render the value exactly as the label set does, so this matches matchSelector.
-				Match: func(v signal.Value) bool { return labelValueString(v) == want },
-				Spec:  &fetch.EqualMatcher{Name: c.rawKey, Value: want},
-			})
-			pushed[label] = true
+			matchers = append(matchers, fetch.Matcher{Name: []byte(c.rawKey), Match: match, Spec: spec})
 		case record && !stream:
 			// A per-record attribute: drop non-matching records at the fetch layer. Match only (no
 			// bloom Equal hint): a typed value token could wrongly part-prune.
-			conditions = append(conditions, fetch.Condition{
-				Column: c.rawKey,
-				Match:  func(v signal.Value) bool { return labelValueString(v) == want },
-			})
-			pushed[label] = true
+			conditions = append(conditions, fetch.Condition{Column: c.rawKey, Match: match})
+		default:
+			// Mixed scope (resource on some streams, record on others) can't be pushed soundly as
+			// either a Matcher or a Condition: leave it to matchSelector.
+			continue
 		}
-		// Mixed scope (resource on some streams, record on others) can't be pushed soundly as either
-		// a Matcher or a Condition: leave it to matchSelector.
+		// A label with an unpushable matcher is filtered by a superset predicate, so it still needs
+		// the matchSelector re-check.
+		applied[label] = !partial[label]
 	}
 
-	// Fully pushed iff every selector matcher is an equality that became a Matcher/Condition.
+	// Fully pushed iff every selector matcher became part of a Matcher/Condition.
 	selectorPushed = true
 	for _, m := range n.selector {
-		if m.Op != logql.OpEq || m.Value == "" || !pushed[string(m.Label)] {
+		if !applied[string(m.Label)] {
 			selectorPushed = false
 			break
 		}

--- a/internal/storagebackend/logs_selector_test.go
+++ b/internal/storagebackend/logs_selector_test.go
@@ -1,0 +1,111 @@
+package storagebackend_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+)
+
+// TestLogQLSelectorPushdown covers lowering stream selector matchers to storage fetch filters.
+//
+// Every matcher shape is pushed to the postings index, not just equality, so a regexp selector prunes
+// streams rather than being resolved after the fetch. The exception is a matcher that also matches
+// the empty string: LogQL reads an absent label as "", so it matches streams that lack the label
+// entirely, but the index only knows streams that have it. The "env" label is present on one stream
+// and absent from the other precisely to pin that case — pushing `env!="dev"` or `env=~".*"` would
+// drop the stream without the label.
+func TestLogQLSelectorPushdown(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+	ld := plog.NewLogs()
+	for i, s := range []struct {
+		service, env, body string
+	}{
+		{"api", "prod", "api line"},   // has env
+		{"web", "", "web line"},       // no env label at all
+		{"api", "stage", "api stage"}, // has env
+	} {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", s.service)
+		if s.env != "" {
+			rl.Resource().Attributes().PutStr("env", s.env)
+		}
+		rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+		rec.Body().SetStr(s.body)
+	}
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	params := logqlengine.EvalParams{
+		Start: ts.Add(-time.Hour), End: ts.Add(time.Hour), Step: time.Minute, Limit: 1000,
+	}
+	run := func(t *testing.T, query string) []string {
+		t.Helper()
+		var opts logqlengine.Options
+		opts.ParseOptions = logql.ParseOptions{AllowDots: true}
+		engine, err := logqlengine.NewEngine(b.Logs(), opts)
+		require.NoError(t, err)
+		q, err := engine.NewQuery(ctx, query)
+		require.NoError(t, err)
+		data, err := q.Eval(ctx, params)
+		require.NoError(t, err)
+		return normalize(t, data)
+	}
+
+	for _, tt := range []struct {
+		name, query string
+		want        []string
+	}{
+		{
+			name:  "equality",
+			query: `{service_name="api"}`,
+			want:  []string{"line:api line", "line:api stage"},
+		},
+		{
+			name:  "regexp alternation",
+			query: `{service_name=~"api|web"}`,
+			want:  []string{"line:api line", "line:web line", "line:api stage"},
+		},
+		{
+			name:  "regexp prunes",
+			query: `{service_name=~"w.+"}`,
+			want:  []string{"line:web line"},
+		},
+		{
+			// Pushable: `^(?:prod|stage)$` does not match "", so a stream lacking env cannot match.
+			name:  "regexp on label absent from one stream",
+			query: `{env=~"prod|stage"}`,
+			want:  []string{"line:api line", "line:api stage"},
+		},
+		{
+			// Not pushable: "" != "dev", so the stream WITHOUT env must still match.
+			name:  "negated matcher keeps stream lacking the label",
+			query: `{service_name=~".+", env!="dev"}`,
+			want:  []string{"line:api line", "line:web line", "line:api stage"},
+		},
+		{
+			// Not pushable: `.*` matches "", so the stream WITHOUT env must still match.
+			name:  "match-all regexp keeps stream lacking the label",
+			query: `{service_name=~".+", env=~".*"}`,
+			want:  []string{"line:api line", "line:web line", "line:api stage"},
+		},
+		{
+			// A pushable matcher AND an unpushable one on the same label: the pushed predicate is a
+			// superset, so matchSelector must still re-check.
+			name:  "mixed pushable and unpushable on one label",
+			query: `{env=~"prod|stage", env!="stage"}`,
+			want:  []string{"line:api line"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ElementsMatch(t, tt.want, run(t, tt.query))
+		})
+	}
+}


### PR DESCRIPTION
Lowers every LogQL stream selector matcher to the postings index, not just equality.

## Why

`streamFilters` only pushed `=`. Every other shape — notably `{foo=~"bar|baz"}` — was left to the in-memory `matchSelector`, so the query fetched and materialized **every** stream into entries with label sets before discarding almost all of them.

There is no reason for the restriction: the fetch contract takes a predicate over the typed value, and the postings layer applies it to a label's distinct values (a small set) rather than to records. The other two signals already do this — metrics via storage's `PushableMatchers`, profiles via `profileLabelMatcher` — so this brings logs up to the existing precedent.

## The empty-string guard

One matcher shape is not soundly pushable. LogQL reads an absent label as `""` (`matchSelector` does `value, _ := set.GetString(...)`), so a matcher that also matches `""` — `env!="dev"`, `env=~".*"` — matches streams that **lack** the label entirely, while the postings index only knows streams that **have** it. Pushing it would silently drop them.

Such matchers stay with `matchSelector`. Two related subtleties:

- A label may carry several matchers, which AND. If any is unpushable, the pushed predicate is only a **superset**, so the label is marked partially applied and `selectorPushed` stays `false` — the `matchSelector` re-check still runs.
- `Spec` remains equality-only: a regexp predicate cannot cross the wire to a peer, so cluster fan-out falls back to the requester's re-check.

This mirrors the `m.Matches("")` guard in storage's `PushableMatchers`; the previous `m.Value != ""` condition was that same guard, narrowed to equality.

## Results

benchstat, 20 services x 300 records:

```
                                          │     before     │             after              │
                                          │     sec/op     │   sec/op     vs base           │
LogQLStreamSelector/Equality-32                 203.5µ ± 18%  217.6µ ± 8%        ~ (p=0.065)
LogQLStreamSelector/Regexp-32                  1853.2µ ±  5%  226.0µ ± 6%  -87.81% (p=0.002)
LogQLStreamSelector/RegexpAlternation-32       2015.0µ ±  5%  425.1µ ± 7%  -78.90% (p=0.002)
LogQLStreamSelector/RegexpMatchAll-32            4.484m ±  5%  4.437m ± 2%        ~ (p=0.240)
LogQLStreamSelector/MatchAllUnpushable-32        4.765m ±  6%  4.756m ± 5%        ~ (p=0.818)
geomean                                          1.746m        849.0µ       -51.38%
```

`allocs/op` falls 85.56% (`Regexp`) and 74.48% (`RegexpAlternation`). A regexp selector now costs the same as an equality one (226µs vs 218µs), down from ~8.5x slower.

The cases that cannot prune are unchanged: `RegexpMatchAll` (pushed, but every stream matches) and `MatchAllUnpushable` (the guard declines to push). So neither the pushdown nor the guard adds measurable overhead.

## Testing

`TestLogQLSelectorPushdown` covers equality, regexp, alternation, a regexp on a label absent from one stream, both unpushable shapes, and a label carrying one pushable plus one unpushable matcher. The dataset deliberately has `env` on some streams and not others, since that is the only way the guard can be exercised. Verified it has teeth: removing the guard fails exactly the two absent-label cases and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
