### PR TITLE
test(storagebackend): golden query benchmarks for LogQL, TraceQL and ProfileQL

### DIFF
--- a/internal/storagebackend/goldenbench_logql_test.go
+++ b/internal/storagebackend/goldenbench_logql_test.go
@@ -1,0 +1,398 @@
+package storagebackend_test
+
+// Golden LogQL benchmarks — the stable set used to gate storage-level read regressions from the
+// LogQL front-end. They mirror the contract of storage's own golden_bench_test.go:
+//
+//   - Deterministic: one fixed canonical corpus, no RNG and no wall-clock (timestamps are derived
+//     from a fixed epoch), so run-to-run variance is the machine, not the data.
+//   - Flushed: the corpus is written as goldenLogQLParts immutable parts (plus one unflushed head
+//     round), so every query exercises the part-scan/decode path and the head+parts merge, not just
+//     the in-memory head.
+//   - Comparable: b.SetBytes is the LOGICAL (uncompressed) size of the streams the query selects, so
+//     MB/s is a real scan speed rather than a function of the codec's compression ratio.
+//   - Guarded: every case asserts an exact result count once, outside the timed loop, so a silently
+//     empty (and therefore fast) query can never masquerade as an improvement.
+//
+// Keep this set small and stable: the sub-benchmark names under BenchmarkGoldenLogQL/… are the CI
+// baseline keys, and changing the corpus resets the historical baseline.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+const (
+	// goldenLogQLServices is the number of JSON-bodied services; each is one stream.
+	goldenLogQLServices = 8
+	// goldenLogQLPerRound is the number of records each stream contributes per round.
+	goldenLogQLPerRound = 600
+	// goldenLogQLParts is the number of rounds flushed to their own immutable part. A ninth round
+	// stays in the head, so reads merge parts with the head the way a live store does.
+	goldenLogQLParts = 8
+	// goldenLogQLNeedleRound is the round that carries the needle records; every other part can be
+	// pruned by the body bloom, which is exactly what the needle case measures.
+	goldenLogQLNeedleRound = 3
+	// goldenLogQLNeedleEvery selects the needle records inside the needle round (svc-0 only).
+	goldenLogQLNeedleEvery = 150
+	// goldenLogQLStartTS is the fixed corpus epoch (2024-01-01T00:00:00Z), so nothing depends on the
+	// wall clock. Records are spaced goldenLogQLSpacing apart.
+	goldenLogQLStartTS = int64(1_704_067_200_000_000_000)
+	goldenLogQLSpacing = 100 * time.Millisecond
+	// goldenLogQLLogfmtService is the one stream whose bodies are logfmt rather than JSON, so the
+	// logfmt parser stage has a corpus of its own.
+	goldenLogQLLogfmtService = "logfmt"
+	// goldenLogQLNeedle is the high-selectivity literal. It is deliberately three words: the storage
+	// optimizer derives a bloom token hint from the *interior* tokens of a line-filter literal only
+	// (edge tokens may be glued into a larger token by a sub-word match), so a one-word needle would
+	// prune nothing.
+	goldenLogQLNeedle = "needle deadbeef marker"
+)
+
+var (
+	goldenLogQLLevels = [6]struct {
+		num  plog.SeverityNumber
+		text string
+	}{
+		{plog.SeverityNumberTrace, "TRACE"},
+		{plog.SeverityNumberDebug, "DEBUG"},
+		{plog.SeverityNumberInfo, "INFO"},
+		{plog.SeverityNumberWarn, "WARN"},
+		{plog.SeverityNumberError, "ERROR"},
+		{plog.SeverityNumberFatal, "FATAL"},
+	}
+	goldenLogQLMethods  = [6]string{"GET", "POST", "PUT", "HEAD", "DELETE", "PATCH"}
+	goldenLogQLStatuses = [6]int64{200, 201, 204, 400, 404, 500}
+	goldenLogQLRegions  = [4]string{"eu-west-1", "us-east-1", "us-west-2", "ap-south-1"}
+)
+
+// goldenLogQLStreams is the canonical stream set: goldenLogQLServices JSON services (the first half
+// in prod, the second in staging) plus one prod logfmt service.
+func goldenLogQLStreams() []goldenLogQLStream {
+	streams := make([]goldenLogQLStream, 0, goldenLogQLServices+1)
+	for s := range goldenLogQLServices {
+		env := "prod"
+		if s >= goldenLogQLServices/2 {
+			env = "staging"
+		}
+		streams = append(streams, goldenLogQLStream{service: "svc-" + strconv.Itoa(s), env: env})
+	}
+	return append(streams, goldenLogQLStream{service: goldenLogQLLogfmtService, env: "prod", logfmt: true})
+}
+
+// goldenLogQLStream describes one resource (stream) of the corpus.
+type goldenLogQLStream struct {
+	service string
+	env     string
+	logfmt  bool
+}
+
+// goldenLogQLCorpus is the read-only fixture shared by every sub-benchmark: a flushed store, the
+// LogQL engine over it, the query window, and the per-service logical (uncompressed) byte tally used
+// for b.SetBytes.
+type goldenLogQLCorpus struct {
+	engine *logqlengine.Engine
+	start  time.Time
+	end    time.Time
+	// logical maps service name → uncompressed bytes of its records (body + attributes + 16 bytes of
+	// timestamp/severity), the denominator for a query's scan throughput.
+	logical map[string]int64
+}
+
+// bytesFor sums the logical size of the named services.
+func (c *goldenLogQLCorpus) bytesFor(services ...string) int64 {
+	var n int64
+	for _, s := range services {
+		n += c.logical[s]
+	}
+	return n
+}
+
+// goldenLogQLRound builds one round of the corpus: every stream's goldenLogQLPerRound records, with
+// a JSON or logfmt body, rotating severities, and http.method/http.status_code/region record
+// attributes (structured metadata). It accumulates each stream's logical byte count into logical.
+// Fully deterministic — round and record index decide everything.
+func goldenLogQLRound(round int, logical map[string]int64) plog.Logs {
+	ld := plog.NewLogs()
+	for _, st := range goldenLogQLStreams() {
+		rl := ld.ResourceLogs().AppendEmpty()
+		res := rl.Resource().Attributes()
+		res.PutStr("service.name", st.service)
+		res.PutStr("env", st.env)
+
+		recs := rl.ScopeLogs().AppendEmpty().LogRecords()
+		recs.EnsureCapacity(goldenLogQLPerRound)
+		for i := range goldenLogQLPerRound {
+			lv := goldenLogQLLevels[i%len(goldenLogQLLevels)]
+			method := goldenLogQLMethods[i%len(goldenLogQLMethods)]
+			status := goldenLogQLStatuses[i%len(goldenLogQLStatuses)]
+			region := goldenLogQLRegions[i%len(goldenLogQLRegions)]
+
+			// The needle lives in exactly one part and one service, so the other parts are prunable.
+			note := "ok"
+			if round == goldenLogQLNeedleRound && st.service == "svc-0" && i%goldenLogQLNeedleEvery == 0 {
+				note = goldenLogQLNeedle
+			}
+
+			var body string
+			if st.logfmt {
+				body = fmt.Sprintf("level=%s method=%s status=%d client_ip=10.0.0.%d duration_ms=%d note=%q",
+					lv.text, method, status, i%256, i%97, note)
+			} else {
+				body = fmt.Sprintf(`{"level":%q,"method":%q,"status":%d,"client_ip":"10.0.0.%d","duration_ms":%d,"note":%q}`,
+					lv.text, method, status, i%256, i%97, note)
+			}
+
+			off := time.Duration(round*goldenLogQLPerRound+i) * goldenLogQLSpacing
+			r := recs.AppendEmpty()
+			r.SetTimestamp(pcommon.Timestamp(goldenLogQLStartTS + int64(off)))
+			r.SetSeverityNumber(lv.num)
+			r.SetSeverityText(lv.text)
+			r.Body().SetStr(body)
+			a := r.Attributes()
+			a.PutStr("http.method", method)
+			a.PutInt("http.status_code", status)
+			a.PutStr("region", region)
+
+			// body + attribute keys/values + timestamp/severity, matching the storage golden bench's
+			// accounting. http.status_code is an int64 ⇒ 8 bytes.
+			logical[st.service] += int64(len(body)) +
+				int64(len("http.method")+len(method)) +
+				int64(len("http.status_code")+8) +
+				int64(len("region")+len(region)) +
+				16
+		}
+	}
+	return ld
+}
+
+// goldenLogQLFixture builds the canonical corpus once: goldenLogQLParts rounds each flushed to its
+// own immutable part, plus one final round left in the head. Reads therefore merge many parts with a
+// live head — the shape a running store actually serves. No compaction is forced, so the cross-part
+// merge and per-part pruning stay in the measured path.
+func goldenLogQLFixture(b *testing.B) *goldenLogQLCorpus {
+	b.Helper()
+
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+
+	backend := storagebackend.New(store)
+	logical := make(map[string]int64)
+
+	for round := range goldenLogQLParts {
+		require.NoError(b, backend.ConsumeLogs(ctx, goldenLogQLRound(round, logical)))
+		require.NoError(b, store.Admin().Flush(ctx, "", signal.Log))
+	}
+	// One more round stays in the head.
+	require.NoError(b, backend.ConsumeLogs(ctx, goldenLogQLRound(goldenLogQLParts, logical)))
+
+	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
+		Optimizers: []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}},
+	})
+	require.NoError(b, err)
+
+	rounds := goldenLogQLParts + 1
+	start := time.Unix(0, goldenLogQLStartTS)
+	end := start.Add(time.Duration(rounds*goldenLogQLPerRound) * goldenLogQLSpacing)
+
+	return &goldenLogQLCorpus{engine: engine, start: start, end: end, logical: logical}
+}
+
+// logqlResultCount counts the samples/entries in a LogQL result, regardless of its shape. It is the
+// single number each case asserts on, so an accidentally-empty query fails loudly instead of
+// benchmarking nothing.
+func logqlResultCount(data lokiapi.QueryResponseData) int {
+	var n int
+	switch data.Type {
+	case lokiapi.StreamsResultQueryResponseData:
+		for _, s := range data.StreamsResult.Result {
+			n += len(s.Values)
+		}
+	case lokiapi.MatrixResultQueryResponseData:
+		for _, s := range data.MatrixResult.Result {
+			n += len(s.Values)
+		}
+	case lokiapi.VectorResultQueryResponseData:
+		n = len(data.VectorResult.Result)
+	case lokiapi.ScalarResultQueryResponseData:
+		n = 1
+	}
+	return n
+}
+
+// goldenLogQLCase is one sub-benchmark: a LogQL query, the eval shape it runs with, the logical
+// bytes it scans, and the exact result count it must produce.
+type goldenLogQLCase struct {
+	name string
+	// query is the LogQL expression.
+	query string
+	// step, when non-zero, makes this a range (metric) query.
+	step time.Duration
+	// limit bounds a log query's entry count (Grafana passes one); <=0 means unbounded.
+	limit int
+	// scans lists the services the selector reaches, for b.SetBytes. Empty ⇒ no throughput number.
+	scans []string
+	// want is the exact number of entries/samples the query must return.
+	want int
+}
+
+// BenchmarkGoldenLogQL is the definitive LogQL-over-storage read set. Sub-benchmarks:
+//
+//	select_service        — bare stream selector on one stream (postings pruning + part scan)
+//	select_multi_stream   — bare selector matching half the streams (wide scan, many streams merged)
+//	select_regexp         — regexp stream matcher (pushed to the postings index, not post-filtered)
+//	line_filter           — `|= "GET"` (offloaded to a storage body condition; one word ⇒ no bloom hint)
+//	line_filter_negated   — `!= "GET"` (negation is NOT offloaded: the engine filters after materializing)
+//	label_filter          — `| http_method="GET"` structured-metadata equality (offloaded per record)
+//	json_parser           — `| json | status>=400` (full body materialization + engine-side parse)
+//	logfmt_parser         — the same shape over the logfmt stream
+//	needle                — high-selectivity multi-word literal present in a single part (bloom pruning)
+//	limit_backward        — the Grafana shape: wide selector, backward, Limit 100
+//	metric_count_by_level — `sum by (level) (count_over_time(…[1m]))` (bucketed sampling pushdown)
+//	metric_rate_by_service— `sum by (service_name) (rate(…[1m]))` (grouping the pushdown can't honor)
+func BenchmarkGoldenLogQL(b *testing.B) {
+	corpus := goldenLogQLFixture(b)
+
+	// The prod half of the corpus: the wide-scan selector's stream set.
+	prod := []string{"svc-0", "svc-1", "svc-2", "svc-3", goldenLogQLLogfmtService}
+
+	for _, tc := range []goldenLogQLCase{
+		{
+			name:  "select_service",
+			query: `{service_name="svc-0"}`,
+			limit: 1000,
+			scans: []string{"svc-0"},
+			want:  1000,
+		},
+		{
+			name:  "select_multi_stream",
+			query: `{env="prod"}`,
+			limit: 1000,
+			scans: prod,
+			want:  1000,
+		},
+		{
+			name:  "select_regexp",
+			query: `{service_name=~"svc-[0-3]"}`,
+			limit: 1000,
+			scans: []string{"svc-0", "svc-1", "svc-2", "svc-3"},
+			want:  1000,
+		},
+		{
+			name:  "line_filter",
+			query: `{service_name="svc-0"} |= "\"method\":\"GET\""`,
+			limit: 1000,
+			scans: []string{"svc-0"},
+			want:  900,
+		},
+		{
+			name:  "line_filter_negated",
+			query: `{service_name="svc-0"} != "\"method\":\"GET\""`,
+			limit: 1000,
+			scans: []string{"svc-0"},
+			want:  1000,
+		},
+		{
+			name:  "label_filter",
+			query: `{service_name="svc-0"} | http_method="GET"`,
+			limit: 1000,
+			scans: []string{"svc-0"},
+			want:  900,
+		},
+		{
+			name:  "json_parser",
+			query: `{service_name="svc-0"} | json | status>=400`,
+			limit: 1000,
+			scans: []string{"svc-0"},
+			want:  1000,
+		},
+		{
+			name:  "logfmt_parser",
+			query: `{service_name="logfmt"} | logfmt | status>=400`,
+			limit: 1000,
+			scans: []string{goldenLogQLLogfmtService},
+			want:  1000,
+		},
+		{
+			name:  "needle",
+			query: `{env="prod"} |= "` + goldenLogQLNeedle + `"`,
+			limit: 1000,
+			scans: prod,
+			want:  4,
+		},
+		{
+			name:  "limit_backward",
+			query: `{env="prod"}`,
+			limit: 100,
+			scans: prod,
+			want:  100,
+		},
+		{
+			name:  "metric_count_by_level",
+			query: `sum by (level) (count_over_time({env="prod"}[1m]))`,
+			step:  30 * time.Second,
+			scans: prod,
+			want:  115,
+		},
+		{
+			name:  "metric_rate_by_service",
+			query: `sum by (service_name) (rate({env="prod"}[1m]))`,
+			step:  30 * time.Second,
+			scans: prod,
+			want:  100,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			goldenLogQLRun(b, corpus, tc)
+		})
+	}
+}
+
+// goldenLogQLRun evaluates one case: it parses+plans once (planning is not the storage signal),
+// checks the result count once outside the timed loop, then times repeated evaluations.
+func goldenLogQLRun(b *testing.B, corpus *goldenLogQLCorpus, tc goldenLogQLCase) {
+	b.Helper()
+
+	ctx := context.Background()
+	params := logqlengine.EvalParams{
+		Start:     corpus.start,
+		End:       corpus.end,
+		Direction: logqlengine.DirectionBackward,
+		Limit:     tc.limit,
+		Step:      tc.step,
+	}
+
+	q, err := corpus.engine.NewQuery(ctx, tc.query)
+	require.NoError(b, err)
+
+	data, err := q.Eval(ctx, params)
+	require.NoError(b, err)
+	require.Equal(b, tc.want, logqlResultCount(data), "query %q returned an unexpected result count", tc.query)
+
+	if n := corpus.bytesFor(tc.scans...); n > 0 {
+		b.SetBytes(n)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		if _, err := q.Eval(ctx, params); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/storagebackend/goldenbench_logql_test.go
+++ b/internal/storagebackend/goldenbench_logql_test.go
@@ -253,6 +253,7 @@ type goldenLogQLCase struct {
 
 // BenchmarkGoldenLogQL is the definitive LogQL-over-storage read set. Sub-benchmarks:
 //
+//	full_scan             — regex over every stream, unbounded: no pruning, everything materialized
 //	select_service        — bare stream selector on one stream (postings pruning + part scan)
 //	select_multi_stream   — bare selector matching half the streams (wide scan, many streams merged)
 //	select_regexp         — regexp stream matcher (pushed to the postings index, not post-filtered)
@@ -271,7 +272,23 @@ func BenchmarkGoldenLogQL(b *testing.B) {
 	// The prod half of the corpus: the wide-scan selector's stream set.
 	prod := []string{"svc-0", "svc-1", "svc-2", "svc-3", goldenLogQLLogfmtService}
 
+	// Every stream, derived from the same source the corpus is built from.
+	all := make([]string, 0, goldenLogQLServices+1)
+	for _, st := range goldenLogQLStreams() {
+		all = append(all, st.service)
+	}
+
 	for _, tc := range []goldenLogQLCase{
+		{
+			// The worst case, mirroring storage's own query/promql_full_scan_count: a regex over
+			// every stream prunes nothing in the postings index, and no limit bounds the result, so
+			// the whole window is fetched and materialized. It is the ceiling the other log cases
+			// are read against.
+			name:  "full_scan",
+			query: `{service_name=~".+"}`,
+			scans: all,
+			want:  (goldenLogQLServices + 1) * goldenLogQLPerRound * (goldenLogQLParts + 1),
+		},
 		{
 			name:  "select_service",
 			query: `{service_name="svc-0"}`,

--- a/internal/storagebackend/goldenbench_profileql_test.go
+++ b/internal/storagebackend/goldenbench_profileql_test.go
@@ -1,0 +1,484 @@
+package storagebackend_test
+
+// Golden benchmarks for the ProfileQL read path over the github.com/oteldb/storage engine.
+//
+// They mirror the contract of storage's own golden_bench_test.go: one fixed, deterministic corpus
+// (no RNG), stable sub-benchmark names (they are the CI baseline — treat them as an API), and
+// b.SetBytes on the LOGICAL (uncompressed) row footprint so MB/s is a real scan speed rather than a
+// function of the codec's compression ratio. Changing the corpus resets the historical baseline, so
+// only do it deliberately.
+//
+// The corpus is ingested in profileqlRounds rounds, each flushed to its own immutable part, so the
+// reads exercise the part-scan path (the head is empty) and the time-windowed select can prune
+// parts. Profiles are the only signal with a content-addressed symbol side store, so every
+// SelectMergeProfile sub-benchmark also pays symbol-store union + stack resolution — the
+// profiles-specific storage path; profile_resolver isolates that cost on its own.
+
+import (
+	"context"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/profileql"
+	"github.com/oteldb/oteldb/internal/profilestorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+const (
+	profileqlServices  = 4  // distinct service.name values
+	profileqlPods      = 8  // pods per service ⇒ 32 distinct pod values (the high-cardinality label)
+	profileqlRounds    = 4  // ingest rounds, each flushed to its own part
+	profileqlPerRound  = 64 // samples per stream per round
+	profileqlBranches  = 4  // handler frames per service
+	profileqlLeaves    = 4  // leaf frames per handler ⇒ 16 distinct stacks per service
+	profileqlSampleVal = 1 << 20
+
+	// profileqlSampleInterval is the spacing of consecutive samples of one stream; a round therefore
+	// spans profileqlPerRound*profileqlSampleInterval and each part covers a distinct time span.
+	profileqlSampleInterval = 10 * time.Second
+
+	// profileqlRowBytes is the logical (uncompressed) footprint of one sample row: timestamp, value,
+	// period and duration (4×8 B) plus the 16-byte stack id and the 16-byte profile id. b.SetBytes
+	// uses it so MB/s reflects the scanned logical volume, not the encoded part size.
+	profileqlRowBytes = 4*8 + 16 + 16
+
+	// profileqlRowsPerStream is the number of rows one stream contributes across all rounds, and
+	// profileqlRowsPerType the rows of one profile type across every stream.
+	profileqlRowsPerStream = profileqlRounds * profileqlPerRound
+	profileqlRowsPerType   = profileqlServices * profileqlPods * profileqlRowsPerStream
+)
+
+// profileqlEpoch is the fixed corpus start (2024-01-01T00:00:00Z). Absolute and constant so the
+// workload — and therefore the baseline — does not depend on when the benchmark runs.
+var profileqlEpoch = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// profileqlTypes are the two ingested profile types: a CPU-time profile and an allocation profile.
+var profileqlTypes = [2]profileql.ProfileType{
+	{Name: "cpu", SampleType: "cpu", SampleUnit: "nanoseconds", PeriodType: "cpu", PeriodUnit: "nanoseconds"},
+	{Name: "alloc_space", SampleType: "alloc_space", SampleUnit: "bytes", PeriodType: "space", PeriodUnit: "bytes"},
+}
+
+// profileqlCorpus is the shared read-only fixture: a flushed store plus the metadata the assertions
+// need (the exact stack shapes ingested, so expected flame-tree node counts are derived, not
+// hardcoded).
+type profileqlCorpus struct {
+	querier *storagebackend.ProfileQuerier
+	store   *storage.Storage
+
+	// stacks[service] are the root→leaf function-name paths that service emits, in ingest order.
+	stacks [][][]string
+	// start/end bound the whole corpus; lastRound starts the final round's part.
+	start, end, lastRound time.Time
+}
+
+// profileqlService returns the service.name of service index s.
+func profileqlService(s int) string { return "svc-" + strconv.Itoa(s) }
+
+// profileqlPod returns the globally unique pod name of pod p of service s.
+func profileqlPod(s, p int) string { return "pod-" + strconv.Itoa(s*profileqlPods+p) }
+
+// profileqlStacks builds the deterministic call-stack shapes of one service: profileqlBranches ×
+// profileqlLeaves root→leaf paths sharing a common prefix, so the symbol store dedups the prefix
+// frames and the flame-tree merge folds them into shared nodes.
+func profileqlStacks(s int) [][]string {
+	prefix := []string{
+		"main.main",
+		"svc." + profileqlService(s) + ".serve",
+		"net/http.serveHTTP",
+		"app.middleware",
+	}
+
+	out := make([][]string, 0, profileqlBranches*profileqlLeaves)
+	for b := range profileqlBranches {
+		for l := range profileqlLeaves {
+			path := make([]string, 0, len(prefix)+3)
+			path = append(path, prefix...)
+			path = append(path,
+				"app.handler"+strconv.Itoa(b),
+				"compute.step"+strconv.Itoa(l),
+				"runtime.mallocgc",
+			)
+			out = append(out, path)
+		}
+	}
+
+	return out
+}
+
+// profileqlBuilder accumulates the OTLP shared dictionary of one round's batch, interning strings
+// and materializing one location (with a single line) per function so a resolved frame maps
+// one-to-one onto a call-path element.
+type profileqlBuilder struct {
+	dict    pprofile.ProfilesDictionary
+	strings map[string]int32
+	funcs   map[string]int32
+	stacks  map[string]int32
+}
+
+func newProfileqlBuilder(dict pprofile.ProfilesDictionary) *profileqlBuilder {
+	b := &profileqlBuilder{
+		dict:    dict,
+		strings: map[string]int32{},
+		funcs:   map[string]int32{},
+		stacks:  map[string]int32{},
+	}
+	dict.StringTable().Append("")
+	b.strings[""] = 0
+
+	mp := dict.MappingTable().AppendEmpty()
+	mp.SetFilenameStrindex(b.str("/usr/bin/app"))
+
+	return b
+}
+
+// str interns s into the string table.
+func (b *profileqlBuilder) str(s string) int32 {
+	if idx, ok := b.strings[s]; ok {
+		return idx
+	}
+	idx := int32(b.dict.StringTable().Len())
+	b.dict.StringTable().Append(s)
+	b.strings[s] = idx
+	return idx
+}
+
+// location returns the location index of the named function, creating the function+location pair on
+// first use.
+func (b *profileqlBuilder) location(name string) int32 {
+	if idx, ok := b.funcs[name]; ok {
+		return idx
+	}
+
+	fn := b.dict.FunctionTable().AppendEmpty()
+	fn.SetNameStrindex(b.str(name))
+	fn.SetFilenameStrindex(b.str("app.go"))
+	fnIdx := int32(b.dict.FunctionTable().Len() - 1)
+
+	loc := b.dict.LocationTable().AppendEmpty()
+	loc.SetMappingIndex(0)
+	line := loc.Lines().AppendEmpty()
+	line.SetFunctionIndex(fnIdx)
+	line.SetLine(int64(fnIdx) * 10)
+
+	idx := int32(b.dict.LocationTable().Len() - 1)
+	b.funcs[name] = idx
+	return idx
+}
+
+// stack returns the stack-table index of a root→leaf path, storing it leaf-first as OTLP requires.
+func (b *profileqlBuilder) stack(path []string) int32 {
+	key := strings.Join(path, ";")
+	if idx, ok := b.stacks[key]; ok {
+		return idx
+	}
+
+	st := b.dict.StackTable().AppendEmpty()
+	for _, name := range slices.Backward(path) {
+		st.LocationIndices().Append(b.location(name))
+	}
+
+	idx := int32(b.dict.StackTable().Len() - 1)
+	b.stacks[key] = idx
+	return idx
+}
+
+// profileqlRound builds one round's OTLP batch: every (service, pod) resource emits both profile
+// types, each with profileqlPerRound samples cycling through that service's stacks. Timestamps of
+// round r fall in [epoch+r*span, epoch+(r+1)*span), so each flushed part covers a distinct span.
+func profileqlRound(round int, stacks [][][]string) pprofile.Profiles {
+	pd := pprofile.NewProfiles()
+	b := newProfileqlBuilder(pd.Dictionary())
+
+	// A small per-sample attribute set, so the (bloom-indexed) attrs column is populated.
+	threads := make([]int32, 4)
+	for i := range threads {
+		attr := b.dict.AttributeTable().AppendEmpty()
+		attr.SetKeyStrindex(b.str("thread.name"))
+		attr.Value().SetStr("worker-" + strconv.Itoa(i))
+		threads[i] = int32(b.dict.AttributeTable().Len() - 1)
+	}
+
+	roundStart := profileqlEpoch.Add(time.Duration(round) * profileqlPerRound * profileqlSampleInterval)
+
+	for s := range profileqlServices {
+		for p := range profileqlPods {
+			rp := pd.ResourceProfiles().AppendEmpty()
+			res := rp.Resource().Attributes()
+			res.PutStr("service.name", profileqlService(s))
+			res.PutStr("pod", profileqlPod(s, p))
+			res.PutStr("region", "region-"+strconv.Itoa(p%2))
+			scp := rp.ScopeProfiles().AppendEmpty()
+			scp.Scope().SetName("profiler")
+
+			for ti, typ := range profileqlTypes {
+				pr := scp.Profiles().AppendEmpty()
+				pr.SampleType().SetTypeStrindex(b.str(typ.SampleType))
+				pr.SampleType().SetUnitStrindex(b.str(typ.SampleUnit))
+				pr.PeriodType().SetTypeStrindex(b.str(typ.PeriodType))
+				pr.PeriodType().SetUnitStrindex(b.str(typ.PeriodUnit))
+				pr.SetPeriod(int64(10_000_000))
+				pr.SetDurationNano(uint64(profileqlPerRound) * uint64(profileqlSampleInterval))
+				pr.SetTime(pcommon.Timestamp(roundStart.UnixNano()))
+
+				var id [16]byte
+				id[0], id[1], id[2], id[3] = byte(round), byte(s), byte(p), byte(ti)
+				pr.SetProfileID(pprofile.ProfileID(id))
+
+				for i := range profileqlPerRound {
+					path := stacks[s][i%len(stacks[s])]
+					ts := roundStart.Add(time.Duration(i) * profileqlSampleInterval)
+
+					sm := pr.Samples().AppendEmpty()
+					sm.SetStackIndex(b.stack(path))
+					sm.Values().Append(profileqlSampleVal)
+					sm.TimestampsUnixNano().Append(uint64(ts.UnixNano()))
+					sm.AttributeIndices().Append(threads[i%len(threads)])
+				}
+			}
+		}
+	}
+
+	return pd
+}
+
+// profileqlFixture ingests the canonical corpus into a memory-backed store, flushing each round to
+// its own immutable part. The background maintenance loop is disabled so the layout (one part per
+// round) is deterministic and no flush races the timed loop.
+func profileqlFixture(b *testing.B) *profileqlCorpus {
+	b.Helper()
+
+	ctx := context.Background()
+	store, err := storage.Open(ctx, storage.Options{},
+		storage.WithBackend(backend.Memory()),
+		storage.WithFlushInterval(-1),
+	)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+
+	be := storagebackend.New(store)
+
+	stacks := make([][][]string, profileqlServices)
+	for s := range profileqlServices {
+		stacks[s] = profileqlStacks(s)
+	}
+
+	for round := range profileqlRounds {
+		require.NoError(b, be.ConsumeProfiles(ctx, profileqlRound(round, stacks)))
+		require.NoError(b, store.Admin().Flush(ctx, "", signal.Profile))
+	}
+
+	span := time.Duration(profileqlPerRound) * profileqlSampleInterval
+
+	return &profileqlCorpus{
+		querier:   be.Profiles(),
+		store:     store,
+		stacks:    stacks,
+		start:     profileqlEpoch,
+		end:       profileqlEpoch.Add(profileqlRounds*span + time.Second),
+		lastRound: profileqlEpoch.Add((profileqlRounds - 1) * span),
+	}
+}
+
+// profileqlExpectedNodes returns the number of flame-tree nodes the given services' stacks merge
+// into: every distinct root→leaf prefix, plus the synthetic root.
+func (c *profileqlCorpus) expectedNodes(services ...int) int {
+	seen := map[string]struct{}{}
+	for _, s := range services {
+		for _, path := range c.stacks[s] {
+			for i := range path {
+				seen[strings.Join(path[:i+1], ";")] = struct{}{}
+			}
+		}
+	}
+	return len(seen) + 1
+}
+
+// profileqlCountNodes counts the nodes of a flame tree.
+func profileqlCountNodes(n *profilestorage.FlameNode) int {
+	if n == nil {
+		return 0
+	}
+	total := 1
+	for _, c := range n.Children {
+		total += profileqlCountNodes(c)
+	}
+	return total
+}
+
+// profileqlSelect is one SelectMergeProfile sub-benchmark: it asserts the tree once (so a silently
+// empty result can never look fast), then times repeated evaluations at the logical scan rate.
+func profileqlSelect(
+	b *testing.B,
+	c *profileqlCorpus,
+	params profilestorage.SelectProfileParams,
+	wantRows, wantNodes int,
+) {
+	b.Helper()
+
+	ctx := context.Background()
+
+	tree, err := c.querier.SelectMergeProfile(ctx, params)
+	require.NoError(b, err)
+	require.Equal(b, int64(wantRows)*profileqlSampleVal, tree.Total())
+	require.Equal(b, wantNodes, profileqlCountNodes(tree.Root))
+
+	b.SetBytes(int64(wantRows) * profileqlRowBytes)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		if _, err := c.querier.SelectMergeProfile(ctx, params); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGoldenProfileQL is the definitive ProfileQL read set over the storage engine.
+//
+//	select_merge_profile/all_services  — the flame-tree merge over every cpu stream (heaviest path)
+//	select_merge_profile/single_pod    — the same, narrowed to one stream (postings selectivity)
+//	select_merge_profile/regex_service — a regex label matcher over half the services
+//	select_merge_profile/alloc_space   — the second profile type (type folded into stream identity)
+//	select_merge_profile/recent_window — the last round's window only (part/time pruning)
+//	profile_types                      — stream enumeration + reserved-label projection
+//	label_names                        — distinct user-label names across all streams
+//	label_values/pod                   — values of the high-cardinality label
+//	profile_resolver                   — symbol side-store snapshot + decode, isolated
+func BenchmarkGoldenProfileQL(b *testing.B) {
+	c := profileqlFixture(b)
+
+	cpu, alloc := profileqlTypes[0], profileqlTypes[1]
+
+	b.Run("select_merge_profile/all_services", func(b *testing.B) {
+		profileqlSelect(b, c, profilestorage.SelectProfileParams{
+			Type:  cpu,
+			Start: c.start,
+			End:   c.end,
+		}, profileqlRowsPerType, c.expectedNodes(0, 1, 2, 3))
+	})
+
+	b.Run("select_merge_profile/single_pod", func(b *testing.B) {
+		profileqlSelect(b, c, profilestorage.SelectProfileParams{
+			Type: cpu,
+			Matchers: []profileql.LabelMatcher{
+				{Label: "service.name", Op: profileql.OpEq, Value: profileqlService(0)},
+				{Label: "pod", Op: profileql.OpEq, Value: profileqlPod(0, 0)},
+			},
+			Start: c.start,
+			End:   c.end,
+		}, profileqlRowsPerStream, c.expectedNodes(0))
+	})
+
+	b.Run("select_merge_profile/regex_service", func(b *testing.B) {
+		profileqlSelect(b, c, profilestorage.SelectProfileParams{
+			Type: cpu,
+			Matchers: []profileql.LabelMatcher{{
+				Label: "service.name",
+				Op:    profileql.OpRe,
+				Value: "svc-0|svc-1",
+				Re:    regexp.MustCompile(`^(?:svc-0|svc-1)$`),
+			}},
+			Start: c.start,
+			End:   c.end,
+		}, 2*profileqlPods*profileqlRowsPerStream, c.expectedNodes(0, 1))
+	})
+
+	b.Run("select_merge_profile/alloc_space", func(b *testing.B) {
+		profileqlSelect(b, c, profilestorage.SelectProfileParams{
+			Type:  alloc,
+			Start: c.start,
+			End:   c.end,
+		}, profileqlRowsPerType, c.expectedNodes(0, 1, 2, 3))
+	})
+
+	b.Run("select_merge_profile/recent_window", func(b *testing.B) {
+		profileqlSelect(b, c, profilestorage.SelectProfileParams{
+			Type:  cpu,
+			Start: c.lastRound,
+			End:   c.end,
+		}, profileqlRowsPerType/profileqlRounds, c.expectedNodes(0, 1, 2, 3))
+	})
+
+	b.Run("profile_types", func(b *testing.B) {
+		ctx := context.Background()
+		opts := profilestorage.ProfileTypesOptions{Start: c.start, End: c.end}
+
+		types, err := c.querier.ProfileTypes(ctx, opts)
+		require.NoError(b, err)
+		require.Len(b, types, len(profileqlTypes))
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for range b.N {
+			if _, err := c.querier.ProfileTypes(ctx, opts); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("label_names", func(b *testing.B) {
+		ctx := context.Background()
+		opts := profilestorage.LabelNamesOptions{Start: c.start, End: c.end}
+
+		names, err := c.querier.LabelNames(ctx, opts)
+		require.NoError(b, err)
+		require.Equal(b, []string{"pod", "region", "service.name"}, names)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for range b.N {
+			if _, err := c.querier.LabelNames(ctx, opts); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("label_values/pod", func(b *testing.B) {
+		ctx := context.Background()
+		opts := profilestorage.LabelValuesOptions{Start: c.start, End: c.end}
+
+		values, err := c.querier.LabelValues(ctx, "pod", opts)
+		require.NoError(b, err)
+		require.Len(b, values, profileqlServices*profileqlPods)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for range b.N {
+			if _, err := c.querier.LabelValues(ctx, "pod", opts); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("profile_resolver", func(b *testing.B) {
+		ctx := context.Background()
+
+		r, err := c.store.ProfileResolver(ctx, "")
+		require.NoError(b, err)
+		require.NotNil(b, r)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for range b.N {
+			if _, err := c.store.ProfileResolver(ctx, ""); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/storagebackend/goldenbench_traceql_test.go
+++ b/internal/storagebackend/goldenbench_traceql_test.go
@@ -298,7 +298,54 @@ var traceqlCases = []traceqlCase{
 		query: `{resource.service.name = "frontend"} >> {resource.service.name = "cart"}`,
 		want:  traceqlTraces,
 	},
+	// The relational family. Every operand is spelled from traceqlShape rather than a literal, so a
+	// change to the corpus shape cannot silently turn one of these into an always-false query.
+	//
+	// rootName/rootServiceName are spanset-level intrinsics: the engine resolves the trace's root
+	// once per trace (engine.go picks the parentless span) and every span of that trace then compares
+	// against the same constant, so these are whole-corpus scans, not selectors.
+	{
+		name:  "root_name",
+		query: `{rootName = "` + traceqlRootName + `"}`,
+		want:  traceqlTraces,
+	},
+	{
+		name:  "root_service_name",
+		query: `{rootServiceName = "` + traceqlRootService + `"}`,
+		want:  traceqlTraces,
+	},
+	// The same both-sides-must-match constraint as `descendant` applies to `~` and `>`: the engine
+	// indexes a[0]/b[0] after checking only that *both* sides are empty, so a pair where one side
+	// misses on some trace panics. authorize and GET /cart are both direct children of the root, and
+	// checkout.process is the child of POST /checkout, in every single trace.
+	{
+		name:  "sibling",
+		query: `{name = "` + traceqlSiblingLeft + `"} ~ {name = "` + traceqlSiblingRight + `"}`,
+		want:  traceqlTraces,
+	},
+	{
+		name:  "child",
+		query: `{name = "` + traceqlChildParent + `"} > {name = "` + traceqlChildName + `"}`,
+		want:  traceqlTraces,
+	},
 }
+
+// The operands of the relational cases, taken from traceqlShape so they track the corpus.
+//
+// There is deliberately no `parent.<attr>` case: `parent.` scoped predicates parse (traceql.Attribute
+// carries a Parent bool) but traceqlengine cannot build them — buildAttributeEvaluater's default
+// branch does `if attr.Parent { break }` on a TODO, so the query fails with
+// `unsupported attribute "parent.span.…"` before it ever reaches a span.
+var (
+	traceqlRootName    = traceqlShape[0].name // the parentless span's name
+	traceqlRootService = traceqlShape[0].service
+	// Two direct children of the root, hence siblings in every trace.
+	traceqlSiblingLeft  = traceqlShape[1].name
+	traceqlSiblingRight = traceqlShape[2].name
+	// A parent/child pair present in every trace.
+	traceqlChildParent = traceqlShape[4].name
+	traceqlChildName   = traceqlShape[5].name
+)
 
 // traceqlPushdownCase describes one storage-level sub-benchmark: the same predicate lowered to a
 // [fetch.Condition] instead of being applied by the TraceQL engine after materialization.
@@ -416,6 +463,14 @@ func traceqlFetchRows(b *testing.B, f *traceqlFixture, conds []fetch.Condition) 
 //	duration_gt      — a numeric comparison outside the int memo's domain
 //	attr_and_status  — a selective attribute filter ANDed with a status filter
 //	descendant       — the structural walk (frontend root >> payments descendant)
+//
+// The relational family, all engine-side (SelectSpansets pushes nothing down):
+//
+//	root_name         — the rootName intrinsic: a per-trace constant resolved from the parentless span
+//	root_service_name — the rootServiceName intrinsic, resolved from that span's resource
+//	sibling           — the `~` operator over two direct children of the root
+//	child             — the `>` operator over a parent/child pair present in every trace
+//
 //	pushdown/…       — the same predicates lowered to the storage fetch contract
 func BenchmarkGoldenTraceQL(b *testing.B) {
 	f := traceqlNewFixture(b)

--- a/internal/storagebackend/goldenbench_traceql_test.go
+++ b/internal/storagebackend/goldenbench_traceql_test.go
@@ -1,0 +1,500 @@
+package storagebackend_test
+
+// Golden TraceQL benchmarks — the stable set used to detect github.com/oteldb/storage performance
+// regressions from the embedder's side. They are deliberately:
+//
+//   - Deterministic: one fixed synthetic trace corpus (no RNG), built once and reused read-only, so
+//     run-to-run variance is the machine, not the data.
+//   - Flushed: the corpus is flushed and compacted into an immutable part before any query runs, so
+//     the benchmarks exercise the part-scan path (decode + filter), not the in-memory head.
+//   - Comparable: b.SetBytes carries the LOGICAL (uncompressed) footprint of the spans a query must
+//     scan, so MB/s is a real scan speed rather than a function of the codec's ratio.
+//
+// Keep the sub-benchmark names stable — they are the CI baseline, i.e. an API. Changing the corpus
+// resets the historical baseline, so only do it deliberately.
+//
+// Two families live here:
+//
+//   - The unprefixed cases run the real TraceQL engine end-to-end (parse → SelectSpansets → filter →
+//     tempoapi result). Note that [storagebackend.TraceQuerier.SelectSpansets] does not push its
+//     matchers into storage: every one of them is a full window scan plus a full span
+//     materialization, and TraceQL filters afterwards in memory.
+//   - The pushdown/… cases lower the same predicates to the storage fetch contract directly. They
+//     are what the TraceQL path *would* cost with push-down, and they are the cases that isolate the
+//     record engine's condition memoization (per-distinct-value for narrow int columns such as kind
+//     and status_code, per-dictionary-entry for byte and attribute columns).
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+const (
+	// traceqlTraces is the number of traces in the golden corpus.
+	traceqlTraces = 500
+	// traceqlSpansPerTrace is the fixed span-tree size of every trace.
+	traceqlSpansPerTrace = 8
+	// traceqlRoutes is the http.route cardinality; a route filter selects traceqlTraces/traceqlRoutes
+	// traces, i.e. a high-selectivity attribute lookup.
+	traceqlRoutes = 64
+	// traceqlErrorEvery makes every Nth trace fail, so `status = error` selects 1/N of the corpus.
+	traceqlErrorEvery = 10
+	// traceqlLimit is deliberately >= traceqlTraces: SelectSpansets truncates to Limit *before* the
+	// engine filters, so a smaller limit would make the selective cases assert on an arbitrary prefix.
+	traceqlLimit = traceqlTraces
+	// traceqlSelectedRoute is the route the attribute-filter case selects.
+	traceqlSelectedRoute = "/route/7"
+	// traceqlRouteTraces is how many traces carry traceqlSelectedRoute (i%64 == 7 over 500 traces).
+	traceqlRouteTraces = 8
+	// traceqlComboRoute is the route used by the combined attribute+status case: it is the only
+	// route that co-occurs with a failing trace (i%64 == 0 && i%10 == 0 ⇒ i ∈ {0, 320}).
+	traceqlComboRoute = "/route/0"
+	// traceqlComboSpans is the surviving span count of that combination: 2 traces × 2 failing spans.
+	traceqlComboSpans = 4
+)
+
+// traceqlTenant is the tenant every ingested batch routes to (storagebackend.New has no tenant
+// callback).
+const traceqlTenant signal.TenantID = "default"
+
+// traceqlStart is the fixed wall-clock origin of the corpus. A constant (not time.Now) keeps the
+// encoded timestamps — and therefore the part layout — identical between runs.
+var traceqlStart = time.Unix(1_600_000_000, 0).UTC()
+
+// traceqlMethods is the http.request.method cycle; a method varies per (trace, span) so a method
+// filter is neither trivially true nor trivially false per trace.
+var traceqlMethods = [...]string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"}
+
+// traceqlSpanSpec is one node of the fixed span tree shared by every trace.
+type traceqlSpanSpec struct {
+	service string
+	name    string
+	kind    ptrace.SpanKind
+	parent  int // index into traceqlShape, -1 for the root
+	durMs   int
+	fails   bool // carries StatusCodeError on a failing trace
+}
+
+// traceqlShape is the canonical trace: a frontend root fanning out to cart and checkout, with
+// checkout calling payments — four services, a spread of kinds, and a two-level descendant chain so
+// the structural operator has something to walk. The root's duration is far above every child's, so
+// a duration comparison isolates roots.
+var traceqlShape = [traceqlSpansPerTrace]traceqlSpanSpec{
+	{service: "frontend", name: "GET /api/checkout", kind: ptrace.SpanKindServer, parent: -1, durMs: 200},
+	{service: "frontend", name: "authorize", kind: ptrace.SpanKindInternal, parent: 0, durMs: 5},
+	{service: "cart", name: "GET /cart", kind: ptrace.SpanKindClient, parent: 0, durMs: 20},
+	{service: "cart", name: "cart.load", kind: ptrace.SpanKindServer, parent: 2, durMs: 15},
+	{service: "checkout", name: "POST /checkout", kind: ptrace.SpanKindClient, parent: 0, durMs: 60},
+	{service: "checkout", name: "checkout.process", kind: ptrace.SpanKindServer, parent: 4, durMs: 55},
+	{service: "payments", name: "POST /pay", kind: ptrace.SpanKindClient, parent: 5, durMs: 40, fails: true},
+	{service: "payments", name: "payments.charge", kind: ptrace.SpanKindServer, parent: 6, durMs: 35, fails: true},
+}
+
+// traceqlServices lists the corpus' resources in a stable order; each becomes one storage stream.
+var traceqlServices = [...]string{"frontend", "cart", "checkout", "payments"}
+
+// traceqlTraceID derives trace i's id: a fixed prefix plus the big-endian index, so ids are distinct,
+// non-zero and reproducible.
+func traceqlTraceID(i int) pcommon.TraceID {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[:8], 0x0705_0300_0000_0000)
+	binary.BigEndian.PutUint64(id[8:], uint64(i)+1)
+
+	return pcommon.TraceID(id)
+}
+
+// traceqlSpanID derives the id of span j of trace i.
+func traceqlSpanID(i, j int) pcommon.SpanID {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i)<<8|uint64(j)+1)
+
+	return pcommon.SpanID(id)
+}
+
+// traceqlCorpus builds the canonical trace set and returns it with its logical (uncompressed)
+// footprint: the bytes a full scan must decode per span — ids, timestamps, the narrow int columns,
+// the name, and the attribute key/value payload. Fully deterministic (no RNG).
+func traceqlCorpus() (td ptrace.Traces, logical int64) {
+	td = ptrace.NewTraces()
+
+	spans := make(map[string]ptrace.SpanSlice, len(traceqlServices))
+	for _, svc := range traceqlServices {
+		rs := td.ResourceSpans().AppendEmpty()
+		attrs := rs.Resource().Attributes()
+		attrs.PutStr("service.name", svc)
+		attrs.PutStr("deployment.environment", "production")
+		attrs.PutStr("host.name", "host-"+svc)
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("oteldb/goldenbench")
+		ss.Scope().SetVersion("v1")
+		spans[svc] = ss.Spans()
+	}
+
+	for i := range traceqlTraces {
+		var (
+			traceID = traceqlTraceID(i)
+			base    = traceqlStart.Add(time.Duration(i) * time.Millisecond)
+			route   = "/route/" + strconv.Itoa(i%traceqlRoutes)
+			failing = i%traceqlErrorEvery == 0
+		)
+
+		for j, spec := range &traceqlShape {
+			s := spans[spec.service].AppendEmpty()
+			s.SetTraceID(traceID)
+			s.SetSpanID(traceqlSpanID(i, j))
+			if spec.parent >= 0 {
+				s.SetParentSpanID(traceqlSpanID(i, spec.parent))
+			}
+			s.SetName(spec.name)
+			s.SetKind(spec.kind)
+
+			start := base.Add(time.Duration(j) * time.Millisecond)
+			// The i%17 jitter is deterministic but keeps durations from being a single repeated value.
+			dur := time.Duration(spec.durMs)*time.Millisecond + time.Duration(i%17)*time.Millisecond
+			s.SetStartTimestamp(pcommon.Timestamp(start.UnixNano()))
+			s.SetEndTimestamp(pcommon.Timestamp(start.Add(dur).UnixNano()))
+
+			status := int64(200)
+			if failing && spec.fails {
+				s.Status().SetCode(ptrace.StatusCodeError)
+				s.Status().SetMessage("payment declined by upstream")
+				status = 500
+			}
+
+			method := traceqlMethods[(i+j)%len(traceqlMethods)]
+			a := s.Attributes()
+			a.PutStr("http.request.method", method)
+			a.PutInt("http.response.status_code", status)
+			a.PutStr("http.route", route)
+
+			// 16 (trace id) + 8 (span id) + 8 (parent) + 8 (ts) + 8 (duration) + 8 (kind) + 8 (status).
+			logical += 64
+			logical += int64(len(spec.name) + len(method) + len(route) + 8)
+			logical += int64(len("http.request.method") + len("http.response.status_code") + len("http.route"))
+		}
+	}
+
+	return td, logical
+}
+
+// traceqlFixture is the shared, read-only benchmark fixture: a flushed+compacted store, the oteldb
+// backend over it, a TraceQL engine, and the corpus' bounds.
+type traceqlFixture struct {
+	store   *storage.Storage
+	backend *storagebackend.Backend
+	querier *storagebackend.TraceQuerier
+	engine  *traceqlengine.Engine
+
+	logical    int64 // uncompressed bytes of the whole corpus
+	perTrace   int64 // uncompressed bytes of one trace
+	start, end time.Time
+}
+
+// traceqlNewFixture ingests the canonical corpus into a memory-backed store and flushes + compacts
+// it, so every query below reads immutable parts rather than the head.
+func traceqlNewFixture(b *testing.B) *traceqlFixture {
+	b.Helper()
+
+	ctx := context.Background()
+
+	store, err := storage.Open(ctx, storage.Options{}, storage.WithBackend(backend.Memory()))
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = store.Close(ctx) })
+
+	be := storagebackend.New(store)
+
+	td, logical := traceqlCorpus()
+	require.NoError(b, be.ConsumeTraces(ctx, td))
+
+	admin := store.Admin()
+	require.NoError(b, admin.Flush(ctx, traceqlTenant, signal.Trace))
+	require.NoError(b, admin.Compact(ctx, traceqlTenant, signal.Trace))
+
+	querier := be.Traces()
+
+	return &traceqlFixture{
+		store:    store,
+		backend:  be,
+		querier:  querier,
+		engine:   traceqlengine.NewEngine(querier, traceqlengine.Options{}),
+		logical:  logical,
+		perTrace: logical / traceqlTraces,
+		// Widen the window past the corpus: the engine drops any trace not fully inside it.
+		start: traceqlStart.Add(-time.Minute),
+		end:   traceqlStart.Add(time.Duration(traceqlTraces+traceqlSpansPerTrace)*time.Millisecond + time.Minute),
+	}
+}
+
+// traceqlEvalParams is the fixed evaluation window shared by every TraceQL case.
+func (f *traceqlFixture) evalParams() traceqlengine.EvalParams {
+	return traceqlengine.EvalParams{Start: f.start, End: f.end, Limit: traceqlLimit}
+}
+
+// traceqlEval runs one TraceQL query and returns the number of matched traces.
+func traceqlEval(b *testing.B, f *traceqlFixture, query string) int {
+	b.Helper()
+
+	res, err := f.engine.Eval(context.Background(), query, f.evalParams())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return len(res.Traces)
+}
+
+// traceqlCase describes one end-to-end TraceQL sub-benchmark.
+type traceqlCase struct {
+	name  string
+	query string
+	// want is the exact number of traces the query must return. Asserting the count (not just
+	// non-emptiness) keeps a silently-degenerate query from ever looking fast.
+	want int
+}
+
+// traceqlCases is the golden query set. Every case is a distinct storage-relevant predicate shape:
+// intrinsics over the narrow int columns (kind, status), the byte columns (name), the serialized
+// attribute blob, a numeric comparison, a structural walk, and the unfiltered scan as the ceiling.
+var traceqlCases = []traceqlCase{
+	{name: "scan_all", query: `{}`, want: traceqlTraces},
+	{name: "by_service", query: `{resource.service.name = "payments"}`, want: traceqlTraces},
+	{name: "by_name", query: `{name = "checkout.process"}`, want: traceqlTraces},
+	{name: "attr_route", query: `{span.http.route = "` + traceqlSelectedRoute + `"}`, want: traceqlRouteTraces},
+	{name: "attr_status_code", query: `{span.http.response.status_code = 500}`, want: traceqlTraces / traceqlErrorEvery},
+	{name: "status_error", query: `{status = error}`, want: traceqlTraces / traceqlErrorEvery},
+	{name: "kind_server", query: `{kind = server}`, want: traceqlTraces},
+	{name: "duration_gt", query: `{duration > 150ms}`, want: traceqlTraces},
+	{
+		name:  "attr_and_status",
+		query: `{span.http.response.status_code = 500 && status = error}`,
+		want:  traceqlTraces / traceqlErrorEvery,
+	},
+	// Two constraints shape this one. Both sides must match in *every* trace, because the engine's
+	// descendant operator indexes a[0]/b[0] unconditionally and panics on a trace where only one
+	// side matches — so a `>> {status = error}` shape would crash on the 90% of traces that do not
+	// fail. And the ancestor walk only knows the parent links of the spans in left ∪ right, so the
+	// chain must not pass through a span neither side selected; cart hangs directly off the
+	// frontend root, payments does not.
+	{
+		name:  "descendant",
+		query: `{resource.service.name = "frontend"} >> {resource.service.name = "cart"}`,
+		want:  traceqlTraces,
+	},
+}
+
+// traceqlPushdownCase describes one storage-level sub-benchmark: the same predicate lowered to a
+// [fetch.Condition] instead of being applied by the TraceQL engine after materialization.
+type traceqlPushdownCase struct {
+	name string
+	// conds builds the request's conditions.
+	conds func() []fetch.Condition
+	// want is the exact number of surviving spans.
+	want int
+}
+
+// traceqlPushdownCases isolate the record engine's condition evaluation. status_code and kind are
+// narrow int columns (per-distinct-value memo); name is a dictionary byte column and route/method
+// are attribute lookups inside the serialized attrs blob (per-dictionary-entry memo).
+var traceqlPushdownCases = []traceqlPushdownCase{
+	{
+		name:  "status_code",
+		conds: func() []fetch.Condition { return []fetch.Condition{traceqlIntEq(sigtrace.ColStatusCode, 2)} },
+		// Both payments spans of every failing trace.
+		want: traceqlTraces / traceqlErrorEvery * 2,
+	},
+	{
+		name: "kind",
+		conds: func() []fetch.Condition {
+			return []fetch.Condition{traceqlIntEq(sigtrace.ColKind, int64(ptrace.SpanKindServer))}
+		},
+		want: traceqlTraces * 4, // four server spans per trace
+	},
+	{
+		name:  "name",
+		conds: func() []fetch.Condition { return []fetch.Condition{traceqlStrEq(sigtrace.ColName, "checkout.process")} },
+		want:  traceqlTraces,
+	},
+	{
+		name:  "attr_route",
+		conds: func() []fetch.Condition { return []fetch.Condition{traceqlStrEq("http.route", traceqlSelectedRoute)} },
+		want:  traceqlRouteTraces * traceqlSpansPerTrace,
+	},
+	{
+		name: "attr_status_code",
+		conds: func() []fetch.Condition {
+			return []fetch.Condition{traceqlIntEq("http.response.status_code", 500)}
+		},
+		want: traceqlTraces / traceqlErrorEvery * 2,
+	},
+	{
+		name: "attr_and_status",
+		conds: func() []fetch.Condition {
+			return []fetch.Condition{
+				traceqlStrEq("http.route", traceqlComboRoute),
+				traceqlIntEq(sigtrace.ColStatusCode, 2),
+			}
+		},
+		want: traceqlComboSpans,
+	},
+}
+
+// traceqlIntEq builds an exact integer condition over a column (or attribute key).
+func traceqlIntEq(column string, want int64) fetch.Condition {
+	return fetch.Condition{
+		Column: column,
+		Match:  func(v signal.Value) bool { return v.Kind() == signal.KindInt && v.Int() == want },
+	}
+}
+
+// traceqlStrEq builds an exact string condition over a column (or attribute key).
+func traceqlStrEq(column, want string) fetch.Condition {
+	return fetch.Condition{
+		Column: column,
+		Match:  func(v signal.Value) bool { return v.Kind() == signal.KindStr && string(v.Str()) == want },
+	}
+}
+
+// traceqlFetchRows runs one filtered fetch over the whole corpus window and returns the surviving
+// row count.
+func traceqlFetchRows(b *testing.B, f *traceqlFixture, conds []fetch.Condition) int {
+	b.Helper()
+
+	ctx := context.Background()
+	it, err := f.store.TraceFetcher(traceqlTenant).Fetch(ctx, fetch.Request{
+		Tenant:        traceqlTenant,
+		Signal:        signal.Trace,
+		Start:         f.start.UnixNano(),
+		End:           f.end.UnixNano(),
+		Conditions:    conds,
+		AllConditions: true,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	batches, err := fetch.Drain(ctx, it)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	rows := 0
+	for _, batch := range batches {
+		rows += len(batch.Timestamps)
+	}
+
+	return rows
+}
+
+// BenchmarkGoldenTraceQL is the definitive TraceQL-over-storage set.
+//
+//	by_trace_id      — the high-selectivity trace-by-id lookup (equality bloom + SIMD equality scan)
+//	scan_all         — the unfiltered window scan: the ceiling every other case is measured against
+//	by_service       — a resource-identity selector (one stream out of four)
+//	by_name          — an intrinsic over the dictionary-encoded name column
+//	attr_route       — a high-selectivity span-attribute lookup
+//	attr_status_code — an int span-attribute lookup
+//	status_error     — the status intrinsic (narrow int column)
+//	kind_server      — the kind intrinsic (narrow int column)
+//	duration_gt      — a numeric comparison outside the int memo's domain
+//	attr_and_status  — a selective attribute filter ANDed with a status filter
+//	descendant       — the structural walk (frontend root >> payments descendant)
+//	pushdown/…       — the same predicates lowered to the storage fetch contract
+func BenchmarkGoldenTraceQL(b *testing.B) {
+	f := traceqlNewFixture(b)
+
+	b.Run("by_trace_id", func(b *testing.B) { benchTraceQLByTraceID(b, f) })
+
+	for _, tc := range traceqlCases {
+		b.Run(tc.name, func(b *testing.B) {
+			if got := traceqlEval(b, f, tc.query); got != tc.want {
+				b.Fatalf("%s matched %d traces, want %d", tc.query, got, tc.want)
+			}
+
+			b.SetBytes(f.logical)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				traceqlEval(b, f, tc.query)
+			}
+		})
+	}
+
+	for _, tc := range traceqlPushdownCases {
+		b.Run("pushdown/"+tc.name, func(b *testing.B) {
+			conds := tc.conds()
+			if got := traceqlFetchRows(b, f, conds); got != tc.want {
+				b.Fatalf("pushdown/%s matched %d spans, want %d", tc.name, got, tc.want)
+			}
+
+			b.SetBytes(f.logical)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				traceqlFetchRows(b, f, conds)
+			}
+		})
+	}
+}
+
+// benchTraceQLByTraceID measures the trace-by-id lookup: a single equality condition on the trace_id
+// column, pruned by its per-part equality bloom. It is the one trace read path that storage filters
+// itself, so it is the most direct signal for the equality fast path.
+func benchTraceQLByTraceID(b *testing.B, f *traceqlFixture) {
+	ctx := context.Background()
+	id := otelstorage.TraceID(traceqlTraceID(traceqlTraces / 2))
+
+	lookup := func() int {
+		it, err := f.querier.TraceByID(ctx, id, tracestorage.TraceByIDOptions{Start: f.start, End: f.end})
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		var (
+			span tracestorage.Span
+			n    int
+		)
+		for it.Next(&span) {
+			n++
+		}
+		if err := it.Err(); err != nil {
+			b.Fatal(err)
+		}
+		if err := it.Close(); err != nil {
+			b.Fatal(err)
+		}
+
+		return n
+	}
+
+	if got := lookup(); got != traceqlSpansPerTrace {
+		b.Fatalf("trace by id returned %d spans, want %d", got, traceqlSpansPerTrace)
+	}
+
+	b.SetBytes(f.perTrace)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		lookup()
+	}
+}


### PR DESCRIPTION
Deterministic, fixed-workload benchmarks driving each query engine over a `github.com/oteldb/storage` backend, in the shape of storage's own golden set.

They exist so storage can gate its PRs on the read path its real consumers use — a companion workflow there (oteldb/storage#199) checks this repo out, points it at the PR's storage via a `go.work`, and runs `^BenchmarkGolden` against both the PR head and its base commit.

## Contract

Same as storage's `golden_bench_test.go`, and worth preserving:

- **Deterministic** — no RNG, no wall clock; fixed epochs.
- **Flushed to real parts**, so reads exercise the part scan and bloom pruning rather than the head.
- **`b.SetBytes` on the logical uncompressed size**, so MB/s is a real scan speed.
- **Every case asserts an exact result count** outside the timed loop — a silently-empty query can never look fast.
- **Stable sub-names.** These are the CI baseline; renaming one resets its history.

## Measured (`-benchtime=10x`, Ryzen 9 5950X)

```
GoldenLogQL/select_service            12.9 ms    70.83 MB/s   111075 allocs/op
GoldenLogQL/line_filter                3.6 ms   257.31 MB/s    20264 allocs/op
GoldenLogQL/line_filter_negated       13.3 ms    68.75 MB/s   111047 allocs/op
GoldenLogQL/needle                     0.5 ms  9259.68 MB/s      516 allocs/op
GoldenLogQL/limit_backward            46.7 ms    95.73 MB/s   542673 allocs/op
GoldenLogQL/metric_count_by_level      4.1 ms  1098.35 MB/s    29431 allocs/op
GoldenLogQL/metric_rate_by_service    64.2 ms    69.67 MB/s   654595 allocs/op

GoldenTraceQL/scan_all                 7.8 ms    77.17 MB/s    73261 allocs/op
GoldenTraceQL/status_error             6.0 ms    99.87 MB/s    63765 allocs/op
GoldenTraceQL/by_trace_id              0.6 ms     1.87 MB/s      628 allocs/op
GoldenTraceQL/pushdown/status_code     0.6 ms   932.52 MB/s      401 allocs/op
GoldenTraceQL/pushdown/attr_and_status 0.7 ms   844.72 MB/s      362 allocs/op

GoldenProfileQL/select_merge/all       9.8 ms    53.31 MB/s   157421 allocs/op
GoldenProfileQL/select_merge/single_pod 0.8 ms   19.92 MB/s     6035 allocs/op
GoldenProfileQL/profile_resolver      97.5 µs                     755 allocs/op
```

## What they surfaced

These are observations, not fixes — none are addressed here.

**TraceQL pushes nothing into storage.** `TraceQuerier.SelectSpansets` ignores `params.Matchers` and issues a bare `fetch.Request{Start, End}` — no `Conditions`, no `Projection`, no `Limit`. Every TraceQL query is a full window scan that materializes all columns including attributes/events/links, which is why all ten cases land within ~30% of each other regardless of selectivity, and why they cost ~11× the time and ~160× the allocations of the equivalent pushed-down fetch. The `pushdown/*` family exists because of this: it goes through `TraceFetcher` with real `fetch.Condition`s and is the only part of the trace set that exercises storage's scan.

**Negated line filters aren't pushed down.** `|= "…"` is 3.6 ms / 20k allocs; `!= "…"` over the same stream is 13.3 ms / 111k allocs — identical to a bare full scan.

**Bloom hinting silently needs ≥3 words.** The optimizer only emits token hints for interior tokens, so a one- or two-word literal prunes nothing; the 27× `needle` win disappears with no indication why.

**`Limit` isn't pushed down.** `limit_backward` with Limit 100 costs the same as unbounded — the pipeline materializes the whole window, sorts, then truncates. The common Grafana shape, and the single largest allocation source in the set.

**The bucketed-sampling pushdown is gated to level labels.** `sum by (level) (count_over_time(…))` is 4.1 ms; `sum by (service_name) (rate(…))` is 64 ms — worse than a plain selector scan on the same data.

Filed separately: the `>>`/`>`/`~` spanset panic on partial matches, `SelectSpansets` applying `Limit` before filtering, and `descendantSpans` not using storage's `nested_set_left/right` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)