### PR TITLE
feat(ch2storagebackend): migrate metrics

### DIFF
--- a/cmd/ch2storagebackend/main.go
+++ b/cmd/ch2storagebackend/main.go
@@ -1,6 +1,6 @@
 // Command ch2storagebackend migrates data from chstorage's ClickHouse tables into the
 // embedded storagebackend engine, by scanning ClickHouse directly and re-ingesting the
-// decoded records as OTLP pdata. Only logs and traces are supported so far.
+// decoded records as OTLP pdata. Logs, traces, and metrics are supported.
 package main
 
 import (
@@ -33,7 +33,7 @@ func run(ctx context.Context) error {
 		storageDir = flag.String("storage-dir", "", "Directory for the embedded storage engine's file backend (empty uses an ephemeral in-memory backend)")
 		batchSize  = flag.Int("batch", 5_000, "Number of records/spans to convert and ingest per batch")
 		since      = flag.Duration("since", 0, "If positive, only migrate the last since of data (relative to the most recent record), instead of the full table")
-		signals    = flag.String("signals", "logs,traces", "Comma-separated list of signals to migrate (logs, traces)")
+		signals    = flag.String("signals", "logs,traces,metrics", "Comma-separated list of signals to migrate (logs, traces, metrics)")
 		// A bulk migration writes orders of magnitude faster than steady production ingestion, so
 		// the engine's default flush cadence (tuned for the latter) leaves the head/WAL growing
 		// unbounded in RAM for the lifetime of this process. Flush aggressively instead.
@@ -91,6 +91,16 @@ func run(ctx context.Context) error {
 				return errors.Wrap(err, "migrate traces")
 			}
 			lg.Info("Migrated traces", zap.Int("spans", stats.Spans), zap.Int("batches", stats.Batches))
+		case "metrics":
+			stats, err := m.MigrateMetrics(ctx, *since, *batchSize)
+			if err != nil {
+				return errors.Wrap(err, "migrate metrics")
+			}
+			lg.Info("Migrated metrics",
+				zap.Int("points", stats.Points),
+				zap.Int("exp_histograms", stats.ExpHistograms),
+				zap.Int("batches", stats.Batches),
+			)
 		default:
 			return errors.Errorf("unknown signal %q", sig)
 		}

--- a/integration/ch2storagebackende2e/migrate_metrics_test.go
+++ b/integration/ch2storagebackende2e/migrate_metrics_test.go
@@ -82,7 +82,7 @@ func TestMigrateMetrics(t *testing.T) {
 
 	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
 		Name:           "ch2storagebackend-metrics",
-		TablePrefix:    "ch2sbm",
+		TablePrefix:    uniqueTablePrefix(),
 		TracerProvider: provider,
 	})
 

--- a/integration/ch2storagebackende2e/migrate_metrics_test.go
+++ b/integration/ch2storagebackende2e/migrate_metrics_test.go
@@ -1,0 +1,151 @@
+package ch2storagebackende2e_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+
+	"github.com/oteldb/oteldb/integration"
+	"github.com/oteldb/oteldb/internal/ch2storagebackend"
+	"github.com/oteldb/oteldb/internal/chstorage"
+	oteldbpromql "github.com/oteldb/oteldb/internal/promql"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// buildMetrics constructs one resource carrying a gauge, an explicit-bucket histogram, and an
+// exponential histogram, each with a single datapoint at base.
+func buildMetrics(base time.Time) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "metricService")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("ch2storagebackend_test")
+
+	ts := pcommon.NewTimestampFromTime(base)
+
+	// Gauge.
+	{
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("test_gauge")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(ts)
+		dp.SetDoubleValue(42)
+		dp.Attributes().PutStr("host", "a")
+	}
+
+	// Explicit-bucket histogram: bounds [1,5,10], per-bucket counts [1,2,3,4] (total 10), sum 100.
+	{
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("test_hist")
+		h := m.SetEmptyHistogram()
+		h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		dp := h.DataPoints().AppendEmpty()
+		dp.SetTimestamp(ts)
+		dp.SetCount(10)
+		dp.SetSum(100)
+		dp.ExplicitBounds().FromRaw([]float64{1, 5, 10})
+		dp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+	}
+
+	// Exponential histogram.
+	{
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("test_exp")
+		eh := m.SetEmptyExponentialHistogram()
+		eh.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		dp := eh.DataPoints().AppendEmpty()
+		dp.SetTimestamp(ts)
+		dp.SetScale(0)
+		dp.SetCount(6)
+		dp.SetSum(30)
+		dp.SetZeroCount(0)
+		dp.Positive().SetOffset(0)
+		dp.Positive().BucketCounts().FromRaw([]uint64{1, 2, 3})
+	}
+
+	return md
+}
+
+func TestMigrateMetrics(t *testing.T) {
+	integration.Skip(t)
+	var (
+		ctx      = t.Context()
+		provider = integration.TraceProvider(t)
+	)
+
+	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
+		Name:           "ch2storagebackend-metrics",
+		TablePrefix:    "ch2sbm",
+		TracerProvider: provider,
+	})
+
+	inserter, err := chstorage.NewInserter(client, chstorage.InserterOptions{
+		Tables:         tables,
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, inserter.ConsumeMetrics(ctx, buildMetrics(base)))
+
+	store, err := storage.Open(ctx, storage.Options{},
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close(ctx)
+	})
+	back := storagebackend.New(store)
+
+	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
+	stats, err := m.MigrateMetrics(ctx, 0, 1000)
+	require.NoError(t, err)
+	// Number points: gauge(1) + hist _count/_sum/_bucket(le=1,5,10,+Inf) = 1 + 1 + 1 + 4 = 7.
+	require.Equal(t, 7, stats.Points)
+	require.Equal(t, 1, stats.ExpHistograms)
+
+	engine, err := oteldbpromql.New(back, oteldbpromql.EngineOpts{
+		MaxSamples:    1_000_000,
+		Timeout:       time.Minute,
+		LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	query := func(q string) float64 {
+		t.Helper()
+		iq, err := engine.NewInstantQuery(ctx, back, promql.NewPrometheusQueryOpts(false, 0), q, base)
+		require.NoError(t, err)
+		defer iq.Close()
+		res := iq.Exec(ctx)
+		require.NoError(t, res.Err)
+		vec, ok := res.Value.(promql.Vector)
+		require.Truef(t, ok, "query %q: not a vector", q)
+		require.Lenf(t, vec, 1, "query %q: expected exactly one sample", q)
+		return vec[0].F
+	}
+
+	// Gauge round-trips.
+	require.Equal(t, float64(42), query(`test_gauge`))
+
+	// Histogram components round-trip verbatim (name suffixes + le labels preserved). Cumulative
+	// bucket counts: le="1"=1, le="5"=1+2=3, le="10"=1+2+3=6, le="+Inf"=1+2+3+4=10 (the overflow
+	// bucket), matching the datapoint count.
+	require.Equal(t, float64(10), query(`test_hist_count`))
+	require.Equal(t, float64(100), query(`test_hist_sum`))
+	require.Equal(t, float64(1), query(`test_hist_bucket{le="1"}`))
+	require.Equal(t, float64(3), query(`test_hist_bucket{le="5"}`))
+	require.Equal(t, float64(6), query(`test_hist_bucket{le="10"}`))
+	require.Equal(t, float64(10), query(`test_hist_bucket{le="+Inf"}`))
+
+	// Exp histogram is reconstructed natively, then decomposed by storagebackend into _count/_sum.
+	require.Equal(t, float64(6), query(`test_exp_count`))
+	require.Equal(t, float64(30), query(`test_exp_sum`))
+}

--- a/integration/ch2storagebackende2e/migrate_test.go
+++ b/integration/ch2storagebackende2e/migrate_test.go
@@ -5,9 +5,11 @@ package ch2storagebackende2e_test
 
 import (
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -74,7 +76,7 @@ func TestMigrateLogs(t *testing.T) {
 
 	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
 		Name:           "ch2storagebackend",
-		TablePrefix:    "ch2sb",
+		TablePrefix:    uniqueTablePrefix(),
 		TracerProvider: provider,
 	})
 
@@ -158,6 +160,13 @@ func asLokiTime(t time.Time) lokiapi.LokiTime {
 	return lokiapi.LokiTime(t.Format(time.RFC3339Nano))
 }
 
+// uniqueTablePrefix returns a per-run table prefix so tests stay idempotent against a reused
+// ClickHouse container (which otherwise accumulates data across runs and breaks exact-count
+// assertions).
+func uniqueTablePrefix() string {
+	return "ch2sb_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
 // buildTraces constructs a single trace with two spans (a root and a child), belonging to
 // one resource/scope.
 func buildTraces(base time.Time, traceID pcommon.TraceID) ptrace.Traces {
@@ -199,7 +208,7 @@ func TestMigrateTraces(t *testing.T) {
 
 	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
 		Name:           "ch2storagebackend-traces",
-		TablePrefix:    "ch2sbt",
+		TablePrefix:    uniqueTablePrefix(),
 		TracerProvider: provider,
 	})
 

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -2,7 +2,11 @@
 // embedded storagebackend engine, by scanning ClickHouse directly (bypassing chstorage's
 // selector-oriented queriers) and re-ingesting the decoded records as OTLP pdata.
 //
-// Only logs and traces are supported so far; metrics are not migrated.
+// Logs, traces, and metrics are supported. Metrics are migrated verbatim: chstorage already
+// stores them as decomposed Prometheus-style series (histograms/summaries exploded into
+// _count/_sum/_bucket{le}/{quantile} series), so each stored series is re-ingested 1:1 as a gauge
+// number point, and exponential histograms (stored natively) are reconstructed as OTLP
+// exponential-histogram datapoints. Exemplars are not migrated (the target engine drops them).
 package ch2storagebackend
 
 import (
@@ -14,6 +18,7 @@ import (
 
 	"github.com/oteldb/oteldb/internal/chstorage"
 	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/storagebackend"
 	"github.com/oteldb/oteldb/internal/tracestorage"
 )
@@ -34,10 +39,21 @@ type TracesStats struct {
 	Batches int
 }
 
+// MetricsStats reports the outcome of a [Migrator.MigrateMetrics] run.
+type MetricsStats struct {
+	// Points is the total number of decomposed number points migrated.
+	Points int
+	// ExpHistograms is the total number of exponential-histogram datapoints migrated.
+	ExpHistograms int
+	// Batches is the number of batches ConsumeMetrics was called with.
+	Batches int
+}
+
 // Migrator copies data from chstorage's ClickHouse tables into a [storagebackend.Backend].
 type Migrator struct {
 	logs     *chstorage.LogsSource
 	traces   *chstorage.TracesSource
+	metrics  *chstorage.MetricsSource
 	back     *storagebackend.Backend
 	logger   *zap.Logger
 	throttle time.Duration
@@ -61,10 +77,11 @@ func NewMigrator(client chstorage.ClickHouseClient, tables chstorage.Tables, bac
 		logger = zap.NewNop()
 	}
 	m := &Migrator{
-		logs:   chstorage.NewLogsSource(client, tables, logger.Named("logs_source")),
-		traces: chstorage.NewTracesSource(client, tables, logger.Named("traces_source")),
-		back:   back,
-		logger: logger,
+		logs:    chstorage.NewLogsSource(client, tables, logger.Named("logs_source")),
+		traces:  chstorage.NewTracesSource(client, tables, logger.Named("traces_source")),
+		metrics: chstorage.NewMetricsSource(client, tables, logger.Named("metrics_source")),
+		back:    back,
+		logger:  logger,
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -131,6 +148,46 @@ func (m *Migrator) MigrateTraces(ctx context.Context, since time.Duration, batch
 	})
 	if err != nil {
 		return stats, errors.Wrap(err, "migrate traces")
+	}
+	return stats, nil
+}
+
+// MigrateMetrics migrates metrics stored in ClickHouse into the storagebackend engine. Decomposed
+// number series (gauges/sums and histogram/summary components) are ingested verbatim as gauge
+// datapoints; exponential histograms are reconstructed natively. When since is positive, only the
+// last since of data (relative to the most recent point) is migrated.
+func (m *Migrator) MigrateMetrics(ctx context.Context, since time.Duration, batchSize int) (MetricsStats, error) {
+	var stats MetricsStats
+	err := m.metrics.Do(ctx, since, batchSize,
+		func(ctx context.Context, points []metricstorage.NumberPoint) error {
+			md := metricstorage.NumberPointsToMetrics(points)
+			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
+				return errors.Wrap(err, "consume metrics")
+			}
+			stats.Points += len(points)
+			stats.Batches++
+			m.logger.Info("Migrated metric points batch",
+				zap.Int("batch_points", len(points)),
+				zap.Int("total_points", stats.Points),
+			)
+			return m.sleep(ctx)
+		},
+		func(ctx context.Context, points []metricstorage.ExpHistogramPoint) error {
+			md := metricstorage.ExpHistogramsToMetrics(points)
+			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
+				return errors.Wrap(err, "consume exp histograms")
+			}
+			stats.ExpHistograms += len(points)
+			stats.Batches++
+			m.logger.Info("Migrated exp histograms batch",
+				zap.Int("batch_points", len(points)),
+				zap.Int("total_exp_histograms", stats.ExpHistograms),
+			)
+			return m.sleep(ctx)
+		},
+	)
+	if err != nil {
+		return stats, errors.Wrap(err, "migrate metrics")
 	}
 	return stats, nil
 }

--- a/internal/chstorage/bridge.go
+++ b/internal/chstorage/bridge.go
@@ -1,0 +1,26 @@
+package chstorage
+
+import "time"
+
+// forEachDayBucket calls fn for each UTC-day-aligned window covering [mint, maxt], with the first
+// and last buckets clamped to mint/maxt respectively. Day-aligning keeps each scan inside a single
+// daily table partition, while clamping ensures a bounded scan (e.g. a `since`-limited window)
+// reads only the requested range instead of the whole calendar day at each end.
+func forEachDayBucket(mint, maxt time.Time, fn func(from, to time.Time) error) error {
+	const step = 24 * time.Hour
+	start := mint.Truncate(step)
+	end := maxt.Truncate(step).Add(step)
+	for ts := start; ts.Before(end); ts = ts.Add(step) {
+		from, to := ts, ts.Add(step)
+		if from.Before(mint) {
+			from = mint
+		}
+		if to.After(maxt) {
+			to = maxt
+		}
+		if err := fn(from, to); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/chstorage/bridge.go
+++ b/internal/chstorage/bridge.go
@@ -2,10 +2,15 @@ package chstorage
 
 import "time"
 
-// forEachDayBucket calls fn for each UTC-day-aligned window covering [mint, maxt], with the first
-// and last buckets clamped to mint/maxt respectively. Day-aligning keeps each scan inside a single
-// daily table partition, while clamping ensures a bounded scan (e.g. a `since`-limited window)
-// reads only the requested range instead of the whole calendar day at each end.
+// forEachDayBucket calls fn for each UTC-day-aligned window covering [mint, maxt]. Day-aligning
+// keeps each scan inside a single daily table partition; the first bucket's lower bound is clamped
+// to mint so a `since`-limited window skips the early part of its first day instead of scanning the
+// whole calendar day.
+//
+// Only the lower bound is clamped. The upper bound stays at the day's end because mint/maxt come
+// from queryMinMaxTimestamp, which floors to whole seconds (toDateTime): clamping the top to a
+// floored maxt would drop any sub-second data in maxt's final second. Since no data exists past the
+// true max, a full-day upper bound reads the same rows without that risk.
 func forEachDayBucket(mint, maxt time.Time, fn func(from, to time.Time) error) error {
 	const step = 24 * time.Hour
 	start := mint.Truncate(step)
@@ -14,9 +19,6 @@ func forEachDayBucket(mint, maxt time.Time, fn func(from, to time.Time) error) e
 		from, to := ts, ts.Add(step)
 		if from.Before(mint) {
 			from = mint
-		}
-		if to.After(maxt) {
-			to = maxt
 		}
 		if err := fn(from, to); err != nil {
 			return err

--- a/internal/chstorage/bridge_logs.go
+++ b/internal/chstorage/bridge_logs.go
@@ -56,15 +56,12 @@ func (s *LogsSource) Do(ctx context.Context, since time.Duration, batchSize int,
 		}
 	}
 
-	step := 24 * time.Hour
-	start := mint.Truncate(step)
-	end := maxt.Truncate(step).Add(step)
-	for ts := start; ts.Before(end); ts = ts.Add(step) {
-		if err := s.scanDay(ctx, ts, ts.Add(step), batchSize, batchFn); err != nil {
-			return errors.Wrapf(err, "scan day %s", ts)
+	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
+		if err := s.scanDay(ctx, from, to, batchSize, batchFn); err != nil {
+			return errors.Wrapf(err, "scan %s", from)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *LogsSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn LogsBatchFunc) error {

--- a/internal/chstorage/bridge_metrics.go
+++ b/internal/chstorage/bridge_metrics.go
@@ -1,0 +1,321 @@
+package chstorage
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/oteldb/internal/chstorage/chsql"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+// NumberPointsBatchFunc is called with each decoded batch of number points read by [MetricsSource].
+type NumberPointsBatchFunc func(ctx context.Context, points []metricstorage.NumberPoint) error
+
+// ExpHistogramsBatchFunc is called with each decoded batch of exponential histograms.
+type ExpHistogramsBatchFunc func(ctx context.Context, points []metricstorage.ExpHistogramPoint) error
+
+// seriesMeta is the per-series identity resolved from metrics_timeseries by hash: the (already
+// suffixed, for histogram/summary components) metric name, its unit/description, and the
+// attribute maps (attribute already carries the le/quantile label for bucket/quantile series).
+type seriesMeta struct {
+	name        string
+	unit        string
+	description string
+	attrs       otelstorage.Attrs
+	scope       otelstorage.Attrs
+	resource    otelstorage.Attrs
+}
+
+// MetricsSource reads metrics stored in ClickHouse for migration into another storage engine. It
+// first loads the series set from metrics_timeseries (small relative to the point volume) into an
+// in-memory hash→[seriesMeta] map, then day-bucket scans metrics_points and metrics_exp_histograms
+// (mirroring [Backup]) and resolves each row's series by hash. Exemplars are not read (the target
+// engine drops them). metrics_labels is not read (it is an autocomplete index, deriving nothing
+// the timeseries rows do not already carry).
+type MetricsSource struct {
+	client     ClickHouseClient
+	timeseries string
+	points     string
+	expHistos  string
+	logger     *zap.Logger
+}
+
+// NewMetricsSource creates a new [MetricsSource].
+func NewMetricsSource(client ClickHouseClient, tables Tables, logger *zap.Logger) *MetricsSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &MetricsSource{
+		client:     client,
+		timeseries: tables.Timeseries,
+		points:     tables.Points,
+		expHistos:  tables.ExpHistograms,
+		logger:     logger,
+	}
+}
+
+// Do migrates metrics: it loads the series set (restricted to the scan window when since is
+// positive), then scans number points and exponential histograms, invoking numberFn and expFn
+// with batches of up to batchSize decoded points. Rows whose hash is absent from the series set
+// are skipped and counted (logged at the end).
+func (s *MetricsSource) Do(
+	ctx context.Context,
+	since time.Duration,
+	batchSize int,
+	numberFn NumberPointsBatchFunc,
+	expFn ExpHistogramsBatchFunc,
+) error {
+	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client,
+		[2]string{s.points, "timestamp"},
+		[2]string{s.expHistos, "timestamp"},
+	)
+	if err != nil {
+		return errors.Wrap(err, "query min/max timestamp")
+	}
+	if mint.IsZero() && maxt.IsZero() {
+		s.logger.Info("No metrics to migrate")
+		return nil
+	}
+	if since > 0 {
+		if cut := maxt.Add(-since); cut.After(mint) {
+			mint = cut
+		}
+	}
+
+	series, err := s.loadSeries(ctx, mint, maxt)
+	if err != nil {
+		return errors.Wrap(err, "load series")
+	}
+	s.logger.Info("Loaded metric series", zap.Int("series", len(series)))
+
+	var missing int
+	if err := s.scanNumberPoints(ctx, series, mint, maxt, batchSize, &missing, numberFn); err != nil {
+		return errors.Wrap(err, "scan number points")
+	}
+	if err := s.scanExpHistograms(ctx, series, mint, maxt, batchSize, &missing, expFn); err != nil {
+		return errors.Wrap(err, "scan exp histograms")
+	}
+	if missing > 0 {
+		s.logger.Warn("Skipped points with no matching series", zap.Int("count", missing))
+	}
+	return nil
+}
+
+// loadSeries reads metrics_timeseries into a hash→meta map, restricted to series whose
+// [first_seen, last_seen] overlaps [mint, maxt].
+func (s *MetricsSource) loadSeries(ctx context.Context, mint, maxt time.Time) (map[[16]byte]seriesMeta, error) {
+	c := newTimeseriesColumns()
+	prec := c.timestampPrecision()
+
+	query := chsql.Select(s.timeseries, c.ChsqlResult()...).
+		Where(
+			chsql.Lte(chsql.Ident("first_seen"), chsql.DateTime64(maxt, prec)),
+			chsql.Gte(chsql.Ident("last_seen"), chsql.DateTime64(mint, prec)),
+		)
+
+	out := map[[16]byte]seriesMeta{}
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		for i := 0; i < c.hash.Rows(); i++ {
+			out[c.hash.Row(i)] = seriesMeta{
+				name:        c.name.Row(i),
+				unit:        c.unit.Row(i),
+				description: c.description.Row(i),
+				attrs:       c.attributes.Row(i),
+				scope:       c.scope.Row(i),
+				resource:    c.resource.Row(i),
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare query")
+	}
+	if err := s.client.Do(ctx, chq); err != nil {
+		return nil, errors.Wrap(err, "execute query")
+	}
+	return out, nil
+}
+
+func (s *MetricsSource) scanNumberPoints(
+	ctx context.Context,
+	series map[[16]byte]seriesMeta,
+	mint, maxt time.Time,
+	batchSize int,
+	missing *int,
+	fn NumberPointsBatchFunc,
+) error {
+	step := 24 * time.Hour
+	start := mint.Truncate(step)
+	end := maxt.Truncate(step).Add(step)
+	for ts := start; ts.Before(end); ts = ts.Add(step) {
+		if err := s.scanNumberDay(ctx, series, ts, ts.Add(step), batchSize, missing, fn); err != nil {
+			return errors.Wrapf(err, "scan day %s", ts)
+		}
+	}
+	return nil
+}
+
+func (s *MetricsSource) scanNumberDay(
+	ctx context.Context,
+	series map[[16]byte]seriesMeta,
+	start, end time.Time,
+	batchSize int,
+	missing *int,
+	fn NumberPointsBatchFunc,
+) error {
+	var (
+		c   = newPointColumns()
+		buf []metricstorage.NumberPoint
+	)
+
+	flush := func(ctx context.Context) error {
+		if len(buf) == 0 {
+			return nil
+		}
+		if err := fn(ctx, buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+		return nil
+	}
+
+	query := chsql.Select(s.points, c.ChsqlResult()...).
+		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionMilli))
+
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		defer c.Columns().Reset()
+		for i := 0; i < c.timestamp.Rows(); i++ {
+			meta, ok := series[c.hash.Row(i)]
+			if !ok {
+				*missing++
+				continue
+			}
+			buf = append(buf, metricstorage.NumberPoint{
+				Name:        meta.name,
+				Unit:        meta.unit,
+				Description: meta.description,
+				Resource:    meta.resource,
+				Scope:       meta.scope,
+				Attrs:       meta.attrs,
+				Timestamp:   otelstorage.NewTimestampFromTime(c.timestamp.Row(i)),
+				Value:       c.value.Row(i),
+			})
+			if len(buf) >= batchSize {
+				if err := flush(ctx); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "prepare query")
+	}
+	if err := s.client.Do(ctx, chq); err != nil {
+		return errors.Wrap(err, "execute query")
+	}
+	return flush(ctx)
+}
+
+func (s *MetricsSource) scanExpHistograms(
+	ctx context.Context,
+	series map[[16]byte]seriesMeta,
+	mint, maxt time.Time,
+	batchSize int,
+	missing *int,
+	fn ExpHistogramsBatchFunc,
+) error {
+	step := 24 * time.Hour
+	start := mint.Truncate(step)
+	end := maxt.Truncate(step).Add(step)
+	for ts := start; ts.Before(end); ts = ts.Add(step) {
+		if err := s.scanExpDay(ctx, series, ts, ts.Add(step), batchSize, missing, fn); err != nil {
+			return errors.Wrapf(err, "scan day %s", ts)
+		}
+	}
+	return nil
+}
+
+func (s *MetricsSource) scanExpDay(
+	ctx context.Context,
+	series map[[16]byte]seriesMeta,
+	start, end time.Time,
+	batchSize int,
+	missing *int,
+	fn ExpHistogramsBatchFunc,
+) error {
+	var (
+		c   = newExpHistogramColumns()
+		buf []metricstorage.ExpHistogramPoint
+	)
+
+	flush := func(ctx context.Context) error {
+		if len(buf) == 0 {
+			return nil
+		}
+		if err := fn(ctx, buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+		return nil
+	}
+
+	nullable := func(v proto.Nullable[float64]) *float64 {
+		if !v.Set {
+			return nil
+		}
+		return &v.Value
+	}
+
+	query := chsql.Select(s.expHistos, c.ChsqlResult()...).
+		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionMilli))
+
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		defer c.Columns().Reset()
+		for i := 0; i < c.timestamp.Rows(); i++ {
+			meta, ok := series[c.hash.Row(i)]
+			if !ok {
+				*missing++
+				continue
+			}
+			buf = append(buf, metricstorage.ExpHistogramPoint{
+				Name:                 meta.name,
+				Unit:                 meta.unit,
+				Description:          meta.description,
+				Resource:             meta.resource,
+				Scope:                meta.scope,
+				Attrs:                meta.attrs,
+				Timestamp:            otelstorage.NewTimestampFromTime(c.timestamp.Row(i)),
+				Count:                c.count.Row(i),
+				Sum:                  nullable(c.sum.Row(i)),
+				Min:                  nullable(c.min.Row(i)),
+				Max:                  nullable(c.max.Row(i)),
+				Scale:                c.scale.Row(i),
+				ZeroCount:            c.zerocount.Row(i),
+				PositiveOffset:       c.positiveOffset.Row(i),
+				PositiveBucketCounts: c.positiveBucketCounts.Row(i),
+				NegativeOffset:       c.negativeOffset.Row(i),
+				NegativeBucketCounts: c.negativeBucketCounts.Row(i),
+				Flags:                uint32(c.flags.Row(i)),
+			})
+			if len(buf) >= batchSize {
+				if err := flush(ctx); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "prepare query")
+	}
+	if err := s.client.Do(ctx, chq); err != nil {
+		return errors.Wrap(err, "execute query")
+	}
+	return flush(ctx)
+}

--- a/internal/chstorage/bridge_metrics.go
+++ b/internal/chstorage/bridge_metrics.go
@@ -149,15 +149,12 @@ func (s *MetricsSource) scanNumberPoints(
 	missing *int,
 	fn NumberPointsBatchFunc,
 ) error {
-	step := 24 * time.Hour
-	start := mint.Truncate(step)
-	end := maxt.Truncate(step).Add(step)
-	for ts := start; ts.Before(end); ts = ts.Add(step) {
-		if err := s.scanNumberDay(ctx, series, ts, ts.Add(step), batchSize, missing, fn); err != nil {
-			return errors.Wrapf(err, "scan day %s", ts)
+	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
+		if err := s.scanNumberDay(ctx, series, from, to, batchSize, missing, fn); err != nil {
+			return errors.Wrapf(err, "scan %s", from)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *MetricsSource) scanNumberDay(
@@ -230,15 +227,12 @@ func (s *MetricsSource) scanExpHistograms(
 	missing *int,
 	fn ExpHistogramsBatchFunc,
 ) error {
-	step := 24 * time.Hour
-	start := mint.Truncate(step)
-	end := maxt.Truncate(step).Add(step)
-	for ts := start; ts.Before(end); ts = ts.Add(step) {
-		if err := s.scanExpDay(ctx, series, ts, ts.Add(step), batchSize, missing, fn); err != nil {
-			return errors.Wrapf(err, "scan day %s", ts)
+	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
+		if err := s.scanExpDay(ctx, series, from, to, batchSize, missing, fn); err != nil {
+			return errors.Wrapf(err, "scan %s", from)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *MetricsSource) scanExpDay(

--- a/internal/chstorage/bridge_traces.go
+++ b/internal/chstorage/bridge_traces.go
@@ -56,15 +56,12 @@ func (s *TracesSource) Do(ctx context.Context, since time.Duration, batchSize in
 		}
 	}
 
-	step := 24 * time.Hour
-	start := mint.Truncate(step)
-	end := maxt.Truncate(step).Add(step)
-	for ts := start; ts.Before(end); ts = ts.Add(step) {
-		if err := s.scanDay(ctx, ts, ts.Add(step), batchSize, batchFn); err != nil {
-			return errors.Wrapf(err, "scan day %s", ts)
+	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
+		if err := s.scanDay(ctx, from, to, batchSize, batchFn); err != nil {
+			return errors.Wrapf(err, "scan %s", from)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *TracesSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn TracesBatchFunc) error {

--- a/internal/metricstorage/pdata.go
+++ b/internal/metricstorage/pdata.go
@@ -1,0 +1,171 @@
+package metricstorage
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+)
+
+// NumberPoint is a single decomposed numeric sample as chstorage stores it: one point of one
+// Prometheus-style series (a gauge/sum, or a histogram/summary component whose name already
+// carries the _count/_sum/_bucket suffix and whose Attrs already carry the le/quantile label).
+type NumberPoint struct {
+	Name        string
+	Unit        string
+	Description string
+
+	Resource otelstorage.Attrs
+	Scope    otelstorage.Attrs
+	Attrs    otelstorage.Attrs
+
+	Timestamp pcommon.Timestamp
+	Value     float64
+}
+
+// ExpHistogramPoint is a single exponential-histogram datapoint as chstorage stores it (native,
+// not decomposed), resolved together with its series metadata.
+type ExpHistogramPoint struct {
+	Name        string
+	Unit        string
+	Description string
+
+	Resource otelstorage.Attrs
+	Scope    otelstorage.Attrs
+	Attrs    otelstorage.Attrs
+
+	Timestamp pcommon.Timestamp
+
+	Count     uint64
+	Sum       *float64
+	Min       *float64
+	Max       *float64
+	Scale     int32
+	ZeroCount uint64
+
+	PositiveOffset       int32
+	PositiveBucketCounts []uint64
+	NegativeOffset       int32
+	NegativeBucketCounts []uint64
+
+	Flags uint32
+}
+
+// scopeKey groups datapoints into ResourceMetrics/ScopeMetrics by resource and scope identity.
+// chstorage does not store scope name/version separately for metrics (only a scope attribute
+// map), so grouping is by attribute-set hashes alone.
+type scopeKey struct {
+	resource otelstorage.Hash
+	scope    otelstorage.Hash
+}
+
+// metricsGrouper accumulates a pmetric.Metrics, opening one ResourceMetrics/ScopeMetrics per
+// distinct (resource, scope) and one Metric per name within a scope.
+type metricsGrouper struct {
+	md     pmetric.Metrics
+	scopes map[scopeKey]pmetric.ScopeMetrics
+	// metrics keys a Metric by its scope pointer identity and name, so datapoints of the same
+	// series accumulate under a single Metric.
+	metrics map[metricKey]pmetric.Metric
+}
+
+type metricKey struct {
+	scope scopeKey
+	name  string
+}
+
+func newMetricsGrouper() *metricsGrouper {
+	return &metricsGrouper{
+		md:      pmetric.NewMetrics(),
+		scopes:  map[scopeKey]pmetric.ScopeMetrics{},
+		metrics: map[metricKey]pmetric.Metric{},
+	}
+}
+
+func (g *metricsGrouper) scopeMetrics(resource, scope otelstorage.Attrs) (scopeKey, pmetric.ScopeMetrics) {
+	key := scopeKey{resource: resource.Hash(), scope: scope.Hash()}
+	sm, ok := g.scopes[key]
+	if !ok {
+		rm := g.md.ResourceMetrics().AppendEmpty()
+		resource.CopyTo(rm.Resource().Attributes())
+		sm = rm.ScopeMetrics().AppendEmpty()
+		scope.CopyTo(sm.Scope().Attributes())
+		g.scopes[key] = sm
+	}
+	return key, sm
+}
+
+// metric returns the Metric for the given series, creating it (via newMetric) on first use so
+// per-name datapoints accumulate together.
+func (g *metricsGrouper) metric(resource, scope otelstorage.Attrs, name string, newMetric func(pmetric.ScopeMetrics) pmetric.Metric) pmetric.Metric {
+	skey, sm := g.scopeMetrics(resource, scope)
+	mkey := metricKey{scope: skey, name: name}
+	m, ok := g.metrics[mkey]
+	if !ok {
+		m = newMetric(sm)
+		g.metrics[mkey] = m
+	}
+	return m
+}
+
+// NumberPointsToMetrics converts decomposed numeric samples back into an OTLP [pmetric.Metrics]
+// payload, one Gauge per (resource, scope, name). chstorage discards the original gauge-vs-sum
+// distinction for these points, so every series is emitted as a gauge; the values, names, and
+// labels round-trip exactly.
+func NumberPointsToMetrics(points []NumberPoint) pmetric.Metrics {
+	g := newMetricsGrouper()
+	for _, p := range points {
+		m := g.metric(p.Resource, p.Scope, p.Name, func(sm pmetric.ScopeMetrics) pmetric.Metric {
+			m := sm.Metrics().AppendEmpty()
+			m.SetName(p.Name)
+			m.SetUnit(p.Unit)
+			m.SetDescription(p.Description)
+			m.SetEmptyGauge()
+			return m
+		})
+		dp := m.Gauge().DataPoints().AppendEmpty()
+		p.Attrs.CopyTo(dp.Attributes())
+		dp.SetTimestamp(p.Timestamp)
+		dp.SetDoubleValue(p.Value)
+	}
+	return g.md
+}
+
+// ExpHistogramsToMetrics converts exponential-histogram datapoints back into an OTLP
+// [pmetric.Metrics] payload, one ExponentialHistogram per (resource, scope, name). Temporality is
+// set to cumulative (chstorage does not store it, and cumulative is the norm for stored series).
+func ExpHistogramsToMetrics(points []ExpHistogramPoint) pmetric.Metrics {
+	g := newMetricsGrouper()
+	for _, p := range points {
+		m := g.metric(p.Resource, p.Scope, p.Name, func(sm pmetric.ScopeMetrics) pmetric.Metric {
+			m := sm.Metrics().AppendEmpty()
+			m.SetName(p.Name)
+			m.SetUnit(p.Unit)
+			m.SetDescription(p.Description)
+			eh := m.SetEmptyExponentialHistogram()
+			eh.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			return m
+		})
+		dp := m.ExponentialHistogram().DataPoints().AppendEmpty()
+		p.Attrs.CopyTo(dp.Attributes())
+		dp.SetTimestamp(p.Timestamp)
+		dp.SetFlags(pmetric.DataPointFlags(p.Flags))
+		dp.SetCount(p.Count)
+		if p.Sum != nil {
+			dp.SetSum(*p.Sum)
+		}
+		if p.Min != nil {
+			dp.SetMin(*p.Min)
+		}
+		if p.Max != nil {
+			dp.SetMax(*p.Max)
+		}
+		dp.SetScale(p.Scale)
+		dp.SetZeroCount(p.ZeroCount)
+		dp.Positive().SetOffset(p.PositiveOffset)
+		dp.Positive().BucketCounts().FromRaw(p.PositiveBucketCounts)
+		dp.Negative().SetOffset(p.NegativeOffset)
+		dp.Negative().BucketCounts().FromRaw(p.NegativeBucketCounts)
+	}
+	return g.md
+}


### PR DESCRIPTION
Stacked on #1149 (the histogram +Inf fix) — base is `claude/fix-histogram-inf-bucket`; retarget to `main` once #1149 merges.

## What

Adds metrics support to the chstorage→storagebackend bridge tool (`cmd/ch2storagebackend`, `internal/ch2storagebackend`), alongside the existing logs and traces.

## Approach — verbatim passthrough

chstorage already stores metrics as **decomposed Prometheus-style series** (histograms/summaries exploded into `_count`/`_sum`/`_bucket{le}`/`{quantile}`, each a distinct series; the suffixed name + le/quantile label are baked into `metrics_timeseries`). storagebackend's `pdataconv.AppendMetrics` re-decomposes OTLP histograms into the *same* form. So:

- `MetricsSource` (`internal/chstorage/bridge_metrics.go`) loads `metrics_timeseries` into an in-memory `hash→meta` map (windowed by first_seen/last_seen), then day-bucket scans `metrics_points` and emits each row 1:1 as a **gauge** number point — name, labels, and value straight from the series meta. No regrouping/de-cumulation; byte-identical series to chstorage.
- Exponential histograms (stored natively in `metrics_exp_histograms`, not decomposed) are rebuilt as OTLP `ExponentialHistogramDataPoint` and left for storagebackend to decompose.
- `metrics_labels` (autocomplete index) and `metrics_exemplars` (dropped by `AppendMetrics`) are skipped.

Full OTLP reconstruction was rejected: storagebackend's `formatBound` uses `'g'` float format while chstorage stored `le`/`quantile` with `'f'`, so reconstructing + re-decomposing would change the label strings and diverge from the source data.

Caveat: metric *type* shows as gauge in storagebackend metadata (chstorage already discarded gauge-vs-sum for plain points).

## Test

`TestMigrateMetrics` (E2E, `E2E=1`) ingests a gauge + explicit histogram + exponential histogram via the chstorage inserter, migrates into an in-memory storagebackend, and verifies the series/values via the real PromQL engine. Passes. (Depends on #1149: the histogram `+Inf` bucket assertion expects the corrected `_count`-consistent value.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)