### PR TITLE
fix(chstorage): include overflow bucket in histogram +Inf count

### DIFF
--- a/internal/chstorage/inserter_metrics.go
+++ b/internal/chstorage/inserter_metrics.go
@@ -321,6 +321,13 @@ func (b *metricsBatch) addHistogramPoints(name, desc, unit string, res, scope la
 				key,
 			)
 		}
+		// An OTLP histogram carries one more bucket count than bounds: the trailing overflow bucket
+		// (observations above the largest explicit bound). Fold the remaining counts into the
+		// cumulative total so the +Inf bucket equals the datapoint count, per Prometheus convention
+		// (otherwise _bucket{le="+Inf"} < _count whenever the overflow bucket is non-empty).
+		for i := len(explicitBounds); i < len(bucketCounts); i++ {
+			cumCount += bucketCounts[i]
+		}
 		// Generate series with "_bucket" suffix and "le" label.
 		{
 			key := [2]string{

--- a/internal/chstorage/inserter_metrics_test.go
+++ b/internal/chstorage/inserter_metrics_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	noopmeter "go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap/zapcore"
 
@@ -18,6 +20,60 @@ import (
 	"github.com/oteldb/oteldb/internal/prompb"
 	prw "github.com/oteldb/oteldb/prometheusremotewrite"
 )
+
+func newTestMetricBatch(t *testing.T) *metricsBatch {
+	t.Helper()
+	var stats inserterStats
+	require.NoError(t, stats.Init(noopmeter.NewMeterProvider().Meter("test")))
+	return newMetricBatch(&Inserter{
+		chLogLevel: zapcore.PanicLevel,
+		stats:      stats,
+		tracker:    globalmetric.NewNoopTracker(),
+	})
+}
+
+// TestMetricsBatchHistogramInfBucket verifies the decomposed _bucket{le="+Inf"} series equals the
+// datapoint count, i.e. the trailing OTLP overflow bucket is not dropped.
+func TestMetricsBatchHistogramInfBucket(t *testing.T) {
+	md := pmetric.NewMetrics()
+	dp := md.ResourceMetrics().AppendEmpty().
+		ScopeMetrics().AppendEmpty().
+		Metrics().AppendEmpty()
+	dp.SetName("test_hist")
+	h := dp.SetEmptyHistogram()
+	h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	point := h.DataPoints().AppendEmpty()
+	point.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 0)))
+	point.SetCount(10)
+	point.SetSum(100)
+	point.ExplicitBounds().FromRaw([]float64{1, 5, 10})
+	// One more count than bounds: the last (4) is the overflow bucket (> the largest bound).
+	point.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+
+	batch := newTestMetricBatch(t)
+	require.NoError(t, batch.mapMetrics(md))
+
+	// Walk the decomposed samples: _count and the last _bucket (le="+Inf") must both equal 10.
+	var (
+		count      float64
+		haveCount  bool
+		lastBucket float64
+		haveBucket bool
+	)
+	c := batch.points
+	for i := 0; i < c.value.Rows(); i++ {
+		switch metricMapping(c.mapping.Row(i)) {
+		case histogramCount:
+			count, haveCount = c.value.Row(i), true
+		case histogramBucket:
+			lastBucket, haveBucket = c.value.Row(i), true
+		}
+	}
+	require.True(t, haveCount, "no _count sample")
+	require.True(t, haveBucket, "no _bucket sample")
+	require.Equal(t, float64(10), count, "_count")
+	require.Equal(t, float64(10), lastBucket, `_bucket{le="+Inf"} must equal the datapoint count`)
+}
 
 func Benchmark_metricsBatch(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
## Problem

chstorage's histogram ingestion drops OTLP's trailing **overflow bucket count**, producing internally-inconsistent stored histograms.

An OTLP explicit-bucket histogram always has `len(BucketCounts) == len(ExplicitBounds) + 1` — the last count is the overflow bucket (observations above the largest bound). `addHistogramPoints` only iterated the finite bounds when accumulating the cumulative count, then wrote `_bucket{le="+Inf"}` with that finite-only total. So whenever the overflow bucket is non-empty:

- `_bucket{le="+Inf"}` < `_count` (a correct Prometheus/OTLP histogram requires them equal), and
- `histogram_quantile()` under-serves the top of the distribution.

### Repro

Ingest a histogram with `ExplicitBounds=[1,5,10]`, `BucketCounts=[1,2,3,4]`, `Count=10`. Before this fix chstorage stored `le="+Inf"` = 6 (1+2+3), dropping the overflow count 4, while `_count` = 10.

## Fix

Fold the remaining (overflow) bucket counts into the cumulative total before writing the `+Inf` bucket, so it equals the datapoint count.

## Test

`TestMetricsBatchHistogramInfBucket` builds the batch from a crafted OTLP histogram and asserts `_bucket{le="+Inf"} == _count == 10`. Verified it fails without the fix and passes with it. Full `internal/chstorage` suite (incl. golden tests) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)