### PR TITLE
chore(deps): bump github.com/oteldb/storage to v0.31.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.156.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.156.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.30.0
+	github.com/oteldb/storage v0.31.1
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.30.0 h1:8XaIdCosS59umvuS/KuPHk1/naHfo5roUcRtpz+6cfo=
-github.com/oteldb/storage v0.30.0/go.mod h1:pr/qebnQqUWCXvosFM/rV+Sary3OJ+DtRZU99cIYzBQ=
+github.com/oteldb/storage v0.31.1 h1:LBeunxA0lJmQK56uslSfOvS9CaCz2IlUhayzLxOobJo=
+github.com/oteldb/storage v0.31.1/go.mod h1:pr/qebnQqUWCXvosFM/rV+Sary3OJ+DtRZU99cIYzBQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=


### PR DESCRIPTION
Bumps `github.com/oteldb/storage` from v0.30.0 to **v0.31.1**.

## Why

v0.31.x ports **size-tiered compaction** into the record engine (logs/traces/profiles) — [oteldb/storage#94](https://github.com/oteldb/storage/pull/94) — bounding the merge working set to O(part size) instead of O(dataset). That is the root cause of unbounded RSS growth when bulk-loading chstorage data into the embedded `storagebackend` (used by `cmd/ch2storagebackend`, see #1146). **v0.31.1** ([storage#96](https://github.com/oteldb/storage/pull/96)) calibrates the merge seal threshold to a realistic log row (~950 B), keeping merge-time RSS low without needing an aggressive `-max-part-bytes`.

## Validation

- `go build ./...` / `go mod tidy`: clean (only the storage version changes).
- `integration/ch2storagebackende2e` (`E2E=1`, testcontainers ClickHouse): migration correctness **passes** against v0.31.1.
- Real-cluster re-test of the 40M-row logs backfill that OOM'd on v0.30.0: RSS now **bounded** (see #1146 for the tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)