### PR TITLE
refactor(oteldemo): rewrite CLI using cobra

### DIFF
--- a/cmd/oteldemo/client.go
+++ b/cmd/oteldemo/client.go
@@ -8,11 +8,32 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/app"
 	"github.com/go-faster/sdk/zctx"
+	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 )
 
-func client(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
+func newClientCommand() *cobra.Command {
+	var (
+		target   string
+		interval time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "client",
+		Short: "Run demo client sending requests to the demo server",
+		Args:  cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			app.Run(func(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
+				return client(ctx, lg, m, target, interval)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "http://server:8080/api/hello", "URL to send requests to")
+	cmd.Flags().DurationVar(&interval, "interval", time.Second, "interval between requests")
+	return cmd
+}
+
+func client(ctx context.Context, lg *zap.Logger, m *app.Telemetry, target string, interval time.Duration) error {
 	httpTransport := otelhttp.NewTransport(http.DefaultTransport,
 		otelhttp.WithTracerProvider(m.TracerProvider()),
 		otelhttp.WithMeterProvider(m.MeterProvider()),
@@ -36,7 +57,7 @@ func client(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
 		defer span.End()
 
 		time.Sleep(time.Millisecond * 40)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://server:8080/api/hello", http.NoBody)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, http.NoBody)
 		if err != nil {
 			lg.Error("create request", zap.Error(err))
 			return
@@ -55,7 +76,7 @@ func client(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
 		time.Sleep(time.Millisecond * 40)
 	}
 	sendRequest(ctx)
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/cmd/oteldemo/main.go
+++ b/cmd/oteldemo/main.go
@@ -1,25 +1,28 @@
+// Binary oteldemo generates demo telemetry (logs, metrics, traces, profiles) for oteldb.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
-	"github.com/go-faster/sdk/app"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	flag.Parse()
-	switch mode := flag.Arg(0); mode {
-	case "server":
-		app.Run(server)
-	case "client":
-		app.Run(client)
-	case "profiles":
-		app.Run(profiles)
-	default:
-		fmt.Fprintf(os.Stderr, "Unknown mode: %s\n", mode)
-		fmt.Fprintf(os.Stderr, "Usage: %s [server|client|profiles]\n", os.Args[0])
+	rootCmd := &cobra.Command{
+		Use:   "oteldemo",
+		Short: "oteldemo generates demo telemetry for oteldb",
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	rootCmd.AddCommand(
+		newServerCommand(),
+		newClientCommand(),
+		newProfilesCommand(),
+	)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/oteldemo/profiles.go
+++ b/cmd/oteldemo/profiles.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/app"
+	"github.com/spf13/cobra"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
@@ -34,8 +35,25 @@ var profileServices = []string{"client", "server"}
 // demo exercises the profiles signal (served by oteldb's Pyroscope API) alongside logs, metrics, and
 // traces. The OTel Go SDK has no stable profiles exporter, so this dials the collector directly and
 // pushes pprofile batches built with the pdata API (the same shape the storage engine ingests).
-func profiles(ctx context.Context, lg *zap.Logger, _ *app.Telemetry) error {
-	target := otlpEndpoint()
+func newProfilesCommand() *cobra.Command {
+	var endpoint string
+	cmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "Emit synthetic OTLP CPU profiles",
+		Args:  cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			app.Run(func(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
+				return profiles(ctx, lg, m, endpoint)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&endpoint, "endpoint", "",
+		"OTLP gRPC endpoint (defaults to OTEL_EXPORTER_OTLP_ENDPOINT, then oteldb:4317)")
+	return cmd
+}
+
+func profiles(ctx context.Context, lg *zap.Logger, _ *app.Telemetry, endpoint string) error {
+	target := otlpEndpoint(endpoint)
 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return errors.Wrap(err, "dial otlp")
@@ -59,10 +77,13 @@ func profiles(ctx context.Context, lg *zap.Logger, _ *app.Telemetry) error {
 	}
 }
 
-// otlpEndpoint resolves the OTLP gRPC target from OTEL_EXPORTER_OTLP_ENDPOINT, stripping any scheme
-// (gRPC dials host:port). It defaults to the in-cluster oteldb endpoint used by the demo compose.
-func otlpEndpoint() string {
-	ep := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+// otlpEndpoint resolves the OTLP gRPC target from the given override or OTEL_EXPORTER_OTLP_ENDPOINT,
+// stripping any scheme (gRPC dials host:port). It defaults to the in-cluster oteldb endpoint used by
+// the demo compose.
+func otlpEndpoint(ep string) string {
+	if ep == "" {
+		ep = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
 	if ep == "" {
 		ep = "oteldb:4317"
 	}

--- a/cmd/oteldemo/server.go
+++ b/cmd/oteldemo/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-faster/sdk/zctx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -18,7 +19,23 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func server(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
+func newServerCommand() *cobra.Command {
+	var addr string
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Run instrumented demo HTTP server",
+		Args:  cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			app.Run(func(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
+				return server(ctx, lg, m, addr)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&addr, "addr", "0.0.0.0:8080", "HTTP listen address")
+	return cmd
+}
+
+func server(ctx context.Context, lg *zap.Logger, m *app.Telemetry, addr string) error {
 	g, ctx := errgroup.WithContext(ctx)
 	mux := http.NewServeMux()
 
@@ -64,7 +81,7 @@ func server(ctx context.Context, lg *zap.Logger, m *app.Telemetry) error {
 		w.WriteHeader(http.StatusOK)
 	})
 	srv := &http.Server{
-		Addr:              "0.0.0.0:8080",
+		Addr:              addr,
 		ReadHeaderTimeout: time.Second,
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 		Handler: otelhttp.NewHandler(mux, "Hello",


### PR DESCRIPTION
## What

Rewrites `cmd/oteldemo` from a hand-rolled `flag.Arg(0)` mode dispatch to a cobra CLI with `server`, `client`, and `profiles` subcommands, and exposes previously hardcoded settings as flags:

- `server --addr` (default `0.0.0.0:8080`) — HTTP listen address
- `client --target` (default `http://server:8080/api/hello`) and `--interval` (default `1s`)
- `profiles --endpoint` — OTLP gRPC endpoint override; still falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`, then `oteldb:4317`, with the same scheme-stripping applied to all sources

## Why

The hardcoded docker-compose hostnames (`server:8080`, `oteldb:4317`) made oteldemo unusable outside compose, e.g. under systemd on localhost. Flags fix that while defaults preserve existing behavior — the `dev/local` compose files invoking `command: ["client"]` / `["server"]` / `["profiles"]` keep working unchanged.

Each subcommand wraps `app.Run` exactly as before; lifecycle and telemetry setup are untouched.

## Testing

- `go build ./cmd/oteldemo` + `golangci-lint run ./cmd/oteldemo/...` clean
- Ran all three subcommands under systemd user units against a local oteldb (OTLP gRPC): client gets 200s with trace IDs, profiles export without errors