### PR TITLE
fix(storagebackend): apply TraceQL limit after matching, not in scan order

### DIFF
--- a/internal/storagebackend/goldenbench_traceql_test.go
+++ b/internal/storagebackend/goldenbench_traceql_test.go
@@ -57,8 +57,8 @@ const (
 	traceqlRoutes = 64
 	// traceqlErrorEvery makes every Nth trace fail, so `status = error` selects 1/N of the corpus.
 	traceqlErrorEvery = 10
-	// traceqlLimit is deliberately >= traceqlTraces: SelectSpansets truncates to Limit *before* the
-	// engine filters, so a smaller limit would make the selective cases assert on an arbitrary prefix.
+	// traceqlLimit is deliberately >= traceqlTraces, so no case is ever cut short by the engine's
+	// post-filter limit and every want below is a true match count.
 	traceqlLimit = traceqlTraces
 	// traceqlSelectedRoute is the route the attribute-filter case selects.
 	traceqlSelectedRoute = "/route/7"
@@ -211,7 +211,7 @@ type traceqlFixture struct {
 
 // traceqlNewFixture ingests the canonical corpus into a memory-backed store and flushes + compacts
 // it, so every query below reads immutable parts rather than the head.
-func traceqlNewFixture(b *testing.B) *traceqlFixture {
+func traceqlNewFixture(b testing.TB) *traceqlFixture {
 	b.Helper()
 
 	ctx := context.Background()

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -26,6 +26,11 @@ var (
 // SelectSpansets implements [traceqlengine.Querier]. It returns every trace whose spans fall in the
 // window, grouped by trace id; the TraceQL engine evaluates the spanset matchers on the result
 // (mirroring the in-memory reference querier).
+//
+// params.Limit is deliberately not applied here: it counts *matching* traces, and nothing has been
+// matched yet. Truncating the candidate set in scan order would cap the result at "however many of
+// the first N scanned traces happen to match", which for a selective query is usually fewer than N
+// and often zero. The engine applies the limit once the matchers have run.
 func (q *TraceQuerier) SelectSpansets(ctx context.Context, params traceqlengine.SelectSpansetsParams) (iterators.Iterator[traceqlengine.Trace], error) {
 	spans, err := q.scanSpans(ctx, params.Start, params.End)
 	if err != nil {
@@ -43,9 +48,6 @@ func (q *TraceQuerier) SelectSpansets(ctx context.Context, params traceqlengine.
 
 	traces := make([]traceqlengine.Trace, 0, len(order))
 	for _, id := range order {
-		if params.Limit > 0 && len(traces) >= params.Limit {
-			break
-		}
 		traces = append(traces, traceqlengine.Trace{TraceID: id, Spans: byTrace[id]})
 	}
 	return iterators.Slice(traces), nil

--- a/internal/storagebackend/traces_limit_test.go
+++ b/internal/storagebackend/traces_limit_test.go
@@ -1,0 +1,44 @@
+package storagebackend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTraceQLLimitCountsMatches pins the meaning of EvalParams.Limit: it caps the number of traces
+// that *matched* the query, not the number of traces the storage layer looked at.
+//
+// The regression it guards is a limit applied in scan order inside SelectSpansets, before any
+// matcher ran. The selective query below matches 8 of 500 traces, spread across the corpus, so a
+// pre-filter truncation to 20 returned zero or one trace instead of all 8.
+func TestTraceQLLimitCountsMatches(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx   = context.Background()
+		f     = traceqlNewFixture(t)
+		query = `{span.http.route = "` + traceqlSelectedRoute + `"}`
+	)
+
+	eval := func(limit int) int {
+		params := f.evalParams()
+		params.Limit = limit
+
+		res, err := f.engine.Eval(ctx, query, params)
+		require.NoError(t, err)
+
+		return len(res.Traces)
+	}
+
+	// A limit above the match count returns every match, however deep into the scan they sit.
+	for _, limit := range []int{traceqlRouteTraces, traceqlRouteTraces + 1, 20, traceqlTraces} {
+		require.Equalf(t, traceqlRouteTraces, eval(limit), "limit %d", limit)
+	}
+
+	// Below it, the limit still truncates — but to that many matches.
+	for _, limit := range []int{1, 3, traceqlRouteTraces - 1} {
+		require.Equalf(t, limit, eval(limit), "limit %d", limit)
+	}
+}


### PR DESCRIPTION
Fixes #1172.

`TraceQuerier.SelectSpansets` truncated the trace set to `params.Limit` in scan order, before the
TraceQL engine had evaluated any matcher. `Limit = 20` therefore meant "however many of the first 20
scanned traces happen to match" — for a selective query usually far fewer, often zero — and the
result depended on scan order rather than on the query.

The limit is now left to the engine, which already applies it after the matchers run
(`engine.go` breaks out once `len(result) >= limit`). `SelectSpansets` returns a fully materialized
slice, so nothing was being saved by cutting early.

`TestTraceQLLimitCountsMatches` covers it over the golden corpus: `{span.http.route = "/route/7"}`
matches 8 of 500 traces, and before the fix a limit of 8 or 20 returned 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)