### PR TITLE
fix(traceqlengine): don't panic on structural spanset op with empty side

### DIFF
--- a/internal/traceql/traceqlengine/spanset_op.go
+++ b/internal/traceql/traceqlengine/spanset_op.go
@@ -48,10 +48,11 @@ func buildSpansetOp(op traceql.SpansetOp) (SpansetOp, error) {
 		}, nil
 	case traceql.SpansetOpChild:
 		return func(a, b []Spanset) (result []tracestorage.Span, _ error) {
-			if len(a) == 0 && len(b) == 0 {
+			// A structural join against an empty side yields nothing.
+			if len(a) == 0 || len(b) == 0 {
 				return nil, nil
 			}
-			if len(a) != 1 && len(b) != 1 {
+			if len(a) != 1 || len(b) != 1 {
 				return nil, errors.New("can't find children spans of multiple spansets at once, try to use colaesce()")
 			}
 			return childSpans(a[0], b[0]), nil
@@ -65,20 +66,22 @@ func buildSpansetOp(op traceql.SpansetOp) (SpansetOp, error) {
 		}, nil
 	case traceql.SpansetOpSibling:
 		return func(a, b []Spanset) (result []tracestorage.Span, _ error) {
-			if len(a) == 0 && len(b) == 0 {
+			// A structural join against an empty side yields nothing.
+			if len(a) == 0 || len(b) == 0 {
 				return nil, nil
 			}
-			if len(a) != 1 && len(b) != 1 {
+			if len(a) != 1 || len(b) != 1 {
 				return nil, errors.New("can't find siblings of multiple spansets at once, try to use colaesce()")
 			}
 			return siblingSpans(a[0], b[0]), nil
 		}, nil
 	case traceql.SpansetOpDescendant:
 		return func(a, b []Spanset) (result []tracestorage.Span, _ error) {
-			if len(a) == 0 && len(b) == 0 {
+			// A structural join against an empty side yields nothing.
+			if len(a) == 0 || len(b) == 0 {
 				return nil, nil
 			}
-			if len(a) != 1 && len(b) != 1 {
+			if len(a) != 1 || len(b) != 1 {
 				return nil, errors.New("can't find descendant spans of multiple spansets at once, try to use coalesce()")
 			}
 			return descendantSpans(a[0], b[0]), nil

--- a/internal/traceql/traceqlengine/spanset_op_test.go
+++ b/internal/traceql/traceqlengine/spanset_op_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/traceql"
 	"github.com/oteldb/oteldb/internal/tracestorage"
 )
 
@@ -42,6 +43,79 @@ func generateSpans(ids []spanIDs, group string) []tracestorage.Span {
 		})
 	}
 	return result
+}
+
+func TestBuildSpansetOpEmptySide(t *testing.T) {
+	// A structural operator must return an empty result, rather than panic or
+	// error, when either side matches nothing.
+	ops := []traceql.SpansetOp{
+		traceql.SpansetOpChild,
+		traceql.SpansetOpSibling,
+		traceql.SpansetOpDescendant,
+		traceql.SpansetOpAnd,
+		traceql.SpansetOpUnion,
+	}
+	nonEmpty := []Spanset{{Spans: generateSpans([]spanIDs{{id: 1}, {id: 2, parent: 1}}, "set")}}
+
+	tests := []struct {
+		name string
+		a, b []Spanset
+	}{
+		{"BothEmpty", nil, nil},
+		{"LeftEmpty", nil, nonEmpty},
+		{"RightEmpty", nonEmpty, nil},
+	}
+	for _, op := range ops {
+		t.Run(op.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					fn, err := buildSpansetOp(op)
+					require.NoError(t, err)
+
+					result, err := fn(tt.a, tt.b)
+					require.NoError(t, err)
+					if op == traceql.SpansetOpUnion && (len(tt.a) > 0 || len(tt.b) > 0) {
+						// Union keeps whatever the non-empty side has.
+						require.NotEmpty(t, result)
+						return
+					}
+					require.Empty(t, result)
+				})
+			}
+		})
+	}
+}
+
+func TestBuildSpansetOpMultipleSpansets(t *testing.T) {
+	// Structural operators can't join multiple spansets at once.
+	ops := []traceql.SpansetOp{
+		traceql.SpansetOpChild,
+		traceql.SpansetOpSibling,
+		traceql.SpansetOpDescendant,
+	}
+	one := []Spanset{{Spans: generateSpans([]spanIDs{{id: 1}}, "set")}}
+	two := append(slices.Clone(one), Spanset{Spans: generateSpans([]spanIDs{{id: 2}}, "set")})
+
+	for _, op := range ops {
+		t.Run(op.String(), func(t *testing.T) {
+			fn, err := buildSpansetOp(op)
+			require.NoError(t, err)
+
+			for _, tt := range []struct {
+				name string
+				a, b []Spanset
+			}{
+				{"Left", two, one},
+				{"Right", one, two},
+				{"Both", two, two},
+			} {
+				t.Run(tt.name, func(t *testing.T) {
+					_, err := fn(tt.a, tt.b)
+					require.Error(t, err)
+				})
+			}
+		})
+	}
 }
 
 func TestChildSpans(t *testing.T) {


### PR DESCRIPTION
Fixes #1171

`buildSpansetOp` guarded `SpansetOpChild`, `SpansetOpSibling` and `SpansetOpDescendant` with `len(a) == 0 && len(b) == 0`, so a one-sided empty result (`len(a) == 1, len(b) == 0`) passed both guards and panicked on `b[0]`. Both guards are now `||`: an empty side yields an empty result, and more than one spanset on *either* side is the error case.

`SpansetOpAnd`/`SpansetOpUnion` were already correct and are unchanged.

Added `TestBuildSpansetOpEmptySide` and `TestBuildSpansetOpMultipleSpansets`; the former panics against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)