### PR TITLE
feat(ch2storagebackend): add chstorage→storagebackend migration tool

### DIFF
--- a/cmd/ch2storagebackend/main.go
+++ b/cmd/ch2storagebackend/main.go
@@ -1,0 +1,141 @@
+// Command ch2storagebackend migrates data from chstorage's ClickHouse tables into the
+// embedded storagebackend engine, by scanning ClickHouse directly and re-ingesting the
+// decoded records as OTLP pdata. Only logs and traces are supported so far.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/go-faster/sdk/zctx"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	backendfile "github.com/oteldb/storage/backend/file"
+	sigstorage "github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/tenant"
+
+	"github.com/oteldb/oteldb/internal/ch2storagebackend"
+	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+func run(ctx context.Context) error {
+	var (
+		dsn        = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL")
+		storageDir = flag.String("storage-dir", "", "Directory for the embedded storage engine's file backend (empty uses an ephemeral in-memory backend)")
+		batchSize  = flag.Int("batch", 5_000, "Number of records/spans to convert and ingest per batch")
+		since      = flag.Duration("since", 0, "If positive, only migrate the last since of data (relative to the most recent record), instead of the full table")
+		signals    = flag.String("signals", "logs,traces", "Comma-separated list of signals to migrate (logs, traces)")
+		// A bulk migration writes orders of magnitude faster than steady production ingestion, so
+		// the engine's default flush cadence (tuned for the latter) leaves the head/WAL growing
+		// unbounded in RAM for the lifetime of this process. Flush aggressively instead.
+		flushInterval = flag.Duration("flush-interval", 10*time.Second, "Max age of unflushed data in the embedded storage engine's head, for the file backend")
+		// maxPartBytes caps a flushed/merged part's approximate uncompressed size, via the tenant
+		// policy. It is what bounds the record engine's merge working set: a merge decodes at most
+		// ~mergeHeight × maxPartBytes at a time, then seals. The default (0 ⇒ the engine's 64 MiB) is
+		// tuned for steady production; a bulk backfill of large log rows should set this smaller (e.g.
+		// 8-16 MiB) to keep merge-time RSS spikes low.
+		maxPartBytes = flag.Int64("max-part-bytes", 0, "Approx uncompressed cap per flushed/merged part (0 = engine default 64MiB); lower it to bound merge-time memory on large backfills")
+		// Throttling our own submission rate keeps unthrottled ingest from ballooning the head between
+		// flushes (the head has no blocking backpressure; MaxInFlightBytes would *shed* records, which a
+		// migration must not do). With a throttle the head stays small and the merge (bounded by
+		// max-part-bytes) is the only sizable transient.
+		throttle = flag.Duration("throttle", 0, "Sleep this long after every ConsumeLogs/ConsumeTraces batch, to keep ingestion from outpacing the storage engine's flush loop")
+	)
+	flag.Parse()
+
+	lg, err := zap.NewDevelopment()
+	if err != nil {
+		return errors.Wrap(err, "create logger")
+	}
+	defer func() {
+		_ = lg.Sync()
+	}()
+	ctx = zctx.Base(ctx, lg)
+
+	client, err := chstorage.Dial(ctx, *dsn, chstorage.DialOptions{})
+	if err != nil {
+		return errors.Wrap(err, "dial clickhouse")
+	}
+
+	store, err := openStore(ctx, *storageDir, *flushInterval, *maxPartBytes, lg)
+	if err != nil {
+		return errors.Wrap(err, "open storage engine")
+	}
+	defer func() {
+		_ = store.Close(ctx)
+	}()
+	back := storagebackend.New(store)
+
+	m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), back, lg, ch2storagebackend.WithThrottle(*throttle))
+
+	for sig := range strings.SplitSeq(*signals, ",") {
+		switch sig {
+		case "logs":
+			stats, err := m.MigrateLogs(ctx, *since, *batchSize)
+			if err != nil {
+				return errors.Wrap(err, "migrate logs")
+			}
+			lg.Info("Migrated logs", zap.Int("records", stats.Records), zap.Int("batches", stats.Batches))
+		case "traces":
+			stats, err := m.MigrateTraces(ctx, *since, *batchSize)
+			if err != nil {
+				return errors.Wrap(err, "migrate traces")
+			}
+			lg.Info("Migrated traces", zap.Int("spans", stats.Spans), zap.Int("batches", stats.Batches))
+		default:
+			return errors.Errorf("unknown signal %q", sig)
+		}
+	}
+
+	lg.Info("Done")
+	return nil
+}
+
+func openStore(ctx context.Context, dir string, flushInterval time.Duration, maxPartBytes int64, lg *zap.Logger) (*storage.Storage, error) {
+	opts := []storage.Option{storage.WithLogger(lg)}
+	if dir == "" {
+		opts = append(opts,
+			storage.WithBackend(backend.Memory()),
+			storage.WithDurability(storage.DurabilityEphemeral),
+		)
+	} else {
+		fb, err := backendfile.New(dir)
+		if err != nil {
+			return nil, errors.Wrap(err, "open file backend")
+		}
+		opts = append(opts,
+			storage.WithBackend(fb),
+			storage.WithFlushInterval(flushInterval.Nanoseconds()),
+		)
+	}
+
+	// Bound the per-part size (hence the merge working set) via the tenant policy when requested. The
+	// engine converts this to a row cap internally; a smaller cap seals sooner, keeping merge-time RSS
+	// low on a bulk backfill of large rows.
+	if maxPartBytes > 0 {
+		opts = append(opts, storage.WithTenancy(tenant.ResolverFunc(func(sigstorage.TenantID) tenant.Policy {
+			return tenant.Policy{Limits: tenant.Limits{MaxPartSize: maxPartBytes}}
+		})))
+	}
+
+	return storage.Open(ctx, storage.Options{}, opts...)
+}
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+}

--- a/integration/ch2storagebackende2e/migrate_test.go
+++ b/integration/ch2storagebackende2e/migrate_test.go
@@ -1,0 +1,265 @@
+// Package ch2storagebackende2e_test verifies that [ch2storagebackend.Migrator] faithfully
+// migrates logs out of a real ClickHouse-backed chstorage into the embedded storagebackend
+// engine.
+package ch2storagebackende2e_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+
+	"github.com/oteldb/oteldb/integration"
+	"github.com/oteldb/oteldb/internal/ch2storagebackend"
+	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+	"github.com/oteldb/oteldb/internal/lokihandler"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// buildLogs constructs two resources (serviceA, serviceB) with two log records each, at
+// distinct timestamps starting at base.
+func buildLogs(base time.Time) plog.Logs {
+	ld := plog.NewLogs()
+
+	addResource := func(serviceName string) plog.ScopeLogs {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", serviceName)
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.Scope().SetName("ch2storagebackend_test")
+		return sl
+	}
+
+	addRecord := func(sl plog.ScopeLogs, offset time.Duration, severity plog.SeverityNumber, body string) {
+		lr := sl.LogRecords().AppendEmpty()
+		ts := pcommon.NewTimestampFromTime(base.Add(offset))
+		lr.SetTimestamp(ts)
+		lr.SetObservedTimestamp(ts)
+		lr.SetSeverityNumber(severity)
+		lr.SetSeverityText(severity.String())
+		lr.Body().SetStr(body)
+		lr.Attributes().PutStr("http.method", "GET")
+	}
+
+	slA := addResource("serviceA")
+	addRecord(slA, 0*time.Second, plog.SeverityNumberInfo, "hello from A #1")
+	addRecord(slA, 1*time.Second, plog.SeverityNumberWarn, "hello from A #2")
+
+	slB := addResource("serviceB")
+	addRecord(slB, 2*time.Second, plog.SeverityNumberError, "hello from B #1")
+	addRecord(slB, 3*time.Second, plog.SeverityNumberDebug, "hello from B #2")
+
+	return ld
+}
+
+func TestMigrateLogs(t *testing.T) {
+	integration.Skip(t)
+	var (
+		ctx      = t.Context()
+		provider = integration.TraceProvider(t)
+	)
+
+	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
+		Name:           "ch2storagebackend",
+		TablePrefix:    "ch2sb",
+		TracerProvider: provider,
+	})
+
+	inserter, err := chstorage.NewInserter(client, chstorage.InserterOptions{
+		Tables:         tables,
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	consumer, err := logstorage.NewConsumer(inserter, logstorage.ConsumerOptions{})
+	require.NoError(t, err)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, consumer.ConsumeLogs(ctx, buildLogs(base)))
+
+	store, err := storage.Open(ctx, storage.Options{},
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close(ctx)
+	})
+	back := storagebackend.New(store)
+
+	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
+	// Use a batch size smaller than the record count so the migration exercises more than
+	// one ConsumeLogs call.
+	stats, err := m.MigrateLogs(ctx, 0, 2)
+	require.NoError(t, err)
+	require.Equal(t, 4, stats.Records)
+	require.Equal(t, 2, stats.Batches)
+
+	engine, err := logqlengine.NewEngine(back.Logs(), logqlengine.Options{
+		ParseOptions:   logql.ParseOptions{AllowDots: true},
+		Optimizers:     logqlengine.DefaultOptimizers(),
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	api := lokihandler.NewLokiAPI(back.Logs(), engine, lokihandler.LokiAPIOptions{})
+	lokih, err := lokiapi.NewServer(api, lokiapi.WithTracerProvider(provider))
+	require.NoError(t, err)
+
+	s := httptest.NewServer(lokih)
+	t.Cleanup(s.Close)
+
+	c, err := lokiapi.NewClient(s.URL, lokiapi.WithClient(s.Client()), lokiapi.WithTracerProvider(provider))
+	require.NoError(t, err)
+
+	resp, err := c.QueryRange(ctx, lokiapi.QueryRangeParams{
+		Query: `{service_name=~".+"}`,
+		Start: lokiapi.NewOptLokiTime(asLokiTime(base.Add(-time.Minute))),
+		End:   lokiapi.NewOptLokiTime(asLokiTime(base.Add(time.Minute))),
+		Limit: lokiapi.NewOptInt(100),
+	})
+	require.NoError(t, err)
+
+	streams, ok := resp.Data.GetStreamsResult()
+	require.True(t, ok)
+
+	gotBodies := map[string]struct{}{}
+	var total int
+	for _, stream := range streams.Result {
+		require.True(t, stream.Stream.Set)
+		require.Contains(t, stream.Stream.Value, "service_name")
+		for _, v := range stream.Values {
+			total++
+			gotBodies[v.V] = struct{}{}
+		}
+	}
+	require.Equal(t, 4, total)
+	for _, want := range []string{
+		"hello from A #1", "hello from A #2", "hello from B #1", "hello from B #2",
+	} {
+		require.Containsf(t, gotBodies, want, "missing body %q", want)
+	}
+}
+
+func asLokiTime(t time.Time) lokiapi.LokiTime {
+	return lokiapi.LokiTime(t.Format(time.RFC3339Nano))
+}
+
+// buildTraces constructs a single trace with two spans (a root and a child), belonging to
+// one resource/scope.
+func buildTraces(base time.Time, traceID pcommon.TraceID) ptrace.Traces {
+	td := ptrace.NewTraces()
+
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "traceService")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("ch2storagebackend_test")
+
+	root := ss.Spans().AppendEmpty()
+	root.SetTraceID(traceID)
+	root.SetSpanID(pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8})
+	root.SetName("root")
+	root.SetKind(ptrace.SpanKindServer)
+	root.SetStartTimestamp(pcommon.NewTimestampFromTime(base))
+	root.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(2 * time.Second)))
+	root.Attributes().PutStr("http.method", "GET")
+
+	child := ss.Spans().AppendEmpty()
+	child.SetTraceID(traceID)
+	child.SetSpanID(pcommon.SpanID{8, 7, 6, 5, 4, 3, 2, 1})
+	child.SetParentSpanID(root.SpanID())
+	child.SetName("child")
+	child.SetKind(ptrace.SpanKindClient)
+	child.SetStartTimestamp(pcommon.NewTimestampFromTime(base.Add(500 * time.Millisecond)))
+	child.SetEndTimestamp(pcommon.NewTimestampFromTime(base.Add(1500 * time.Millisecond)))
+
+	return td
+}
+
+func TestMigrateTraces(t *testing.T) {
+	integration.Skip(t)
+	var (
+		ctx      = t.Context()
+		provider = integration.TraceProvider(t)
+	)
+
+	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
+		Name:           "ch2storagebackend-traces",
+		TablePrefix:    "ch2sbt",
+		TracerProvider: provider,
+	})
+
+	inserter, err := chstorage.NewInserter(client, chstorage.InserterOptions{
+		Tables:         tables,
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	consumer := tracestorage.NewConsumer(inserter)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	traceID := pcommon.TraceID{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	require.NoError(t, consumer.ConsumeTraces(ctx, buildTraces(base, traceID)))
+
+	store, err := storage.Open(ctx, storage.Options{},
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close(ctx)
+	})
+	back := storagebackend.New(store)
+
+	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
+	// Use a batch size smaller than the span count so the migration exercises more than one
+	// ConsumeTraces call.
+	stats, err := m.MigrateTraces(ctx, 0, 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, stats.Spans)
+	require.Equal(t, 2, stats.Batches)
+
+	it, err := back.Traces().TraceByID(ctx, otelstorage.TraceID(traceID), tracestorage.TraceByIDOptions{})
+	require.NoError(t, err)
+
+	var spans []tracestorage.Span
+	require.NoError(t, iterators.ForEach(it, func(s tracestorage.Span) error {
+		spans = append(spans, s)
+		return nil
+	}))
+
+	require.Len(t, spans, 2)
+	gotNames := map[string]tracestorage.Span{}
+	for _, s := range spans {
+		gotNames[s.Name] = s
+	}
+	require.Contains(t, gotNames, "root")
+	require.Contains(t, gotNames, "child")
+
+	root := gotNames["root"]
+	serviceName, ok := root.ServiceName()
+	require.True(t, ok)
+	require.Equal(t, "traceService", serviceName)
+	if v, ok := root.Attrs.AsMap().Get("http.method"); ok {
+		require.Equal(t, "GET", v.AsString())
+	} else {
+		t.Fatal("root span missing http.method attribute")
+	}
+
+	child := gotNames["child"]
+	require.Equal(t, otelstorage.SpanID(pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}), child.ParentSpanID)
+}

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -1,0 +1,136 @@
+// Package ch2storagebackend migrates data out of chstorage's ClickHouse tables into the
+// embedded storagebackend engine, by scanning ClickHouse directly (bypassing chstorage's
+// selector-oriented queriers) and re-ingesting the decoded records as OTLP pdata.
+//
+// Only logs and traces are supported so far; metrics are not migrated.
+package ch2storagebackend
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// LogsStats reports the outcome of a [Migrator.MigrateLogs] run.
+type LogsStats struct {
+	// Records is the total number of log records migrated.
+	Records int
+	// Batches is the number of batches ConsumeLogs was called with.
+	Batches int
+}
+
+// TracesStats reports the outcome of a [Migrator.MigrateTraces] run.
+type TracesStats struct {
+	// Spans is the total number of spans migrated.
+	Spans int
+	// Batches is the number of batches ConsumeTraces was called with.
+	Batches int
+}
+
+// Migrator copies data from chstorage's ClickHouse tables into a [storagebackend.Backend].
+type Migrator struct {
+	logs     *chstorage.LogsSource
+	traces   *chstorage.TracesSource
+	back     *storagebackend.Backend
+	logger   *zap.Logger
+	throttle time.Duration
+}
+
+// Option configures a [Migrator].
+type Option func(*Migrator)
+
+// WithThrottle sleeps d after every ConsumeLogs/ConsumeTraces batch. A bulk migration can
+// ingest orders of magnitude faster than the storage engine's background flush/compaction
+// loop can drain, so without a cap the head grows unbounded in RAM until the process OOMs
+// (see [storagebackend], the FlushInterval/FlushThresholdBytes options alone do not apply
+// backpressure on the write path). Zero (the default) applies no throttling.
+func WithThrottle(d time.Duration) Option {
+	return func(m *Migrator) { m.throttle = d }
+}
+
+// NewMigrator creates a new [Migrator].
+func NewMigrator(client chstorage.ClickHouseClient, tables chstorage.Tables, back *storagebackend.Backend, logger *zap.Logger, opts ...Option) *Migrator {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	m := &Migrator{
+		logs:   chstorage.NewLogsSource(client, tables, logger.Named("logs_source")),
+		traces: chstorage.NewTracesSource(client, tables, logger.Named("traces_source")),
+		back:   back,
+		logger: logger,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// sleep pauses for the configured throttle, or returns ctx.Err() if ctx is canceled first.
+func (m *Migrator) sleep(ctx context.Context) error {
+	if m.throttle <= 0 {
+		return nil
+	}
+	t := time.NewTimer(m.throttle)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// MigrateLogs migrates log records stored in ClickHouse into the storagebackend engine,
+// converting and ingesting up to batchSize records at a time. When since is positive, only
+// the last since of data (relative to the most recent record) is migrated.
+func (m *Migrator) MigrateLogs(ctx context.Context, since time.Duration, batchSize int) (LogsStats, error) {
+	var stats LogsStats
+	err := m.logs.Do(ctx, since, batchSize, func(ctx context.Context, records []logstorage.Record) error {
+		ld := logstorage.RecordsToLogs(records)
+		if err := m.back.ConsumeLogs(ctx, ld); err != nil {
+			return errors.Wrap(err, "consume logs")
+		}
+		stats.Records += len(records)
+		stats.Batches++
+		m.logger.Info("Migrated logs batch",
+			zap.Int("batch_records", len(records)),
+			zap.Int("total_records", stats.Records),
+		)
+		return m.sleep(ctx)
+	})
+	if err != nil {
+		return stats, errors.Wrap(err, "migrate logs")
+	}
+	return stats, nil
+}
+
+// MigrateTraces migrates spans stored in ClickHouse into the storagebackend engine,
+// converting and ingesting up to batchSize spans at a time. When since is positive, only
+// the last since of data (relative to the most recent span) is migrated.
+func (m *Migrator) MigrateTraces(ctx context.Context, since time.Duration, batchSize int) (TracesStats, error) {
+	var stats TracesStats
+	err := m.traces.Do(ctx, since, batchSize, func(ctx context.Context, spans []tracestorage.Span) error {
+		td := tracestorage.SpansToTraces(spans)
+		if err := m.back.ConsumeTraces(ctx, td); err != nil {
+			return errors.Wrap(err, "consume traces")
+		}
+		stats.Spans += len(spans)
+		stats.Batches++
+		m.logger.Info("Migrated traces batch",
+			zap.Int("batch_spans", len(spans)),
+			zap.Int("total_spans", stats.Spans),
+		)
+		return m.sleep(ctx)
+	})
+	if err != nil {
+		return stats, errors.Wrap(err, "migrate traces")
+	}
+	return stats, nil
+}

--- a/internal/chstorage/bridge_logs.go
+++ b/internal/chstorage/bridge_logs.go
@@ -1,0 +1,109 @@
+package chstorage
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/oteldb/internal/chstorage/chsql"
+	"github.com/oteldb/oteldb/internal/logstorage"
+)
+
+// LogsBatchFunc is called with each decoded batch of records read by [LogsSource.Do].
+type LogsBatchFunc func(ctx context.Context, records []logstorage.Record) error
+
+// LogsSource reads every log record stored in ClickHouse, decoded as [logstorage.Record],
+// for migrating them into another storage engine. Unlike [Querier], it performs a full
+// table scan with no selector pushdown, day-bucketed like [Backup] so a single scan never
+// buffers more than one day's worth of rows in ClickHouse at a time.
+type LogsSource struct {
+	client ClickHouseClient
+	table  string
+	logger *zap.Logger
+}
+
+// NewLogsSource creates a new [LogsSource].
+func NewLogsSource(client ClickHouseClient, tables Tables, logger *zap.Logger) *LogsSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &LogsSource{
+		client: client,
+		table:  tables.Logs,
+		logger: logger,
+	}
+}
+
+// Do scans every log record in the table, in day-bucket then timestamp order, invoking
+// batchFn with batches of up to batchSize records. When since is positive, the scan is
+// restricted to the last since of data, relative to the table's most recent timestamp,
+// instead of the full table.
+func (s *LogsSource) Do(ctx context.Context, since time.Duration, batchSize int, batchFn LogsBatchFunc) error {
+	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client, [2]string{s.table, "timestamp"})
+	if err != nil {
+		return errors.Wrap(err, "query min/max timestamp")
+	}
+	if mint.IsZero() && maxt.IsZero() {
+		s.logger.Info("No logs to migrate")
+		return nil
+	}
+	if since > 0 {
+		if cut := maxt.Add(-since); cut.After(mint) {
+			mint = cut
+		}
+	}
+
+	step := 24 * time.Hour
+	start := mint.Truncate(step)
+	end := maxt.Truncate(step).Add(step)
+	for ts := start; ts.Before(end); ts = ts.Add(step) {
+		if err := s.scanDay(ctx, ts, ts.Add(step), batchSize, batchFn); err != nil {
+			return errors.Wrapf(err, "scan day %s", ts)
+		}
+	}
+	return nil
+}
+
+func (s *LogsSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn LogsBatchFunc) error {
+	var (
+		lc  = newLogColumns()
+		buf []logstorage.Record
+	)
+
+	flush := func(ctx context.Context) error {
+		if len(buf) == 0 {
+			return nil
+		}
+		if err := batchFn(ctx, buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+		return nil
+	}
+
+	query := chsql.Select(s.table, lc.ChsqlResult()...).
+		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionNano))
+
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		// The decoded columns accumulate across blocks (ch-go appends, it never resets),
+		// so lc must be drained and reset before the next block is decoded into it.
+		defer lc.Reset()
+		return lc.ForEach(func(r logstorage.Record) error {
+			buf = append(buf, r)
+			if len(buf) >= batchSize {
+				return flush(ctx)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return errors.Wrap(err, "prepare query")
+	}
+	if err := s.client.Do(ctx, chq); err != nil {
+		return errors.Wrap(err, "execute query")
+	}
+	return flush(ctx)
+}

--- a/internal/chstorage/bridge_traces.go
+++ b/internal/chstorage/bridge_traces.go
@@ -1,0 +1,115 @@
+package chstorage
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/oteldb/internal/chstorage/chsql"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// TracesBatchFunc is called with each decoded batch of spans read by [TracesSource.Do].
+type TracesBatchFunc func(ctx context.Context, spans []tracestorage.Span) error
+
+// TracesSource reads every span stored in ClickHouse, decoded as [tracestorage.Span], for
+// migrating them into another storage engine. Unlike [Querier], it performs a full table
+// scan with no selector pushdown, day-bucketed like [Backup] so a single scan never buffers
+// more than one day's worth of rows in ClickHouse at a time.
+type TracesSource struct {
+	client ClickHouseClient
+	table  string
+	logger *zap.Logger
+}
+
+// NewTracesSource creates a new [TracesSource].
+func NewTracesSource(client ClickHouseClient, tables Tables, logger *zap.Logger) *TracesSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &TracesSource{
+		client: client,
+		table:  tables.Spans,
+		logger: logger,
+	}
+}
+
+// Do scans every span in the table, in day-bucket then start-timestamp order, invoking
+// batchFn with batches of up to batchSize spans. When since is positive, the scan is
+// restricted to the last since of data, relative to the table's most recent start
+// timestamp, instead of the full table.
+func (s *TracesSource) Do(ctx context.Context, since time.Duration, batchSize int, batchFn TracesBatchFunc) error {
+	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client, [2]string{s.table, "start"})
+	if err != nil {
+		return errors.Wrap(err, "query min/max timestamp")
+	}
+	if mint.IsZero() && maxt.IsZero() {
+		s.logger.Info("No traces to migrate")
+		return nil
+	}
+	if since > 0 {
+		if cut := maxt.Add(-since); cut.After(mint) {
+			mint = cut
+		}
+	}
+
+	step := 24 * time.Hour
+	start := mint.Truncate(step)
+	end := maxt.Truncate(step).Add(step)
+	for ts := start; ts.Before(end); ts = ts.Add(step) {
+		if err := s.scanDay(ctx, ts, ts.Add(step), batchSize, batchFn); err != nil {
+			return errors.Wrapf(err, "scan day %s", ts)
+		}
+	}
+	return nil
+}
+
+func (s *TracesSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn TracesBatchFunc) error {
+	var (
+		sc  = newSpanColumns()
+		buf []tracestorage.Span
+	)
+
+	flush := func(ctx context.Context) error {
+		if len(buf) == 0 {
+			return nil
+		}
+		if err := batchFn(ctx, buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+		return nil
+	}
+
+	query := chsql.Select(s.table, sc.ChsqlResult()...).
+		Where(chsql.InTimeRange("start", start, end, proto.PrecisionNano))
+
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		// The decoded columns accumulate across blocks (ch-go appends, it never resets),
+		// so sc must be drained and reset before the next block is decoded into it.
+		defer sc.Reset()
+		spans, err := sc.ReadRowsTo(nil)
+		if err != nil {
+			return errors.Wrap(err, "decode spans")
+		}
+		for _, span := range spans {
+			buf = append(buf, span)
+			if len(buf) >= batchSize {
+				if err := flush(ctx); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "prepare query")
+	}
+	if err := s.client.Do(ctx, chq); err != nil {
+		return errors.Wrap(err, "execute query")
+	}
+	return flush(ctx)
+}

--- a/internal/logstorage/pdata.go
+++ b/internal/logstorage/pdata.go
@@ -1,0 +1,59 @@
+package logstorage
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+// RecordsToLogs converts decoded records back into an OTLP [plog.Logs] payload, e.g. for
+// re-ingesting records read out of storage into another backend. Records are grouped into
+// ResourceLogs/ScopeLogs by resource and scope identity, mirroring what a real OTLP
+// producer would emit (consumers are expected to flatten per-record data regardless of
+// grouping, so this is a cosmetic/efficiency choice, not a correctness one).
+func RecordsToLogs(records []Record) plog.Logs {
+	ld := plog.NewLogs()
+
+	type scopeKey struct {
+		resource     otelstorage.Hash
+		scopeName    string
+		scopeVersion string
+		scopeAttrs   otelstorage.Hash
+	}
+	scopes := map[scopeKey]plog.ScopeLogs{}
+
+	for _, r := range records {
+		key := scopeKey{
+			resource:     r.ResourceAttrs.Hash(),
+			scopeName:    r.ScopeName,
+			scopeVersion: r.ScopeVersion,
+			scopeAttrs:   r.ScopeAttrs.Hash(),
+		}
+		sl, ok := scopes[key]
+		if !ok {
+			rl := ld.ResourceLogs().AppendEmpty()
+			r.ResourceAttrs.CopyTo(rl.Resource().Attributes())
+
+			sl = rl.ScopeLogs().AppendEmpty()
+			sl.Scope().SetName(r.ScopeName)
+			sl.Scope().SetVersion(r.ScopeVersion)
+			r.ScopeAttrs.CopyTo(sl.Scope().Attributes())
+
+			scopes[key] = sl
+		}
+
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetTimestamp(r.Timestamp)
+		lr.SetObservedTimestamp(r.ObservedTimestamp)
+		lr.SetTraceID(pcommon.TraceID(r.TraceID))
+		lr.SetSpanID(pcommon.SpanID(r.SpanID))
+		lr.SetFlags(r.Flags)
+		lr.SetSeverityText(r.SeverityText)
+		lr.SetSeverityNumber(r.SeverityNumber)
+		lr.Body().SetStr(r.Body)
+		r.Attrs.CopyTo(lr.Attributes())
+	}
+
+	return ld
+}

--- a/internal/tracestorage/pdata.go
+++ b/internal/tracestorage/pdata.go
@@ -1,0 +1,49 @@
+package tracestorage
+
+import (
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+// SpansToTraces converts decoded spans back into an OTLP [ptrace.Traces] payload, e.g. for
+// re-ingesting spans read out of storage into another backend. Spans are grouped into
+// ResourceSpans/ScopeSpans by resource and scope identity, mirroring what a real OTLP
+// producer would emit (consumers are expected to flatten per-span data regardless of
+// grouping, so this is a cosmetic/efficiency choice, not a correctness one).
+func SpansToTraces(spans []Span) ptrace.Traces {
+	td := ptrace.NewTraces()
+
+	type scopeKey struct {
+		resource     otelstorage.Hash
+		scopeName    string
+		scopeVersion string
+		scopeAttrs   otelstorage.Hash
+	}
+	scopes := map[scopeKey]ptrace.ScopeSpans{}
+
+	for _, span := range spans {
+		key := scopeKey{
+			resource:     span.ResourceAttrs.Hash(),
+			scopeName:    span.ScopeName,
+			scopeVersion: span.ScopeVersion,
+			scopeAttrs:   span.ScopeAttrs.Hash(),
+		}
+		ss, ok := scopes[key]
+		if !ok {
+			rs := td.ResourceSpans().AppendEmpty()
+			span.ResourceAttrs.CopyTo(rs.Resource().Attributes())
+
+			ss = rs.ScopeSpans().AppendEmpty()
+			ss.Scope().SetName(span.ScopeName)
+			ss.Scope().SetVersion(span.ScopeVersion)
+			span.ScopeAttrs.CopyTo(ss.Scope().Attributes())
+
+			scopes[key] = ss
+		}
+
+		span.FillOTELSpan(ss.Spans().AppendEmpty())
+	}
+
+	return td
+}


### PR DESCRIPTION
Adds a tool to migrate data out of chstorage's ClickHouse tables into the embedded `storagebackend` engine, by scanning ClickHouse directly (the selector-oriented queriers have no "dump everything" mode) and re-ingesting the decoded records as OTLP pdata. **Logs and traces** are supported; metrics and profiles are not.

## Layout

- `internal/chstorage/bridge_{logs,traces}.go` — `LogsSource`/`TracesSource`: full-table, day-bucketed scans (mirrors `Backup`'s loop), reusing the existing row decoders; a `since` bound scans only the most recent slice.
- `internal/logstorage/pdata.go`, `internal/tracestorage/pdata.go` — `Record`→`plog` / `Span`→`ptrace` converters.
- `internal/ch2storagebackend` — `Migrator` library (`MigrateLogs`/`MigrateTraces`) with a per-batch throttle.
- `cmd/ch2storagebackend` — CLI: `-dsn`, `-storage-dir`, `-since`, `-batch`, `-signals`, `-throttle`, `-flush-interval`, `-max-part-bytes`.
- `integration/ch2storagebackende2e` — E2E tests (testcontainers ClickHouse + in-memory storagebackend), gated by `E2E=1`.

## Notes

- Builds against the current storage dep (v0.30.0). The **memory-safe** bulk behavior needs **storage ≥ v0.31.1** — the record engine's size-tiered compaction (oteldb/storage#94) plus the `recordRowBytes` calibration (oteldb/storage#96); bump tracked in #1145. For large backfills set `-max-part-bytes` (e.g. 8–16 MiB) to bound the merge working set.
- `MaxInFlightBytes` is deliberately **not** exposed: `ConsumeLogs` discards the partial-success result, so head admission would silently drop records — a migration must not shed data; use `-throttle` to bound the head instead.

## Validation

- `go build`/`go vet`/`golangci-lint`: clean.
- `integration/ch2storagebackende2e` (`E2E=1`): logs and traces migration correctness **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)