### PR TITLE
perf(logql): push the limit into storage when no stage can drop an entry

### DIFF
--- a/internal/logql/logqlengine/engine_log_query.go
+++ b/internal/logql/logqlengine/engine_log_query.go
@@ -187,9 +187,15 @@ func (n *ProcessorNode) EvalPipeline(ctx context.Context, params EvalParams) (_ 
 		return nil, errors.Wrap(err, "build pipeline")
 	}
 
-	// Do not limit storage query.
+	// Limit the storage query only when nothing below can drop an entry: then the storage top-N and
+	// the final top-N agree. A stage that may drop (a filter) or a non-nop prefilter breaks the
+	// agreement — fetching only N would under-report — so the storage query stays unlimited and
+	// [entryIterator] applies the limit after the pipeline. The [entryIterator] limit stays in place
+	// either way; it is the backstop.
 	qparams := params
-	qparams.Limit = -1
+	if !n.keepsEveryEntry() {
+		qparams.Limit = -1
+	}
 	iter, err := n.Input.EvalPipeline(ctx, qparams)
 	if err != nil {
 		return nil, err

--- a/internal/logql/logqlengine/limit_pushdown.go
+++ b/internal/logql/logqlengine/limit_pushdown.go
@@ -1,0 +1,57 @@
+package logqlengine
+
+import (
+	"github.com/oteldb/oteldb/internal/logql"
+)
+
+// stageKeepsEveryEntry reports whether a pipeline stage is guaranteed to keep every entry it
+// processes, i.e. its [Processor] never returns keep=false.
+//
+// It fails closed: only the stages explicitly listed as non-dropping return true, so a newly added
+// stage is assumed to be able to drop entries until it is classified here. Getting that backwards
+// would silently under-report a limited query (see [ProcessorNode.EvalPipeline]).
+//
+// The listing mirrors buildStage:
+//
+//   - the parsers (json, logfmt, regexp, pattern, unpack) record a parse failure as the __error__
+//     label and return the entry unchanged, so they never drop;
+//   - line_format, decolorize, label_format, drop and keep rewrite the line or the label set only,
+//     and a template error is likewise recorded as __error__;
+//   - line filters, label filters and the distinct filter exist to drop entries.
+func stageKeepsEveryEntry(stage logql.PipelineStage) bool {
+	switch stage.(type) {
+	case *logql.JSONExpressionParser,
+		*logql.LogfmtExpressionParser,
+		*logql.RegexpLabelParser,
+		*logql.PatternLabelParser,
+		*logql.UnpackLabelParser,
+		*logql.LineFormat,
+		*logql.DecolorizeExpr,
+		*logql.LabelFormatExpr,
+		*logql.DropLabelsExpr,
+		*logql.KeepLabelsExpr:
+		return true
+	case *logql.LineFilter,
+		*logql.LabelFilter,
+		*logql.DistinctFilter:
+		return false
+	default:
+		// Unknown (or newly added) stage: assume it drops.
+		return false
+	}
+}
+
+// keepsEveryEntry reports whether the node passes through every entry the input node yields: the
+// prefilter is a no-op and no pipeline stage can drop. The OTEL adapter rewrites the line and never
+// drops, so it does not affect the answer.
+func (n *ProcessorNode) keepsEveryEntry() bool {
+	if p := n.Prefilter; p != nil && p != Processor(NopProcessor) {
+		return false
+	}
+	for _, stage := range n.Pipeline {
+		if !stageKeepsEveryEntry(stage) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/logql/logqlengine/limit_pushdown_test.go
+++ b/internal/logql/logqlengine/limit_pushdown_test.go
@@ -1,0 +1,111 @@
+package logqlengine
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlerrors"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlpattern"
+)
+
+func mustPattern(t *testing.T, input string) logqlpattern.Pattern {
+	t.Helper()
+	p, err := logqlpattern.Parse(input, 0)
+	require.NoError(t, err)
+	return p
+}
+
+// TestStageKeepsEveryEntry pins the classification of every pipeline stage buildStage knows about.
+// The table must stay in sync with the [logql.PipelineStage] implementors listed in
+// internal/logql/pipeline.go — a stage missing from it is a stage whose limit-pushdown safety was
+// never decided, and the length assertion below fails loudly when one is added.
+func TestStageKeepsEveryEntry(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage logql.PipelineStage
+		keeps bool
+	}{
+		// Parsers: a parse failure is recorded as the __error__ label, the entry survives.
+		{"json", &logql.JSONExpressionParser{Labels: []logql.Label{"foo"}}, true},
+		{"logfmt", &logql.LogfmtExpressionParser{Labels: []logql.Label{"foo"}}, true},
+		{"regexp", &logql.RegexpLabelParser{Regexp: regexp.MustCompile(`(?P<foo>.+)`)}, true},
+		{"pattern", &logql.PatternLabelParser{Pattern: mustPattern(t, "<foo>")}, true},
+		{"unpack", &logql.UnpackLabelParser{}, true},
+		// Line/label rewriters: they change the line or the label set, never the entry count.
+		{"line_format", &logql.LineFormat{Template: "{{.foo}}"}, true},
+		{"decolorize", &logql.DecolorizeExpr{}, true},
+		{"label_format", &logql.LabelFormatExpr{Values: []logql.LabelTemplate{{Label: "foo", Template: "{{.bar}}"}}}, true},
+		{"drop_labels", &logql.DropLabelsExpr{Labels: []logql.Label{"foo"}}, true},
+		{"keep_labels", &logql.KeepLabelsExpr{Labels: []logql.Label{"foo"}}, true},
+		// Filters: these exist to drop entries.
+		{"line_filter", &logql.LineFilter{Op: logql.OpEq, By: logql.LineFilterValue{Value: "foo"}}, false},
+		{"label_filter", &logql.LabelFilter{Pred: &logql.LabelMatcher{Label: "foo", Op: logql.OpEq, Value: "bar"}}, false},
+		{"distinct", &logql.DistinctFilter{Labels: []logql.Label{"foo"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.keeps, stageKeepsEveryEntry(tt.stage))
+
+			// Guard the table against drift: every listed stage must be one buildStage knows.
+			_, err := buildStage(tt.stage)
+			var unsupported *logqlerrors.UnsupportedError
+			require.False(t, errors.As(err, &unsupported), "stage is not built by buildStage")
+		})
+	}
+
+	// buildStage enumerates 13 stage types; bump this only together with a new table entry.
+	require.Len(t, tests, 13)
+
+	t.Run("unknown", func(t *testing.T) {
+		// Fail closed: an unclassified stage must be assumed to drop.
+		require.False(t, stageKeepsEveryEntry(nil))
+	})
+}
+
+// TestProcessorNodeKeepsEveryEntry covers the node-level predicate: the prefilter counts too, and a
+// nop prefilter with a non-dropping pipeline is what enables the limit pushdown.
+func TestProcessorNodeKeepsEveryEntry(t *testing.T) {
+	labelMatcher, err := buildLabelMatcher(logql.LabelMatcher{Label: "foo", Op: logql.OpEq, Value: "bar"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		node  ProcessorNode
+		keeps bool
+	}{
+		{"empty", ProcessorNode{Prefilter: NopProcessor}, true},
+		{"nil prefilter", ProcessorNode{}, true},
+		{"otel adapter does not drop", ProcessorNode{Prefilter: NopProcessor, EnableOTELAdapter: true}, true},
+		{
+			name: "non-dropping pipeline",
+			node: ProcessorNode{
+				Prefilter: NopProcessor,
+				Pipeline:  []logql.PipelineStage{&logql.UnpackLabelParser{}, &logql.DecolorizeExpr{}},
+			},
+			keeps: true,
+		},
+		{
+			name: "dropping stage",
+			node: ProcessorNode{
+				Prefilter: NopProcessor,
+				Pipeline:  []logql.PipelineStage{&logql.UnpackLabelParser{}, &logql.DistinctFilter{}},
+			},
+			keeps: false,
+		},
+		{
+			name:  "prefilter drops",
+			node:  ProcessorNode{Prefilter: labelMatcher},
+			keeps: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.keeps, tt.node.keepsEveryEntry())
+		})
+	}
+}

--- a/internal/logql/logqlengine/sampler.go
+++ b/internal/logql/logqlengine/sampler.go
@@ -43,6 +43,11 @@ func (n *SamplingNode) Traverse(cb NodeVisitor) error {
 
 // EvalSample implements [SampleNode].
 func (n *SamplingNode) EvalSample(ctx context.Context, params EvalParams) (SampleIterator, error) {
+	// A metric query's entry limit bounds the returned series, not the lines a range aggregation
+	// samples: truncating the input would silently under-count. The API passes its default limit
+	// down for metric queries too, so drop it here rather than relying on the pipeline node to do
+	// it (a bare selector has no [ProcessorNode] at all).
+	params.Limit = -1
 	iter, err := n.Input.EvalPipeline(ctx, params)
 	if err != nil {
 		return nil, err

--- a/internal/storagebackend/goldenbench_logql_test.go
+++ b/internal/storagebackend/goldenbench_logql_test.go
@@ -183,28 +183,28 @@ func goldenLogQLRound(round int, logical map[string]int64) plog.Logs {
 // own immutable part, plus one final round left in the head. Reads therefore merge many parts with a
 // live head — the shape a running store actually serves. No compaction is forced, so the cross-part
 // merge and per-part pruning stay in the measured path.
-func goldenLogQLFixture(b *testing.B) *goldenLogQLCorpus {
-	b.Helper()
+func goldenLogQLFixture(tb testing.TB) *goldenLogQLCorpus {
+	tb.Helper()
 
 	ctx := context.Background()
 	store, err := storage.InMemory()
-	require.NoError(b, err)
-	b.Cleanup(func() { _ = store.Close(ctx) })
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = store.Close(ctx) })
 
 	backend := storagebackend.New(store)
 	logical := make(map[string]int64)
 
 	for round := range goldenLogQLParts {
-		require.NoError(b, backend.ConsumeLogs(ctx, goldenLogQLRound(round, logical)))
-		require.NoError(b, store.Admin().Flush(ctx, "", signal.Log))
+		require.NoError(tb, backend.ConsumeLogs(ctx, goldenLogQLRound(round, logical)))
+		require.NoError(tb, store.Admin().Flush(ctx, "", signal.Log))
 	}
 	// One more round stays in the head.
-	require.NoError(b, backend.ConsumeLogs(ctx, goldenLogQLRound(goldenLogQLParts, logical)))
+	require.NoError(tb, backend.ConsumeLogs(ctx, goldenLogQLRound(goldenLogQLParts, logical)))
 
 	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
 		Optimizers: []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}},
 	})
-	require.NoError(b, err)
+	require.NoError(tb, err)
 
 	rounds := goldenLogQLParts + 1
 	start := time.Unix(0, goldenLogQLStartTS)

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -30,10 +30,19 @@ var (
 	_ logqlengine.Querier = (*LogQuerier)(nil)
 )
 
-// Capabilities implements [logqlengine.Querier]. The storage backend does not push any pipeline
-// filtering down, so it advertises no supported ops; the LogQL engine applies the whole pipeline
-// (line filters, parsers, label filters) on top of the raw entry stream this backend returns.
+// Capabilities implements [logqlengine.Querier].
+//
+// Every stream selector matcher shape is applied by this backend: [matchSelector] re-checks each
+// materialized record against the whole selector with LogQL semantics (absent label reads as ""),
+// and selector regexps are compiled anchored, matching the engine's own label matcher exactly. So
+// the label ops are advertised and the engine builds no redundant prefilter — which also lets a
+// bare selector query push its limit into the fetch (see [logStreamNode.EvalPipeline]).
+//
+// No line op is advertised: line filters are not applied by this backend. [LogQLOptimizer] may
+// offload some of them as fetch conditions, but those only ever skip work — the engine still
+// evaluates the whole pipeline on the surviving entries.
 func (q *LogQuerier) Capabilities() (caps logqlengine.QuerierCapabilities) {
+	caps.Label.Add(logql.OpEq, logql.OpNotEq, logql.OpRe, logql.OpNotRe)
 	return caps
 }
 
@@ -62,12 +71,21 @@ var _ logqlengine.PipelineNode = (*logStreamNode)(nil)
 // Traverse implements [logqlengine.Node].
 func (n *logStreamNode) Traverse(cb logqlengine.NodeVisitor) error { return cb(n) }
 
-// EvalPipeline implements [logqlengine.PipelineNode]. It fetches every record in the window, builds
+// EvalPipeline implements [logqlengine.PipelineNode]. It fetches the records in the window, builds
 // each record's label set, keeps the records whose set satisfies the stream selector, and returns
 // them as entries ordered per params.Direction (and truncated to params.Limit).
+//
+// A positive params.Limit is offered to the fetch as an ordered top-N pushdown. The engine only
+// passes one down when nothing above this node can drop an entry, and [fetchBatches] takes it only
+// when the selector is fully pushed, so no post-fetch filter can reduce the result below the limit.
+// The fetch answers with a superset (it keeps every row tying at the boundary timestamp), so the
+// sort+truncate below still decides the exact result.
 func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.EvalParams) (logqlengine.EntryIterator, error) {
 	lo, hi := fetchWindow(params.Start, params.End)
-	batches, _, err := n.fetchBatches(ctx, lo, hi)
+	batches, _, err := n.fetchBatches(ctx, lo, hi, fetchOptions{
+		limit:   params.Limit,
+		reverse: params.Direction == logqlengine.DirectionBackward,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -84,12 +102,25 @@ func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.Eva
 	return iterators.Slice(entries), nil
 }
 
+// fetchOptions are the per-call knobs of [logStreamNode.fetchBatches].
+type fetchOptions struct {
+	// projection limits the columns materialized for surviving rows (the bucketed sampling path
+	// needs only severity/body, not the attributes column whose decode dominates a full
+	// materialization); empty ⇒ the fetcher's default full set.
+	projection []string
+	// limit, when > 0, requests the ordered top-N pushdown: the fetch trims the survivors to the
+	// newest (reverse) or oldest limit records across every matched stream, keeping boundary ties so
+	// the result stays a correct superset. Taken only when the selector is fully pushed — otherwise
+	// the post-fetch matchSelector could drop rows and leave fewer than limit.
+	limit int
+	// reverse selects the limit direction: newest records when set, oldest otherwise.
+	reverse bool
+}
+
 // fetchBatches resolves the selector to storage fetch filters and returns the matching record
 // batches for [lo, hi]. Shared by the entry-materialization path (EvalPipeline) and the bucketed
-// sampling path (bucketSamplingNode.EvalBucketedSample). A non-empty projection limits the columns
-// materialized for surviving rows (the bucketed path needs only severity/body, not the attributes
-// column whose decode dominates a full materialization); empty ⇒ the fetcher's default full set.
-func (n *logStreamNode) fetchBatches(ctx context.Context, lo, hi int64, projection ...string) (_ []*fetch.Batch, selectorPushed bool, _ error) {
+// sampling path (bucketSamplingNode.EvalBucketedSample).
+func (n *logStreamNode) fetchBatches(ctx context.Context, lo, hi int64, opts fetchOptions) (_ []*fetch.Batch, selectorPushed bool, _ error) {
 	// Offload equality matchers: resource/scope labels prune streams via the postings index, clean
 	// record-attribute labels drop records via a per-record condition — both before materialization.
 	matchers, selConds, selectorPushed := n.streamFilters(ctx, lo, hi)
@@ -99,7 +130,14 @@ func (n *logStreamNode) fetchBatches(ctx context.Context, lo, hi int64, projecti
 		Start:      lo,
 		End:        hi,
 		Matchers:   matchers,
-		Projection: projection,
+		Projection: opts.projection,
+	}
+	// The fetch applies Matchers and Conditions before selecting the top-N, so the limit is exact
+	// over the rows that survive filtering. It is sound only when nothing after the fetch can drop a
+	// row: matchSelector re-checks every record, so require the selector to be fully pushed.
+	if opts.limit > 0 && selectorPushed {
+		req.Limit = opts.limit
+		req.Reverse = opts.reverse
 	}
 	// Selector record-attribute conditions plus any offloaded line filters (set by LogQLOptimizer).
 	if len(selConds)+len(n.conditions) > 0 {

--- a/internal/storagebackend/logs_limit_internal_test.go
+++ b/internal/storagebackend/logs_limit_internal_test.go
@@ -1,0 +1,103 @@
+package storagebackend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/logql"
+)
+
+// TestLogFetchLimitPushdown is a white-box check that the ordered top-N is really pushed into the
+// storage fetch, and that it is gated on the selector being fully pushed.
+//
+// The equivalence test in logs_limit_test.go proves the results are right; this one proves the work
+// is actually skipped, which a result-level test cannot see.
+func TestLogFetchLimitPushdown(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := New(store)
+
+	const records = 500
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ld := plog.NewLogs()
+	for _, env := range []string{"prod", "stage"} {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("service.name", "svc")
+		rl.Resource().Attributes().PutStr("env", env)
+		recs := rl.ScopeLogs().AppendEmpty().LogRecords()
+		for i := range records {
+			r := recs.AppendEmpty()
+			r.SetTimestamp(pcommon.Timestamp(base.Add(time.Duration(i) * time.Millisecond).UnixNano()))
+			r.Body().SetStr(fmt.Sprintf("%s %d", env, i))
+		}
+	}
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	lo, hi := fetchWindow(base.Add(-time.Hour), base.Add(time.Hour))
+	node := func(matchers ...logql.LabelMatcher) *logStreamNode {
+		t.Helper()
+		n, err := b.Logs().Query(ctx, matchers)
+		require.NoError(t, err)
+		sn, ok := n.(*logStreamNode)
+		require.True(t, ok)
+		return sn
+	}
+	rows := func(n *logStreamNode, opts fetchOptions) (int, bool) {
+		t.Helper()
+		batches, pushed, err := n.fetchBatches(ctx, lo, hi, opts)
+		require.NoError(t, err)
+		total := 0
+		for _, batch := range batches {
+			total += len(batch.Timestamps)
+		}
+		return total, pushed
+	}
+
+	pushable := node(logql.LabelMatcher{Label: "env", Op: logql.OpEq, Value: "prod"})
+	// `env!="dev"` also matches a stream without env, so it cannot be pushed to the index; the
+	// post-fetch matchSelector must re-check it, and a fetch-side limit would be unsound.
+	unpushable := node(logql.LabelMatcher{Label: "env", Op: logql.OpNotEq, Value: "dev"})
+
+	t.Run("unlimited", func(t *testing.T) {
+		got, pushed := rows(pushable, fetchOptions{})
+		require.True(t, pushed)
+		require.Equal(t, records, got)
+	})
+	t.Run("limited", func(t *testing.T) {
+		// The fetch keeps boundary ties, so it may return a superset of the limit — but far less
+		// than the whole window.
+		got, pushed := rows(pushable, fetchOptions{limit: 10, reverse: true})
+		require.True(t, pushed)
+		require.GreaterOrEqual(t, got, 10)
+		require.Less(t, got, records)
+	})
+	t.Run("newest when reverse", func(t *testing.T) {
+		batches, _, err := pushable.fetchBatches(ctx, lo, hi, fetchOptions{limit: 1, reverse: true})
+		require.NoError(t, err)
+		require.Len(t, batches, 1)
+		require.Equal(t, []int64{base.Add((records - 1) * time.Millisecond).UnixNano()}, batches[0].Timestamps)
+	})
+	t.Run("oldest when forward", func(t *testing.T) {
+		batches, _, err := pushable.fetchBatches(ctx, lo, hi, fetchOptions{limit: 1})
+		require.NoError(t, err)
+		require.Len(t, batches, 1)
+		require.Equal(t, []int64{base.UnixNano()}, batches[0].Timestamps)
+	})
+	t.Run("not pushed when selector is not fully pushed", func(t *testing.T) {
+		got, pushed := rows(unpushable, fetchOptions{limit: 10, reverse: true})
+		require.False(t, pushed)
+		require.Equal(t, 2*records, got, "the limit must be ignored: matchSelector still filters")
+	})
+}

--- a/internal/storagebackend/logs_limit_test.go
+++ b/internal/storagebackend/logs_limit_test.go
@@ -1,0 +1,167 @@
+package storagebackend_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+)
+
+// limitResult is a streams result in canonical form: stream label set → its entries, each stream's
+// entries ordered by ascending timestamp (the order the API itself produces).
+type limitResult map[string][]lokiapi.LogEntry
+
+// canonicalize flattens a streams result into a [limitResult].
+func canonicalize(tb testing.TB, data lokiapi.QueryResponseData) limitResult {
+	tb.Helper()
+	require.Equal(tb, lokiapi.StreamsResultQueryResponseData, data.Type)
+
+	out := limitResult{}
+	for _, s := range data.StreamsResult.Result {
+		pairs := make([]string, 0, len(s.Stream.Value))
+		for k, v := range s.Stream.Value {
+			pairs = append(pairs, k+"="+v)
+		}
+		sort.Strings(pairs)
+		key := strings.Join(pairs, ",")
+		require.NotContains(tb, out, key, "duplicate stream in result")
+		out[key] = s.Values
+	}
+	return out
+}
+
+// timestamps returns every entry's timestamp, sorted ascending.
+func (r limitResult) timestamps() []uint64 {
+	var out []uint64
+	for _, values := range r {
+		for _, v := range values {
+			out = append(out, v.T)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func (r limitResult) len() (n int) {
+	for _, values := range r {
+		n += len(values)
+	}
+	return n
+}
+
+// TestLogQLLimitPushdownEquivalence proves a limited log query returns the same entries whether or
+// not the limit is pushed into the storage fetch.
+//
+// For each query it evaluates the unlimited form once as the reference, then every limit/direction
+// combination, and asserts the limited result is exactly the reference cut to N in the query's
+// order:
+//
+//   - it holds min(N, total) entries;
+//   - each stream's entries are a contiguous end of that stream's reference entries — the newest
+//     when backward, the oldest when forward;
+//   - the kept timestamps are the N extreme timestamps of the reference, so no entry that should
+//     have made the cut was dropped for one that should not have.
+//
+// The last point is what a storage-side limit gets wrong when a stage can still drop entries, and
+// the per-stream check pins that nothing is reordered or substituted among timestamp ties (the
+// corpus has many: every stream shares the same timestamp grid).
+//
+// The bare selector (and the selector plus a non-dropping parser stage) is where the pushdown is
+// active; the line-filter query is where it must stay off.
+func TestLogQLLimitPushdownEquivalence(t *testing.T) {
+	corpus := goldenLogQLFixture(t)
+	ctx := context.Background()
+
+	// Number of entries a single service contributes to the corpus.
+	const perService = goldenLogQLPerRound * (goldenLogQLParts + 1)
+
+	for _, tc := range []struct {
+		name   string
+		query  string
+		limits []int
+	}{
+		{
+			// Pushdown active: nothing can drop an entry.
+			name:   "bare_selector",
+			query:  `{env="prod"}`,
+			limits: []int{1, 7, 100, 999},
+		},
+		{
+			// Pushdown active: a parser records failures as __error__, it never drops.
+			name:   "non_dropping_stage",
+			query:  `{service_name="svc-0"} | json`,
+			limits: []int{1, 45, 1000},
+		},
+		{
+			// Pushdown must stay off: the line filter drops entries after the fetch.
+			name:   "line_filter",
+			query:  `{service_name="svc-0"} |= "\"method\":\"GET\""`,
+			limits: []int{1, 100, 900, 901},
+		},
+		{
+			// Boundary: one short of, exactly, and more than the matching entry count.
+			name:   "boundary",
+			query:  `{service_name="svc-0"}`,
+			limits: []int{perService - 1, perService, perService + 1, 10 * perService},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := corpus.engine.NewQuery(ctx, tc.query)
+			require.NoError(t, err)
+
+			for _, dir := range []logqlengine.Direction{logqlengine.DirectionForward, logqlengine.DirectionBackward} {
+				t.Run(string(dir), func(t *testing.T) {
+					eval := func(limit int) limitResult {
+						t.Helper()
+						data, err := q.Eval(ctx, logqlengine.EvalParams{
+							Start:     corpus.start,
+							End:       corpus.end,
+							Direction: dir,
+							Limit:     limit,
+						})
+						require.NoError(t, err)
+						return canonicalize(t, data)
+					}
+
+					want := eval(-1)
+					wantTS := want.timestamps()
+					require.NotEmpty(t, wantTS)
+
+					backward := dir == logqlengine.DirectionBackward
+					for _, limit := range tc.limits {
+						t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+							got := eval(limit)
+							n := min(limit, len(wantTS))
+							require.Equal(t, n, got.len())
+
+							// The kept timestamps are the n extreme ones of the reference.
+							cut := wantTS[:n]
+							if backward {
+								cut = wantTS[len(wantTS)-n:]
+							}
+							require.Equal(t, cut, got.timestamps())
+
+							// Each stream keeps a contiguous end of its reference entries.
+							for key, values := range got {
+								ref, ok := want[key]
+								require.Truef(t, ok, "stream %q is not in the unlimited result", key)
+								if backward {
+									require.Equal(t, ref[len(ref)-len(values):], values, "stream %q", key)
+								} else {
+									require.Equal(t, ref[:len(values)], values, "stream %q", key)
+								}
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/storagebackend/logs_sampling.go
+++ b/internal/storagebackend/logs_sampling.go
@@ -78,7 +78,8 @@ func (n *bucketSamplingNode) EvalBucketedSample(ctx context.Context, params logq
 	if n.op == bytesSampling {
 		projection = append(projection, siglog.ColBody)
 	}
-	batches, fullyPushed, err := n.src.fetchBatches(ctx, startNs-windowNs, endNs, projection...)
+	// No limit: a range aggregation must see every record in the window.
+	batches, fullyPushed, err := n.src.fetchBatches(ctx, startNs-windowNs, endNs, fetchOptions{projection: projection})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ProcessorNode.EvalPipeline` stripped the limit unconditionally before the storage query, so the
whole window was fetched and materialized even for a bare selector with a limit — the common
Grafana shape, and the largest allocation source in the golden LogQL set.

## What changed

- **`stageKeepsEveryEntry`** (`internal/logql/logqlengine/limit_pushdown.go`): a classifier over
  `buildStage`'s stage list. The five parsers keep the entry and record failures as `__error__`;
  `line_format`, `decolorize`, `label_format`, `drop`, `keep` only rewrite the line or the label
  set. Line filters, label filters and the distinct filter drop. The `default` arm returns "can
  drop", so a newly added stage fails closed.
- **`ProcessorNode.keepsEveryEntry`** folds in the prefilter (a non-nop prefilter from
  `extractQueryConditions` drops, so it disables the pushdown) — the OTEL adapter rewrites the line
  and never drops. `EvalPipeline` passes `params.Limit` through when it holds; the `entryIterator`
  limit stays in place as the backstop either way.
- **`SamplingNode.EvalSample`** now clears the limit. The Loki API passes its log-listing limit down
  for metric queries too, and a bare selector has no `ProcessorNode` to strip it — so
  `count_over_time({sel}[1m])` could silently sample a truncated input. Pre-existing on the
  ClickHouse path; this fix is also what keeps the new pushdown from reaching a range aggregation.
- **`internal/storagebackend`** advertises the label ops it already applies exactly (`matchSelector`
  re-checks every record with Loki semantics, and selector regexps are compiled anchored), so the
  engine builds no redundant prefilter, and turns a pushed limit into the fetch's ordered top-N
  (`fetch.Request.Limit`/`Reverse`) — gated on `selectorPushed`, since otherwise the post-fetch
  `matchSelector` could reduce the result below the limit.

## Backend limit + direction

- `storagebackend`: the record engine applies matchers (postings) and conditions (per-row `Match`)
  *before* selecting the global top-N by timestamp across all matched streams, keeping every
  boundary tie — a correct superset that `sortEntries` + truncate then cuts exactly. `Reverse` maps
  to `DirectionBackward`. Multi-tenant concat and the cluster remote fetcher are still safe: the
  former unions per-tenant top-Ns, the latter does not forward the limit at all.
- `chstorage`: `ORDER BY timestamp DESC/ASC LIMIT n` over the single merged query — global, not
  per-stream, and direction-correct.

## Tests

- `TestStageKeepsEveryEntry` / `TestProcessorNodeKeepsEveryEntry` — table over every stage type in
  `buildStage`, plus the fail-closed default and the prefilter.
- `TestLogQLLimitPushdownEquivalence` — over the golden LogQL corpus: for a bare selector, a
  selector plus a parser, and a selector plus a line filter, every limit/direction combination must
  equal the unlimited result cut to N (per-stream contiguity plus the extreme-timestamp set, so
  timestamp ties are pinned). Includes limit == matching count and limit > corpus.
- `TestLogFetchLimitPushdown` — white-box: the fetch really returns fewer rows, the right end for
  each direction, and ignores the limit when the selector is not fully pushed.

## Benchmark

`go test -bench BenchmarkGoldenLogQL -benchmem -count 6 ./internal/storagebackend/`, benchstat:

```
                                      │  before.txt  │              after.txt              │
                                      │    sec/op    │    sec/op     vs base               │
GoldenLogQL/full_scan-32                 126.1m ± 1%   126.2m ±  3%        ~ (p=0.818 n=6)
GoldenLogQL/select_service-32           13.345m ± 4%   8.117m ± 14%  -39.18% (p=0.002 n=6)
GoldenLogQL/select_multi_stream-32       46.40m ± 1%   11.50m ±  8%  -75.21% (p=0.002 n=6)
GoldenLogQL/select_regexp-32             40.87m ± 2%   11.26m ±  6%  -72.44% (p=0.002 n=6)
GoldenLogQL/line_filter-32               3.486m ± 3%   3.417m ±  2%   -1.97% (p=0.026 n=6)
GoldenLogQL/line_filter_negated-32       14.86m ± 3%   13.73m ±  7%   -7.58% (p=0.009 n=6)
GoldenLogQL/label_filter-32              3.606m ± 1%   3.473m ±  1%   -3.69% (p=0.002 n=6)
GoldenLogQL/json_parser-32               20.27m ± 3%   18.42m ±  2%   -9.11% (p=0.002 n=6)
GoldenLogQL/logfmt_parser-32             22.78m ± 1%   21.32m ±  3%   -6.42% (p=0.002 n=6)
GoldenLogQL/needle-32                    694.1µ ± 5%   680.6µ ±  2%   -1.94% (p=0.002 n=6)
GoldenLogQL/limit_backward-32            46.82m ± 4%   10.33m ±  3%  -77.93% (p=0.002 n=6)
GoldenLogQL/metric_count_by_level-32     4.151m ± 1%   3.894m ±  2%   -6.19% (p=0.002 n=6)
GoldenLogQL/metric_rate_by_service-32    64.95m ± 1%   64.30m ±  2%        ~ (p=0.240 n=6)
geomean                                  15.25m        10.31m        -32.36%

                                      │  before.txt   │              after.txt               │
                                      │   allocs/op   │  allocs/op   vs base                 │
GoldenLogQL/select_service-32            111.06k ± 0%   23.06k ± 0%  -79.24% (p=0.002 n=6)
GoldenLogQL/select_multi_stream-32       543.81k ± 0%   23.78k ± 0%  -95.63% (p=0.002 n=6)
GoldenLogQL/select_regexp-32             435.68k ± 0%   23.64k ± 0%  -94.57% (p=0.002 n=6)
GoldenLogQL/limit_backward-32           542.670k ± 0%   4.637k ± 0%  -99.15% (p=0.002 n=6)
geomean                                   113.0k        43.60k       -61.41%
```

The filter cases (`line_filter`, `json_parser`, …) keep the pushdown off and improve only from the
dropped redundant prefilter.

Fixes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)