### PR TITLE
fix(chstorage): tolerate int attributes outside int64 range

### DIFF
--- a/internal/chstorage/attributes_json.go
+++ b/internal/chstorage/attributes_json.go
@@ -145,18 +145,20 @@ func decodeValue(d *jx.Decoder, val pcommon.Value) error {
 			return err
 		}
 		if n.IsInt() {
-			v, err := n.Int64()
-			if err != nil {
-				return err
+			if v, err := n.Int64(); err == nil {
+				val.SetInt(v)
+				return nil
 			}
-			val.SetInt(v)
-		} else {
-			v, err := n.Float64()
-			if err != nil {
-				return err
-			}
-			val.SetDouble(v)
+			// An integer outside the int64 range (e.g. a uint64 id/hash) does not fit pcommon's int
+			// value. Preserve it exactly as a string rather than failing the whole block decode.
+			val.SetStr(n.String())
+			return nil
 		}
+		v, err := n.Float64()
+		if err != nil {
+			return err
+		}
+		val.SetDouble(v)
 		return nil
 	case jx.Null:
 		if err := d.Null(); err != nil {

--- a/internal/chstorage/attributes_test.go
+++ b/internal/chstorage/attributes_test.go
@@ -189,3 +189,23 @@ func BenchmarkEncodeAttributes(b *testing.B) {
 		b.Fatal("unexpected result")
 	}
 }
+
+func TestDecodeAttributesBigInt(t *testing.T) {
+	// A uint64 attribute value beyond the int64 range must decode without error, preserved as a
+	// string (pcommon's int value is int64-only). Regression: a full-table scan previously crashed
+	// the whole block decode here with "value out of range".
+	attrs, err := decodeAttributes([]byte(`{"id":18446744073709551615}`))
+	require.NoError(t, err)
+	v, ok := attrs.AsMap().Get("id")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeStr, v.Type())
+	require.Equal(t, "18446744073709551615", v.Str())
+
+	// An in-range integer still decodes as an int.
+	attrs, err = decodeAttributes([]byte(`{"n":42}`))
+	require.NoError(t, err)
+	v, ok = attrs.AsMap().Get("n")
+	require.True(t, ok)
+	require.Equal(t, pcommon.ValueTypeInt, v.Type())
+	require.Equal(t, int64(42), v.Int())
+}


### PR DESCRIPTION
## Problem

`chstorage.decodeValue` (attributes_json.go) called `jx.Num.Int64()` on every integer attribute value. A value beyond the int64 range — e.g. a uint64 id/hash — returns `value out of range`, which fails the **entire ClickHouse block decode** (`jsonAttrCol.DecodeColumn`), not just that one value.

This surfaced running a full-table scan (via the `ch2storagebackend` migration over the whole `logs`/`traces_spans` tables): a single row with a big-int attribute crashed the scan. Steady-state selector queries hit the same path whenever a matching row carries such an attribute.

## Fix

Preserve an out-of-range integer exactly, as a **string** (pcommon's int value is int64-only), instead of failing the decode:

```go
if n.IsInt() {
    if v, err := n.Int64(); err == nil {
        val.SetInt(v)
        return nil
    }
    val.SetStr(n.String()) // uint64 id/hash etc.
    return nil
}
```

Regression test (`TestDecodeAttributesBigInt`) covers a `uint64`-max value decoding to a string and an in-range int still decoding as an int.

## Validation

`go test ./internal/chstorage/` and `golangci-lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)