### PR TITLE
feat(traceql): parse TraceQL metrics queries

### DIFF
--- a/internal/traceql/lexer/token.go
+++ b/internal/traceql/lexer/token.go
@@ -114,6 +114,16 @@ const (
 	UnionDesc    // &>>
 	UnionAnce    // &<<
 	UnionSibling // &~
+
+	// Metrics aggregations.
+	Rate              // rate
+	CountOverTime     // count_over_time
+	MinOverTime       // min_over_time
+	MaxOverTime       // max_over_time
+	SumOverTime       // sum_over_time
+	AvgOverTime       // avg_over_time
+	QuantileOverTime  // quantile_over_time
+	HistogramOverTime // histogram_over_time
 )
 
 var tokens = map[string]TokenType{
@@ -193,4 +203,13 @@ var tokens = map[string]TokenType{
 	"parentID":        ParentID,
 	"timeSinceStart":  TimeSinceStart,
 	"version":         Version,
+
+	"rate":                Rate,
+	"count_over_time":     CountOverTime,
+	"min_over_time":       MinOverTime,
+	"max_over_time":       MaxOverTime,
+	"sum_over_time":       SumOverTime,
+	"avg_over_time":       AvgOverTime,
+	"quantile_over_time":  QuantileOverTime,
+	"histogram_over_time": HistogramOverTime,
 }

--- a/internal/traceql/lexer/token.go
+++ b/internal/traceql/lexer/token.go
@@ -128,6 +128,10 @@ const (
 	// Metrics second stage functions.
 	TopK    // topk
 	BottomK // bottomk
+
+	// NOTE: keep this block append-only, the generated stringer indexes
+	// constants by position.
+	Compare // compare
 )
 
 var tokens = map[string]TokenType{
@@ -216,6 +220,8 @@ var tokens = map[string]TokenType{
 	"avg_over_time":       AvgOverTime,
 	"quantile_over_time":  QuantileOverTime,
 	"histogram_over_time": HistogramOverTime,
+
+	"compare": Compare,
 
 	"topk":    TopK,
 	"bottomk": BottomK,

--- a/internal/traceql/lexer/token.go
+++ b/internal/traceql/lexer/token.go
@@ -124,6 +124,10 @@ const (
 	AvgOverTime       // avg_over_time
 	QuantileOverTime  // quantile_over_time
 	HistogramOverTime // histogram_over_time
+
+	// Metrics second stage functions.
+	TopK    // topk
+	BottomK // bottomk
 )
 
 var tokens = map[string]TokenType{
@@ -212,4 +216,7 @@ var tokens = map[string]TokenType{
 	"avg_over_time":       AvgOverTime,
 	"quantile_over_time":  QuantileOverTime,
 	"histogram_over_time": HistogramOverTime,
+
+	"topk":    TopK,
+	"bottomk": BottomK,
 }

--- a/internal/traceql/lexer/tokentype_string.go
+++ b/internal/traceql/lexer/tokentype_string.go
@@ -96,11 +96,19 @@ func _() {
 	_ = x[UnionDesc-85]
 	_ = x[UnionAnce-86]
 	_ = x[UnionSibling-87]
+	_ = x[Rate-88]
+	_ = x[CountOverTime-89]
+	_ = x[MinOverTime-90]
+	_ = x[MaxOverTime-91]
+	_ = x[SumOverTime-92]
+	_ = x[AvgOverTime-93]
+	_ = x[QuantileOverTime-94]
+	_ = x[HistogramOverTime-95]
 }
 
-const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSibling"
+const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSiblingRateCountOverTimeMinOverTimeMaxOverTimeSumOverTimeAvgOverTimeQuantileOverTimeHistogramOverTime"
 
-var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629}
+var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629, 633, 646, 657, 668, 679, 690, 706, 723}
 
 func (i TokenType) String() string {
 	idx := int(i) - 0

--- a/internal/traceql/lexer/tokentype_string.go
+++ b/internal/traceql/lexer/tokentype_string.go
@@ -104,11 +104,13 @@ func _() {
 	_ = x[AvgOverTime-93]
 	_ = x[QuantileOverTime-94]
 	_ = x[HistogramOverTime-95]
+	_ = x[TopK-96]
+	_ = x[BottomK-97]
 }
 
-const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSiblingRateCountOverTimeMinOverTimeMaxOverTimeSumOverTimeAvgOverTimeQuantileOverTimeHistogramOverTime"
+const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSiblingRateCountOverTimeMinOverTimeMaxOverTimeSumOverTimeAvgOverTimeQuantileOverTimeHistogramOverTimeTopKBottomK"
 
-var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629, 633, 646, 657, 668, 679, 690, 706, 723}
+var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629, 633, 646, 657, 668, 679, 690, 706, 723, 727, 734}
 
 func (i TokenType) String() string {
 	idx := int(i) - 0

--- a/internal/traceql/lexer/tokentype_string.go
+++ b/internal/traceql/lexer/tokentype_string.go
@@ -106,11 +106,12 @@ func _() {
 	_ = x[HistogramOverTime-95]
 	_ = x[TopK-96]
 	_ = x[BottomK-97]
+	_ = x[Compare-98]
 }
 
-const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSiblingRateCountOverTimeMinOverTimeMaxOverTimeSumOverTimeAvgOverTimeQuantileOverTimeHistogramOverTimeTopKBottomK"
+const _TokenType_name = "InvalidEOFIdentStringIntegerNumberDurationCommaDotOpenBraceCloseBraceOpenParenCloseParenEqNotEqReNotReGtGteLtLteAddSubDivModMulPowTrueFalseNilStatusOkStatusErrorStatusUnsetKindUnspecifiedKindInternalKindServerKindClientKindProducerKindConsumerAndOrNotPipeDescTildeSpanDurationChildCountNameStatusKindRootNameRootServiceNameTraceDurationParentCountAvgMaxMinSumByCoalesceSelectTraceColonSpanColonEventColonLinkColonInstrumentationColonStatusMessageRootServiceNestedSetLeftNestedSetRightNestedSetParentIDTraceIDSpanIDParentIDTimeSinceStartVersionAnceNotChildNotParentNotDescNotAnceUnionChildUnionParentUnionDescUnionAnceUnionSiblingRateCountOverTimeMinOverTimeMaxOverTimeSumOverTimeAvgOverTimeQuantileOverTimeHistogramOverTimeTopKBottomKCompare"
 
-var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629, 633, 646, 657, 668, 679, 690, 706, 723, 727, 734}
+var _TokenType_index = [...]uint16{0, 7, 10, 15, 21, 28, 34, 42, 47, 50, 59, 69, 78, 88, 90, 95, 97, 102, 104, 107, 109, 112, 115, 118, 121, 124, 127, 130, 134, 139, 142, 150, 161, 172, 187, 199, 209, 219, 231, 243, 246, 248, 251, 255, 259, 264, 276, 286, 290, 296, 300, 308, 323, 336, 342, 347, 350, 353, 356, 359, 361, 369, 375, 385, 394, 404, 413, 433, 446, 457, 470, 484, 499, 501, 508, 514, 522, 536, 543, 547, 555, 564, 571, 578, 588, 599, 608, 617, 629, 633, 646, 657, 668, 679, 690, 706, 723, 727, 734, 741}
 
 func (i TokenType) String() string {
 	idx := int(i) - 0

--- a/internal/traceql/metrics_expr.go
+++ b/internal/traceql/metrics_expr.go
@@ -12,6 +12,12 @@ type MetricsExpr interface {
 
 func (*MetricsAggregation) expr()        {}
 func (*MetricsAggregation) metricsExpr() {}
+func (*CompareOperation) expr()          {}
+func (*CompareOperation) metricsExpr()   {}
+func (*MetricsPipeline) expr()           {}
+func (*MetricsPipeline) metricsExpr()    {}
+func (*MetricsBinaryExpr) expr()         {}
+func (*MetricsBinaryExpr) metricsExpr()  {}
 
 // MetricsAggregation aggregates a spanset pipeline into a time series.
 type MetricsAggregation struct {
@@ -24,31 +30,6 @@ type MetricsAggregation struct {
 	Parameters []float64
 	// By is a set of attributes to group series by, may be empty.
 	By []Attribute
-	// Stages are second stage operations applied to resulting series, may be empty.
-	Stages []MetricsStage
-}
-
-// MetricsStage is a metrics query second stage operation.
-//
-// See https://grafana.com/docs/tempo/latest/traceql/metrics-queries/#second-stage-functions.
-type MetricsStage interface {
-	metricsStage()
-}
-
-func (*TopKOperation) metricsStage() {}
-func (*MetricsFilter) metricsStage() {}
-
-// TopKOperation is a `topk()`/`bottomk()` operation, keeping only Limit series
-// with the highest (or lowest) values.
-type TopKOperation struct {
-	Op    MetricsStageOp
-	Limit int
-}
-
-// MetricsFilter drops series points not matching the comparison.
-type MetricsFilter struct {
-	Op    BinaryOp
-	Value *Static
 }
 
 func (e *MetricsAggregation) validate() error {
@@ -73,4 +54,92 @@ func (e *MetricsAggregation) validate() error {
 		return errors.Errorf("operation %q takes no parameters", e.Op)
 	}
 	return nil
+}
+
+const (
+	// DefaultCompareTopN is a default [CompareOperation.TopN].
+	DefaultCompareTopN = 10
+	// MaxCompareTopN is a maximum [CompareOperation.TopN].
+	MaxCompareTopN = 1000
+)
+
+// CompareOperation is a `compare()` metrics aggregation.
+//
+// It splits spans into a selection matching Filter and a baseline of the rest,
+// returning a series per attribute value found on them.
+type CompareOperation struct {
+	// Spanset is a pipeline producing spans to compare.
+	Spanset Expr
+	// Filter selects spans of the selection group.
+	Filter *SpansetFilter
+	// TopN limits values returned per attribute.
+	TopN int
+	// Start and End constrain the selection window, in Unix nanoseconds.
+	//
+	// Both are zero if unset.
+	Start, End int64
+}
+
+func (e *CompareOperation) validate() error {
+	if e.TopN <= 0 || e.TopN > MaxCompareTopN {
+		return errors.Errorf("compare() top number of values must be between 1 and %d, got %d", MaxCompareTopN, e.TopN)
+	}
+	switch {
+	case e.Start == 0 && e.End == 0:
+	case e.Start <= 0 || e.End <= 0:
+		return errors.New("compare() start and end timestamps must be both set")
+	case e.End <= e.Start:
+		return errors.New("compare() end timestamp must be greater than start timestamp")
+	}
+	return nil
+}
+
+// MetricsPipeline applies second stage operations to a metrics expression.
+type MetricsPipeline struct {
+	Expr   MetricsExpr
+	Stages []MetricsStage
+}
+
+// MetricsBinaryExpr is an arithmetic operation between two metrics expressions.
+//
+// Op is always arithmetic and never [OpMod] or [OpPow].
+type MetricsBinaryExpr struct {
+	Left  MetricsExpr
+	Op    BinaryOp
+	Right MetricsExpr
+}
+
+// MetricsStage is a metrics query second stage operation.
+//
+// See https://grafana.com/docs/tempo/latest/traceql/metrics-queries/#multi-stage-metrics-queries.
+type MetricsStage interface {
+	metricsStage()
+}
+
+func (*TopKOperation) metricsStage()   {}
+func (*MetricsFilter) metricsStage()   {}
+func (*MetricsScalarOp) metricsStage() {}
+
+// TopKOperation is a `topk()`/`bottomk()` operation, keeping only Limit series
+// with the highest (or lowest) values.
+type TopKOperation struct {
+	Op    MetricsStageOp
+	Limit int
+}
+
+// MetricsFilter drops series points not matching the comparison.
+type MetricsFilter struct {
+	Op    BinaryOp
+	Value *Static
+}
+
+// MetricsScalarOp applies constant arithmetic to every series point.
+//
+// A duration cannot be used as a scalar operand, so a float carries the value
+// without loss.
+type MetricsScalarOp struct {
+	Op    BinaryOp
+	Value float64
+	// ScalarLeft whether the constant is the left operand, as in `2 / ({} | rate())`.
+	ScalarLeft bool
 }

--- a/internal/traceql/metrics_expr.go
+++ b/internal/traceql/metrics_expr.go
@@ -1,0 +1,51 @@
+package traceql
+
+import "github.com/go-faster/errors"
+
+// MetricsExpr is a TraceQL metrics query expression.
+//
+// See https://grafana.com/docs/tempo/latest/traceql/metrics-queries/.
+type MetricsExpr interface {
+	Expr
+	metricsExpr()
+}
+
+func (*MetricsAggregation) expr()        {}
+func (*MetricsAggregation) metricsExpr() {}
+
+// MetricsAggregation aggregates a spanset pipeline into a time series.
+type MetricsAggregation struct {
+	Op MetricsOp
+	// Spanset is a pipeline producing spans to aggregate.
+	Spanset Expr
+	// Field is an attribute to aggregate, set if [MetricsOp.TakesField].
+	Field *Attribute
+	// Parameters are quantiles of [MetricsOpQuantileOverTime].
+	Parameters []float64
+	// By is a set of attributes to group series by, may be empty.
+	By []Attribute
+}
+
+func (e *MetricsAggregation) validate() error {
+	if e.Op.TakesField() {
+		if e.Field == nil {
+			return errors.Errorf("operation %q requires an attribute argument", e.Op)
+		}
+	} else if e.Field != nil {
+		return errors.Errorf("operation %q takes no arguments", e.Op)
+	}
+
+	if e.Op == MetricsOpQuantileOverTime {
+		if len(e.Parameters) == 0 {
+			return errors.Errorf("operation %q requires at least one quantile", e.Op)
+		}
+		for _, q := range e.Parameters {
+			if q < 0 || q > 1 {
+				return errors.Errorf("quantile must be within [0, 1] range, got %v", q)
+			}
+		}
+	} else if len(e.Parameters) > 0 {
+		return errors.Errorf("operation %q takes no parameters", e.Op)
+	}
+	return nil
+}

--- a/internal/traceql/metrics_expr.go
+++ b/internal/traceql/metrics_expr.go
@@ -24,6 +24,31 @@ type MetricsAggregation struct {
 	Parameters []float64
 	// By is a set of attributes to group series by, may be empty.
 	By []Attribute
+	// Stages are second stage operations applied to resulting series, may be empty.
+	Stages []MetricsStage
+}
+
+// MetricsStage is a metrics query second stage operation.
+//
+// See https://grafana.com/docs/tempo/latest/traceql/metrics-queries/#second-stage-functions.
+type MetricsStage interface {
+	metricsStage()
+}
+
+func (*TopKOperation) metricsStage() {}
+func (*MetricsFilter) metricsStage() {}
+
+// TopKOperation is a `topk()`/`bottomk()` operation, keeping only Limit series
+// with the highest (or lowest) values.
+type TopKOperation struct {
+	Op    MetricsStageOp
+	Limit int
+}
+
+// MetricsFilter drops series points not matching the comparison.
+type MetricsFilter struct {
+	Op    BinaryOp
+	Value *Static
 }
 
 func (e *MetricsAggregation) validate() error {

--- a/internal/traceql/metrics_expr_test.go
+++ b/internal/traceql/metrics_expr_test.go
@@ -297,6 +297,9 @@ var metricsTests = []TestCase{
 	{`{} | compare({}, 0)`, nil, true},
 	{`{} | compare({}, -1)`, nil, true},
 	{`{} | compare({}, 1001)`, nil, true},
+	// A value out of int range must not wrap into a valid one.
+	{`{} | compare({}, 2147483648)`, nil, true},
+	{`{} | compare({}, 4294967297)`, nil, true},
 	// Selection window must be a valid range.
 	{`{} | compare({}, 10, 2000, 1000)`, nil, true},
 	{`{} | compare({}, 10, 0, 2000)`, nil, true},

--- a/internal/traceql/metrics_expr_test.go
+++ b/internal/traceql/metrics_expr_test.go
@@ -1,0 +1,186 @@
+package traceql
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// allSpans is a `{}` pipeline, the most common spanset of a metrics query.
+func allSpans() Expr {
+	return &SpansetPipeline{
+		Pipeline: []PipelineStage{
+			&SpansetFilter{Expr: &Static{Type: TypeBool, Data: 1}},
+		},
+	}
+}
+
+var metricsTests = []TestCase{
+	{
+		`{} | rate()`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+		},
+		false,
+	},
+	{
+		`{} | rate() by (resource.service.name)`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+			By: []Attribute{
+				{Name: "service.name", Scope: ScopeResource},
+			},
+		},
+		false,
+	},
+	{
+		`{ status = error } | count_over_time()`,
+		&MetricsAggregation{
+			Op: MetricsOpCountOverTime,
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&SpansetFilter{
+						Expr: &BinaryFieldExpr{
+							Left:  &Attribute{Prop: SpanStatus},
+							Op:    OpEq,
+							Right: &Static{Type: TypeSpanStatus, Data: uint64(ptrace.StatusCodeError)},
+						},
+					},
+				},
+			},
+		},
+		false,
+	},
+	{
+		`{} | min_over_time(duration)`,
+		&MetricsAggregation{
+			Op:      MetricsOpMinOverTime,
+			Spanset: allSpans(),
+			Field:   new(Attribute{Prop: SpanDuration}),
+		},
+		false,
+	},
+	{
+		`{} | max_over_time(duration) by (name)`,
+		&MetricsAggregation{
+			Op:      MetricsOpMaxOverTime,
+			Spanset: allSpans(),
+			Field:   new(Attribute{Prop: SpanDuration}),
+			By:      []Attribute{{Prop: SpanName}},
+		},
+		false,
+	},
+	{
+		`{} | sum_over_time(span.http.request.size) by (name, resource.service.name)`,
+		&MetricsAggregation{
+			Op:      MetricsOpSumOverTime,
+			Spanset: allSpans(),
+			Field:   new(Attribute{Name: "http.request.size", Scope: ScopeSpan}),
+			By: []Attribute{
+				{Prop: SpanName},
+				{Name: "service.name", Scope: ScopeResource},
+			},
+		},
+		false,
+	},
+	{
+		`{} | avg_over_time(.latency)`,
+		&MetricsAggregation{
+			Op:      MetricsOpAvgOverTime,
+			Spanset: allSpans(),
+			Field:   new(Attribute{Name: "latency"}),
+		},
+		false,
+	},
+	{
+		`{} | quantile_over_time(duration, 0.9, 0.99) by (name)`,
+		&MetricsAggregation{
+			Op:         MetricsOpQuantileOverTime,
+			Spanset:    allSpans(),
+			Field:      new(Attribute{Prop: SpanDuration}),
+			Parameters: []float64{0.9, 0.99},
+			By:         []Attribute{{Prop: SpanName}},
+		},
+		false,
+	},
+	{
+		// Integer quantiles are casted to float.
+		`{} | quantile_over_time(duration, 0, 1)`,
+		&MetricsAggregation{
+			Op:         MetricsOpQuantileOverTime,
+			Spanset:    allSpans(),
+			Field:      new(Attribute{Prop: SpanDuration}),
+			Parameters: []float64{0, 1},
+		},
+		false,
+	},
+	{
+		`{} | histogram_over_time(duration)`,
+		&MetricsAggregation{
+			Op:      MetricsOpHistogramOverTime,
+			Spanset: allSpans(),
+			Field:   new(Attribute{Prop: SpanDuration}),
+		},
+		false,
+	},
+	{
+		// Aggregation applies to the entire pipeline.
+		`{ .a } | by(name) | rate()`,
+		&MetricsAggregation{
+			Op: MetricsOpRate,
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&SpansetFilter{Expr: &Attribute{Name: "a"}},
+					&GroupOperation{By: &Attribute{Prop: SpanName}},
+				},
+			},
+		},
+		false,
+	},
+	{
+		`{ .a } && { .b } | count_over_time()`,
+		&MetricsAggregation{
+			Op: MetricsOpCountOverTime,
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&BinarySpansetExpr{
+						Left:  &SpansetFilter{Expr: &Attribute{Name: "a"}},
+						Op:    SpansetOpAnd,
+						Right: &SpansetFilter{Expr: &Attribute{Name: "b"}},
+					},
+				},
+			},
+		},
+		false,
+	},
+
+	// Operations taking no argument.
+	{`{} | rate(duration)`, nil, true},
+	{`{} | count_over_time(duration)`, nil, true},
+	{`{} | rate(duration, 0.9)`, nil, true},
+	// Operations requiring an argument.
+	{`{} | min_over_time()`, nil, true},
+	{`{} | avg_over_time()`, nil, true},
+	{`{} | histogram_over_time()`, nil, true},
+	// Only quantile_over_time takes parameters.
+	{`{} | sum_over_time(duration, 0.9)`, nil, true},
+	{`{} | quantile_over_time(duration)`, nil, true},
+	{`{} | quantile_over_time(duration, 1.5)`, nil, true},
+	{`{} | quantile_over_time(duration, -1)`, nil, true},
+	// Malformed queries.
+	{`| rate()`, nil, true},
+	{`rate()`, nil, true},
+	{`{} | rate`, nil, true},
+	{`{} | rate(`, nil, true},
+	{`{} | rate() by ()`, nil, true},
+	{`{} | rate() by (name`, nil, true},
+	{`{} | rate() by (name,)`, nil, true},
+	{`{} | rate() | rate()`, nil, true},
+	{`{} | rate() by (1)`, nil, true},
+}
+
+func TestParseMetrics(t *testing.T) {
+	runParseTests(t, metricsTests)
+}

--- a/internal/traceql/metrics_expr_test.go
+++ b/internal/traceql/metrics_expr_test.go
@@ -161,9 +161,11 @@ var metricsTests = []TestCase{
 	// Second stage operations.
 	{
 		`{} | rate() | topk(10)`,
-		&MetricsAggregation{
-			Op:      MetricsOpRate,
-			Spanset: allSpans(),
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
 			Stages: []MetricsStage{
 				&TopKOperation{Op: MetricsStageOpTopK, Limit: 10},
 			},
@@ -172,10 +174,12 @@ var metricsTests = []TestCase{
 	},
 	{
 		`{} | rate() by (name) | bottomk(5)`,
-		&MetricsAggregation{
-			Op:      MetricsOpRate,
-			Spanset: allSpans(),
-			By:      []Attribute{{Prop: SpanName}},
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+				By:      []Attribute{{Prop: SpanName}},
+			},
 			Stages: []MetricsStage{
 				&TopKOperation{Op: MetricsStageOpBottomK, Limit: 5},
 			},
@@ -185,9 +189,11 @@ var metricsTests = []TestCase{
 	{
 		// A filter is not preceded by a pipe.
 		`{} | count_over_time() > 100`,
-		&MetricsAggregation{
-			Op:      MetricsOpCountOverTime,
-			Spanset: allSpans(),
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpCountOverTime,
+				Spanset: allSpans(),
+			},
 			Stages: []MetricsStage{
 				&MetricsFilter{Op: OpGt, Value: &Static{Type: TypeInt, Data: 100}},
 			},
@@ -196,11 +202,13 @@ var metricsTests = []TestCase{
 	},
 	{
 		`{} | quantile_over_time(duration, 0.9) >= 100ms`,
-		&MetricsAggregation{
-			Op:         MetricsOpQuantileOverTime,
-			Spanset:    allSpans(),
-			Field:      new(Attribute{Prop: SpanDuration}),
-			Parameters: []float64{0.9},
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:         MetricsOpQuantileOverTime,
+				Spanset:    allSpans(),
+				Field:      new(Attribute{Prop: SpanDuration}),
+				Parameters: []float64{0.9},
+			},
 			Stages: []MetricsStage{
 				&MetricsFilter{
 					Op:    OpGte,
@@ -212,9 +220,11 @@ var metricsTests = []TestCase{
 	},
 	{
 		`{} | rate() != 0.5`,
-		&MetricsAggregation{
-			Op:      MetricsOpRate,
-			Spanset: allSpans(),
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
 			Stages: []MetricsStage{
 				&MetricsFilter{Op: OpNotEq, Value: &Static{Type: TypeNumber, Data: math.Float64bits(0.5)}},
 			},
@@ -224,9 +234,11 @@ var metricsTests = []TestCase{
 	{
 		// Stages chain in the order they are written.
 		`{} | rate() > 10 | topk(3) < 100 | bottomk(2)`,
-		&MetricsAggregation{
-			Op:      MetricsOpRate,
-			Spanset: allSpans(),
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
 			Stages: []MetricsStage{
 				&MetricsFilter{Op: OpGt, Value: &Static{Type: TypeInt, Data: 10}},
 				&TopKOperation{Op: MetricsStageOpTopK, Limit: 3},
@@ -236,6 +248,277 @@ var metricsTests = []TestCase{
 		},
 		false,
 	},
+
+	// compare().
+	{
+		`{ .a } | compare({ status = error })`,
+		&CompareOperation{
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&SpansetFilter{Expr: &Attribute{Name: "a"}},
+				},
+			},
+			Filter: &SpansetFilter{
+				Expr: &BinaryFieldExpr{
+					Left:  &Attribute{Prop: SpanStatus},
+					Op:    OpEq,
+					Right: &Static{Type: TypeSpanStatus, Data: uint64(ptrace.StatusCodeError)},
+				},
+			},
+			TopN: DefaultCompareTopN,
+		},
+		false,
+	},
+	{
+		`{} | compare({}, 25)`,
+		&CompareOperation{
+			Spanset: allSpans(),
+			Filter:  &SpansetFilter{Expr: &Static{Type: TypeBool, Data: 1}},
+			TopN:    25,
+		},
+		false,
+	},
+	{
+		`{} | compare({}, 25, 1000, 2000)`,
+		&CompareOperation{
+			Spanset: allSpans(),
+			Filter:  &SpansetFilter{Expr: &Static{Type: TypeBool, Data: 1}},
+			TopN:    25,
+			Start:   1000,
+			End:     2000,
+		},
+		false,
+	},
+	// compare() takes 0, 1 or 3 arguments.
+	{`{} | compare()`, nil, true},
+	{`{} | compare({}, 10, 1000)`, nil, true},
+	{`{} | compare({}, 10, 1000, 2000, 3000)`, nil, true},
+	// TopN must be within [1, MaxCompareTopN].
+	{`{} | compare({}, 0)`, nil, true},
+	{`{} | compare({}, -1)`, nil, true},
+	{`{} | compare({}, 1001)`, nil, true},
+	// Selection window must be a valid range.
+	{`{} | compare({}, 10, 2000, 1000)`, nil, true},
+	{`{} | compare({}, 10, 0, 2000)`, nil, true},
+	{`{} | compare({}, 10, 1000, 0)`, nil, true},
+	{`{} | compare({}, 10, -1000, 2000)`, nil, true},
+	// compare() supports neither second stage operations nor arithmetic.
+	{`{} | compare({}) | topk(10)`, nil, true},
+	{`{} | compare({}) > 10`, nil, true},
+	{`({} | compare({})) / ({} | rate())`, nil, true},
+	{`({} | compare({})) * 2`, nil, true},
+	// compare() takes a spanset filter.
+	{`{} | compare(.a)`, nil, true},
+	{`{} | compare({} | rate())`, nil, true},
+
+	// Metrics arithmetic.
+	{
+		`({ status = error } | rate()) / ({} | rate())`,
+		&MetricsBinaryExpr{
+			Left: &MetricsAggregation{
+				Op: MetricsOpRate,
+				Spanset: &SpansetPipeline{
+					Pipeline: []PipelineStage{
+						&SpansetFilter{
+							Expr: &BinaryFieldExpr{
+								Left:  &Attribute{Prop: SpanStatus},
+								Op:    OpEq,
+								Right: &Static{Type: TypeSpanStatus, Data: uint64(ptrace.StatusCodeError)},
+							},
+						},
+					},
+				},
+			},
+			Op: OpDiv,
+			Right: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+		},
+		false,
+	},
+	{
+		// A single sub-query is a valid arithmetic expression.
+		`({} | rate())`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+		},
+		false,
+	},
+	{
+		// A constant operand becomes a stage, since it applies to every point.
+		`({} | rate()) * 100`,
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+			Stages: []MetricsStage{
+				&MetricsScalarOp{Op: OpMul, Value: 100},
+			},
+		},
+		false,
+	},
+	{
+		`2 - ({} | rate())`,
+		&MetricsPipeline{
+			Expr: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+			Stages: []MetricsStage{
+				&MetricsScalarOp{Op: OpSub, Value: 2, ScalarLeft: true},
+			},
+		},
+		false,
+	},
+	{
+		// Multiplication binds tighter than addition.
+		`({} | rate()) + ({} | rate()) * 2`,
+		&MetricsBinaryExpr{
+			Left: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+			Op: OpAdd,
+			Right: &MetricsPipeline{
+				Expr: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+				Stages: []MetricsStage{
+					&MetricsScalarOp{Op: OpMul, Value: 2},
+				},
+			},
+		},
+		false,
+	},
+	{
+		// Parentheses override precedence.
+		`(({} | rate()) + ({} | rate())) / ({} | rate())`,
+		&MetricsBinaryExpr{
+			Left: &MetricsBinaryExpr{
+				Left: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+				Op: OpAdd,
+				Right: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+			},
+			Op: OpDiv,
+			Right: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+		},
+		false,
+	},
+	{
+		// Second stage operations apply to the arithmetic result.
+		`({} | rate()) / ({} | rate()) | topk(10)`,
+		&MetricsPipeline{
+			Expr: &MetricsBinaryExpr{
+				Left: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+				Op: OpDiv,
+				Right: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+			},
+			Stages: []MetricsStage{
+				&TopKOperation{Op: MetricsStageOpTopK, Limit: 10},
+			},
+		},
+		false,
+	},
+	{
+		// Second stage operations may also be inside a sub-query.
+		`({} | rate() | topk(10)) - ({} | rate())`,
+		&MetricsBinaryExpr{
+			Left: &MetricsPipeline{
+				Expr: &MetricsAggregation{
+					Op:      MetricsOpRate,
+					Spanset: allSpans(),
+				},
+				Stages: []MetricsStage{
+					&TopKOperation{Op: MetricsStageOpTopK, Limit: 10},
+				},
+			},
+			Op: OpSub,
+			Right: &MetricsAggregation{
+				Op:      MetricsOpRate,
+				Spanset: allSpans(),
+			},
+		},
+		false,
+	},
+	{
+		// A parenthesized spanset expression is not a sub-query.
+		`({ .a } && { .b }) | rate()`,
+		&MetricsAggregation{
+			Op: MetricsOpRate,
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&BinarySpansetExpr{
+						Left:  &SpansetFilter{Expr: &Attribute{Name: "a"}},
+						Op:    SpansetOpAnd,
+						Right: &SpansetFilter{Expr: &Attribute{Name: "b"}},
+					},
+				},
+			},
+		},
+		false,
+	},
+	{
+		`({ .a }) | rate()`,
+		&MetricsAggregation{
+			Op: MetricsOpRate,
+			Spanset: &SpansetPipeline{
+				Pipeline: []PipelineStage{
+					&SpansetFilter{Expr: &Attribute{Name: "a"}},
+				},
+			},
+		},
+		false,
+	},
+	{
+		// A parenthesized query without a metrics function stays a spanset query.
+		`({ .a }) && { .b }`,
+		&SpansetPipeline{
+			Pipeline: []PipelineStage{
+				&BinarySpansetExpr{
+					Left:  &SpansetFilter{Expr: &Attribute{Name: "a"}},
+					Op:    SpansetOpAnd,
+					Right: &SpansetFilter{Expr: &Attribute{Name: "b"}},
+				},
+			},
+		},
+		false,
+	},
+
+	// Each sub-query must be parenthesized.
+	{`{} | rate() + {} | rate()`, nil, true},
+	{`({} | rate()) + {} | rate()`, nil, true},
+	// A duration cannot be used as a scalar operand.
+	{`({} | rate()) * 10s`, nil, true},
+	// Constant arithmetic is not folded.
+	{`({} | rate()) * (2 * 3)`, nil, true},
+	// Only +, -, * and / are supported.
+	{`({} | rate()) % ({} | rate())`, nil, true},
+	{`({} | rate()) ^ 2`, nil, true},
+	// Malformed arithmetic.
+	{`({} | rate()) /`, nil, true},
+	{`({} | rate()) / ()`, nil, true},
+	{`({} | rate()`, nil, true},
+	{`({} | rate()) / ({} | rate()`, nil, true},
+	{`2 * 2`, nil, true},
 
 	// Operations taking no argument.
 	{`{} | rate(duration)`, nil, true},

--- a/internal/traceql/metrics_expr_test.go
+++ b/internal/traceql/metrics_expr_test.go
@@ -1,7 +1,9 @@
 package traceql
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -156,6 +158,85 @@ var metricsTests = []TestCase{
 		false,
 	},
 
+	// Second stage operations.
+	{
+		`{} | rate() | topk(10)`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+			Stages: []MetricsStage{
+				&TopKOperation{Op: MetricsStageOpTopK, Limit: 10},
+			},
+		},
+		false,
+	},
+	{
+		`{} | rate() by (name) | bottomk(5)`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+			By:      []Attribute{{Prop: SpanName}},
+			Stages: []MetricsStage{
+				&TopKOperation{Op: MetricsStageOpBottomK, Limit: 5},
+			},
+		},
+		false,
+	},
+	{
+		// A filter is not preceded by a pipe.
+		`{} | count_over_time() > 100`,
+		&MetricsAggregation{
+			Op:      MetricsOpCountOverTime,
+			Spanset: allSpans(),
+			Stages: []MetricsStage{
+				&MetricsFilter{Op: OpGt, Value: &Static{Type: TypeInt, Data: 100}},
+			},
+		},
+		false,
+	},
+	{
+		`{} | quantile_over_time(duration, 0.9) >= 100ms`,
+		&MetricsAggregation{
+			Op:         MetricsOpQuantileOverTime,
+			Spanset:    allSpans(),
+			Field:      new(Attribute{Prop: SpanDuration}),
+			Parameters: []float64{0.9},
+			Stages: []MetricsStage{
+				&MetricsFilter{
+					Op:    OpGte,
+					Value: &Static{Type: TypeDuration, Data: uint64(100 * time.Millisecond)},
+				},
+			},
+		},
+		false,
+	},
+	{
+		`{} | rate() != 0.5`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+			Stages: []MetricsStage{
+				&MetricsFilter{Op: OpNotEq, Value: &Static{Type: TypeNumber, Data: math.Float64bits(0.5)}},
+			},
+		},
+		false,
+	},
+	{
+		// Stages chain in the order they are written.
+		`{} | rate() > 10 | topk(3) < 100 | bottomk(2)`,
+		&MetricsAggregation{
+			Op:      MetricsOpRate,
+			Spanset: allSpans(),
+			Stages: []MetricsStage{
+				&MetricsFilter{Op: OpGt, Value: &Static{Type: TypeInt, Data: 10}},
+				&TopKOperation{Op: MetricsStageOpTopK, Limit: 3},
+				&MetricsFilter{Op: OpLt, Value: &Static{Type: TypeInt, Data: 100}},
+				&TopKOperation{Op: MetricsStageOpBottomK, Limit: 2},
+			},
+		},
+		false,
+	},
+
 	// Operations taking no argument.
 	{`{} | rate(duration)`, nil, true},
 	{`{} | count_over_time(duration)`, nil, true},
@@ -179,6 +260,20 @@ var metricsTests = []TestCase{
 	{`{} | rate() by (name,)`, nil, true},
 	{`{} | rate() | rate()`, nil, true},
 	{`{} | rate() by (1)`, nil, true},
+	// Second stage without an aggregation.
+	{`{} | topk(5)`, nil, true},
+	{`topk(5)`, nil, true},
+	// Malformed second stage.
+	{`{} | rate() | topk()`, nil, true},
+	{`{} | rate() | topk(0)`, nil, true},
+	{`{} | rate() | topk(-1)`, nil, true},
+	{`{} | rate() | topk(1.5)`, nil, true},
+	{`{} | rate() | topk(10`, nil, true},
+	{`{} | rate() | topk(10) topk(5)`, nil, true},
+	{`{} | rate() | count_over_time()`, nil, true},
+	{`{} | rate() >`, nil, true},
+	{`{} | rate() =~ 10`, nil, true},
+	{`{} | rate() > 10 > `, nil, true},
 }
 
 func TestParseMetrics(t *testing.T) {

--- a/internal/traceql/op.go
+++ b/internal/traceql/op.go
@@ -393,3 +393,23 @@ func (op MetricsOp) TakesField() bool {
 		return true
 	}
 }
+
+// MetricsStageOp defines a metrics second stage operator.
+type MetricsStageOp int
+
+const (
+	MetricsStageOpTopK MetricsStageOp = iota + 1
+	MetricsStageOpBottomK
+)
+
+// String implements fmt.Stringer.
+func (op MetricsStageOp) String() string {
+	switch op {
+	case MetricsStageOpTopK:
+		return "topk"
+	case MetricsStageOpBottomK:
+		return "bottomk"
+	default:
+		return fmt.Sprintf("<unknown op %d>", op)
+	}
+}

--- a/internal/traceql/op.go
+++ b/internal/traceql/op.go
@@ -345,3 +345,51 @@ func (op AggregateOp) String() string {
 		return fmt.Sprintf("<unknown op %d>", op)
 	}
 }
+
+// MetricsOp defines a metrics aggregation operator.
+type MetricsOp int
+
+const (
+	MetricsOpRate MetricsOp = iota + 1
+	MetricsOpCountOverTime
+	MetricsOpMinOverTime
+	MetricsOpMaxOverTime
+	MetricsOpSumOverTime
+	MetricsOpAvgOverTime
+	MetricsOpQuantileOverTime
+	MetricsOpHistogramOverTime
+)
+
+// String implements fmt.Stringer.
+func (op MetricsOp) String() string {
+	switch op {
+	case MetricsOpRate:
+		return "rate"
+	case MetricsOpCountOverTime:
+		return "count_over_time"
+	case MetricsOpMinOverTime:
+		return "min_over_time"
+	case MetricsOpMaxOverTime:
+		return "max_over_time"
+	case MetricsOpSumOverTime:
+		return "sum_over_time"
+	case MetricsOpAvgOverTime:
+		return "avg_over_time"
+	case MetricsOpQuantileOverTime:
+		return "quantile_over_time"
+	case MetricsOpHistogramOverTime:
+		return "histogram_over_time"
+	default:
+		return fmt.Sprintf("<unknown op %d>", op)
+	}
+}
+
+// TakesField whether op aggregates over a span attribute.
+func (op MetricsOp) TakesField() bool {
+	switch op {
+	case MetricsOpRate, MetricsOpCountOverTime:
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/traceql/parser.go
+++ b/internal/traceql/parser.go
@@ -113,6 +113,19 @@ func (p *parser) parseNumber() (float64, error) {
 	return strconv.ParseFloat(text, 64)
 }
 
+// parseFloat parses a numeric literal, casting integers to float.
+func (p *parser) parseFloat() (float64, error) {
+	switch t := p.peek(); t.Type {
+	case lexer.Integer:
+		v, err := p.parseInteger()
+		return float64(v), err
+	case lexer.Number:
+		return p.parseNumber()
+	default:
+		return 0, p.unexpectedToken(t)
+	}
+}
+
 func (p *parser) parseDuration() (time.Duration, error) {
 	text, err := p.consumeText(lexer.Duration)
 	if err != nil {

--- a/internal/traceql/parser.go
+++ b/internal/traceql/parser.go
@@ -43,6 +43,10 @@ type parser struct {
 
 	first  bool
 	parens int
+
+	// metricsSubQuery whether a metrics sub-query has been parsed, see
+	// [parser.tryMetricsMath].
+	metricsSubQuery bool
 }
 
 func (p *parser) consume(tt lexer.TokenType) error {

--- a/internal/traceql/parser.go
+++ b/internal/traceql/parser.go
@@ -2,6 +2,7 @@ package traceql
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -107,6 +108,21 @@ func (p *parser) parseInteger() (int64, error) {
 		return 0, err
 	}
 	return strconv.ParseInt(text, 0, 64)
+}
+
+// clampInt narrows v to int, saturating rather than truncating.
+//
+// On a 32-bit platform a plain conversion would wrap an out-of-range literal
+// into a valid-looking value, slipping past the range checks done afterwards.
+func clampInt(v int64) int {
+	switch {
+	case v > math.MaxInt:
+		return math.MaxInt
+	case v < math.MinInt:
+		return math.MinInt
+	default:
+		return int(v)
+	}
 }
 
 func (p *parser) parseNumber() (float64, error) {

--- a/internal/traceql/parser_expr.go
+++ b/internal/traceql/parser_expr.go
@@ -1,6 +1,20 @@
 package traceql
 
+import (
+	"github.com/oteldb/oteldb/internal/traceql/lexer"
+)
+
 func (p *parser) parseExpr() (Expr, error) {
+	switch p.peek().Type {
+	case lexer.OpenParen, lexer.Integer, lexer.Number:
+		switch expr, ok, err := p.tryMetricsMath(); {
+		case err != nil:
+			return nil, err
+		case ok:
+			return expr, nil
+		}
+	}
+
 	expr, err := p.parseExpr1()
 	if err != nil {
 		return nil, err

--- a/internal/traceql/parser_expr.go
+++ b/internal/traceql/parser_expr.go
@@ -5,7 +5,11 @@ func (p *parser) parseExpr() (Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.parseBinaryExpr(expr, 0)
+	expr, err = p.parseBinaryExpr(expr, 0)
+	if err != nil {
+		return nil, err
+	}
+	return p.parseMetricsExpr(expr)
 }
 
 func (p *parser) parseExpr1() (Expr, error) {

--- a/internal/traceql/parser_metrics_expr.go
+++ b/internal/traceql/parser_metrics_expr.go
@@ -1,0 +1,133 @@
+package traceql
+
+import (
+	"github.com/oteldb/oteldb/internal/traceql/lexer"
+)
+
+// parseMetricsExpr parses a metrics aggregation applied to the given spanset
+// pipeline, if there is any.
+//
+// The pipe is left unconsumed by [parser.parsePipeline], since a metrics
+// aggregation terminates the pipeline rather than being a stage of it.
+func (p *parser) parseMetricsExpr(spanset Expr) (Expr, error) {
+	if p.peek().Type != lexer.Pipe {
+		return spanset, nil
+	}
+	// Consume "|".
+	p.next()
+
+	e, err := p.parseMetricsAggregation()
+	if err != nil {
+		return nil, err
+	}
+	e.Spanset = spanset
+	return e, nil
+}
+
+func (p *parser) parseMetricsAggregation() (e *MetricsAggregation, _ error) {
+	e = new(MetricsAggregation)
+
+	opTok := p.next()
+	op, ok := metricsOp(opTok.Type)
+	if !ok {
+		return nil, p.unexpectedToken(opTok)
+	}
+	e.Op = op
+
+	if err := p.consume(lexer.OpenParen); err != nil {
+		return nil, err
+	}
+	if t := p.peek(); t.Type != lexer.CloseParen {
+		attr, ok, err := p.tryAttribute()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, p.unexpectedToken(t)
+		}
+		e.Field = &attr
+
+		for p.peek().Type == lexer.Comma {
+			// Consume comma.
+			p.next()
+
+			param, err := p.parseFloat()
+			if err != nil {
+				return nil, err
+			}
+			e.Parameters = append(e.Parameters, param)
+		}
+	}
+	if err := p.consume(lexer.CloseParen); err != nil {
+		return nil, err
+	}
+
+	if p.peek().Type == lexer.By {
+		// Consume "by".
+		p.next()
+
+		by, err := p.parseAttributeList()
+		if err != nil {
+			return nil, err
+		}
+		e.By = by
+	}
+
+	if err := e.validate(); err != nil {
+		return nil, &SyntaxError{Msg: err.Error(), Pos: opTok.Pos}
+	}
+	return e, nil
+}
+
+// parseAttributeList parses a parenthesized list of comma-separated attributes.
+func (p *parser) parseAttributeList() (attrs []Attribute, _ error) {
+	if err := p.consume(lexer.OpenParen); err != nil {
+		return nil, err
+	}
+
+	for {
+		t := p.peek()
+		attr, ok, err := p.tryAttribute()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, p.unexpectedToken(t)
+		}
+		attrs = append(attrs, attr)
+
+		if p.peek().Type != lexer.Comma {
+			break
+		}
+		// Consume comma.
+		p.next()
+	}
+
+	if err := p.consume(lexer.CloseParen); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}
+
+func metricsOp(tt lexer.TokenType) (op MetricsOp, _ bool) {
+	switch tt {
+	case lexer.Rate:
+		return MetricsOpRate, true
+	case lexer.CountOverTime:
+		return MetricsOpCountOverTime, true
+	case lexer.MinOverTime:
+		return MetricsOpMinOverTime, true
+	case lexer.MaxOverTime:
+		return MetricsOpMaxOverTime, true
+	case lexer.SumOverTime:
+		return MetricsOpSumOverTime, true
+	case lexer.AvgOverTime:
+		return MetricsOpAvgOverTime, true
+	case lexer.QuantileOverTime:
+		return MetricsOpQuantileOverTime, true
+	case lexer.HistogramOverTime:
+		return MetricsOpHistogramOverTime, true
+	default:
+		return op, false
+	}
+}

--- a/internal/traceql/parser_metrics_expr.go
+++ b/internal/traceql/parser_metrics_expr.go
@@ -2,6 +2,7 @@ package traceql
 
 import (
 	"fmt"
+	"text/scanner"
 
 	"github.com/oteldb/oteldb/internal/traceql/lexer"
 )
@@ -18,15 +19,101 @@ func (p *parser) parseMetricsExpr(spanset Expr) (Expr, error) {
 	// Consume "|".
 	p.next()
 
-	e, err := p.parseMetricsAggregation()
+	return p.parseMetricsFirstStage(spanset)
+}
+
+// parseMetricsFirstStage parses a metrics aggregation applied to the given
+// spanset pipeline, along with its second stage operations.
+func (p *parser) parseMetricsFirstStage(spanset Expr) (MetricsExpr, error) {
+	var (
+		e   MetricsExpr
+		err error
+	)
+	if p.peek().Type == lexer.Compare {
+		e, err = p.parseCompareOperation(spanset)
+	} else {
+		e, err = p.parseMetricsAggregation(spanset)
+	}
 	if err != nil {
 		return nil, err
 	}
-	e.Spanset = spanset
 
-	e.Stages, err = p.parseMetricsStages()
+	stagesPos := p.peek().Pos
+	stages, err := p.parseMetricsStages()
 	if err != nil {
 		return nil, err
+	}
+	if len(stages) == 0 {
+		return e, nil
+	}
+	if err := checkNotCompare(e, stagesPos); err != nil {
+		return nil, err
+	}
+	return &MetricsPipeline{Expr: e, Stages: stages}, nil
+}
+
+// checkNotCompare reports an error if e is a `compare()` operation, which
+// supports neither second stage operations nor arithmetic.
+func checkNotCompare(e MetricsExpr, pos scanner.Position) error {
+	if _, ok := e.(*CompareOperation); ok {
+		return &SyntaxError{
+			Msg: "compare() does not support second stage operations and arithmetic",
+			Pos: pos,
+		}
+	}
+	return nil
+}
+
+func (p *parser) parseCompareOperation(spanset Expr) (e *CompareOperation, _ error) {
+	e = &CompareOperation{Spanset: spanset, TopN: DefaultCompareTopN}
+
+	opTok := p.next()
+	if opTok.Type != lexer.Compare {
+		return nil, p.unexpectedToken(opTok)
+	}
+
+	if err := p.consume(lexer.OpenParen); err != nil {
+		return nil, err
+	}
+
+	filter, err := p.parseSpansetFilter()
+	if err != nil {
+		return nil, err
+	}
+	e.Filter = filter
+
+	var args []int64
+	for p.peek().Type == lexer.Comma {
+		// Consume comma.
+		p.next()
+
+		arg, err := p.parseInteger()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+
+	if err := p.consume(lexer.CloseParen); err != nil {
+		return nil, err
+	}
+
+	switch len(args) {
+	case 0:
+	case 1:
+		e.TopN = int(args[0])
+	case 3:
+		e.TopN = int(args[0])
+		e.Start, e.End = args[1], args[2]
+	default:
+		return nil, &SyntaxError{
+			Msg: fmt.Sprintf("compare() takes a top N and a start and end timestamp, got %d arguments", len(args)),
+			Pos: opTok.Pos,
+		}
+	}
+
+	if err := e.validate(); err != nil {
+		return nil, &SyntaxError{Msg: err.Error(), Pos: opTok.Pos}
 	}
 	return e, nil
 }
@@ -130,8 +217,8 @@ func (p *parser) parseMetricsFilter() (e *MetricsFilter, _ error) {
 	return e, nil
 }
 
-func (p *parser) parseMetricsAggregation() (e *MetricsAggregation, _ error) {
-	e = new(MetricsAggregation)
+func (p *parser) parseMetricsAggregation(spanset Expr) (e *MetricsAggregation, _ error) {
+	e = &MetricsAggregation{Spanset: spanset}
 
 	opTok := p.next()
 	op, ok := metricsOp(opTok.Type)
@@ -213,6 +300,15 @@ func (p *parser) parseAttributeList() (attrs []Attribute, _ error) {
 		return nil, err
 	}
 	return attrs, nil
+}
+
+// isMetricsFirstStage whether tt starts a metrics aggregation.
+func isMetricsFirstStage(tt lexer.TokenType) bool {
+	if tt == lexer.Compare {
+		return true
+	}
+	_, ok := metricsOp(tt)
+	return ok
 }
 
 func metricsOp(tt lexer.TokenType) (op MetricsOp, _ bool) {

--- a/internal/traceql/parser_metrics_expr.go
+++ b/internal/traceql/parser_metrics_expr.go
@@ -1,6 +1,8 @@
 package traceql
 
 import (
+	"fmt"
+
 	"github.com/oteldb/oteldb/internal/traceql/lexer"
 )
 
@@ -21,6 +23,110 @@ func (p *parser) parseMetricsExpr(spanset Expr) (Expr, error) {
 		return nil, err
 	}
 	e.Spanset = spanset
+
+	e.Stages, err = p.parseMetricsStages()
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// parseMetricsStages parses a chain of second stage operations.
+//
+// Unlike a filter, a `topk()`/`bottomk()` operation is preceded by a pipe.
+func (p *parser) parseMetricsStages() (stages []MetricsStage, _ error) {
+	for {
+		switch t := p.peek(); t.Type {
+		case lexer.Pipe:
+			// Consume "|".
+			p.next()
+
+			stage, err := p.parseTopKOperation()
+			if err != nil {
+				return nil, err
+			}
+			stages = append(stages, stage)
+		case lexer.Eq, lexer.NotEq, lexer.Gt, lexer.Gte, lexer.Lt, lexer.Lte:
+			stage, err := p.parseMetricsFilter()
+			if err != nil {
+				return nil, err
+			}
+			stages = append(stages, stage)
+		default:
+			return stages, nil
+		}
+	}
+}
+
+func (p *parser) parseTopKOperation() (e *TopKOperation, _ error) {
+	e = new(TopKOperation)
+
+	opTok := p.next()
+	switch opTok.Type {
+	case lexer.TopK:
+		e.Op = MetricsStageOpTopK
+	case lexer.BottomK:
+		e.Op = MetricsStageOpBottomK
+	default:
+		return nil, p.unexpectedToken(opTok)
+	}
+
+	if err := p.consume(lexer.OpenParen); err != nil {
+		return nil, err
+	}
+
+	limitPos := p.peek().Pos
+	limit, err := p.parseInteger()
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, &SyntaxError{
+			Msg: fmt.Sprintf("%s limit must be greater than 0, got %d", e.Op, limit),
+			Pos: limitPos,
+		}
+	}
+	e.Limit = int(limit)
+
+	if err := p.consume(lexer.CloseParen); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func (p *parser) parseMetricsFilter() (e *MetricsFilter, _ error) {
+	e = new(MetricsFilter)
+
+	switch t := p.next(); t.Type {
+	case lexer.Eq:
+		e.Op = OpEq
+	case lexer.NotEq:
+		e.Op = OpNotEq
+	case lexer.Gt:
+		e.Op = OpGt
+	case lexer.Gte:
+		e.Op = OpGte
+	case lexer.Lt:
+		e.Op = OpLt
+	case lexer.Lte:
+		e.Op = OpLte
+	default:
+		return nil, p.unexpectedToken(t)
+	}
+
+	valuePos := p.peek().Pos
+	value, err := p.parseStatic()
+	if err != nil {
+		return nil, err
+	}
+	if !value.Type.IsNumeric() {
+		return nil, &TypeError{
+			Msg: "metrics filter value must be numeric",
+			Pos: valuePos,
+		}
+	}
+	e.Value = value
+
 	return e, nil
 }
 

--- a/internal/traceql/parser_metrics_expr.go
+++ b/internal/traceql/parser_metrics_expr.go
@@ -101,9 +101,9 @@ func (p *parser) parseCompareOperation(spanset Expr) (e *CompareOperation, _ err
 	switch len(args) {
 	case 0:
 	case 1:
-		e.TopN = int(args[0])
+		e.TopN = clampInt(args[0])
 	case 3:
-		e.TopN = int(args[0])
+		e.TopN = clampInt(args[0])
 		e.Start, e.End = args[1], args[2]
 	default:
 		return nil, &SyntaxError{
@@ -173,7 +173,7 @@ func (p *parser) parseTopKOperation() (e *TopKOperation, _ error) {
 			Pos: limitPos,
 		}
 	}
-	e.Limit = int(limit)
+	e.Limit = clampInt(limit)
 
 	if err := p.consume(lexer.CloseParen); err != nil {
 		return nil, err

--- a/internal/traceql/parser_metrics_math.go
+++ b/internal/traceql/parser_metrics_math.go
@@ -1,0 +1,208 @@
+package traceql
+
+import (
+	"text/scanner"
+
+	"github.com/oteldb/oteldb/internal/traceql/lexer"
+)
+
+// mathOperand is an operand of a metrics arithmetic expression.
+//
+// Exactly one of the fields is set: an operand is either a metrics expression
+// or a constant.
+type mathOperand struct {
+	expr   MetricsExpr
+	scalar float64
+}
+
+// tryMetricsMath tries to parse a metrics arithmetic expression.
+//
+// A metrics arithmetic expression starts either with a parenthesized sub-query
+// or with a constant, and so does a spanset query like `({a}) && {b}` or a
+// scalar filter pipeline like `1 > count()`. They are told apart by parsing:
+// unless a metrics sub-query is reached, the parser state is restored and ok
+// is false, so that the caller may parse a spanset query instead.
+func (p *parser) tryMetricsMath() (_ Expr, ok bool, _ error) {
+	save := *p
+
+	expr, err := p.parseMetricsMath()
+	if err != nil {
+		if !p.metricsSubQuery {
+			*p = save
+			return nil, false, nil
+		}
+		return nil, true, err
+	}
+	return expr, true, nil
+}
+
+func (p *parser) parseMetricsMath() (Expr, error) {
+	operand, err := p.parseMetricsMathOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	operand, err = p.parseMetricsMathExpr(operand, 0)
+	if err != nil {
+		return nil, err
+	}
+	if operand.expr == nil {
+		// A bare constant is not a metrics expression.
+		return nil, p.unexpectedToken(p.peek())
+	}
+
+	stagesPos := p.peek().Pos
+	stages, err := p.parseMetricsStages()
+	if err != nil {
+		return nil, err
+	}
+	if len(stages) == 0 {
+		return operand.expr, nil
+	}
+	if err := checkNotCompare(operand.expr, stagesPos); err != nil {
+		return nil, err
+	}
+	return &MetricsPipeline{Expr: operand.expr, Stages: stages}, nil
+}
+
+// parseMetricsMathExpr parses arithmetic operations applied to left, if any.
+func (p *parser) parseMetricsMathExpr(left mathOperand, minPrecedence int) (mathOperand, error) {
+	for {
+		op, ok := p.peekMetricsMathOp()
+		if !ok || op.Precedence() < minPrecedence {
+			return left, nil
+		}
+		// Consume op.
+		opPos := p.next().Pos
+
+		right, err := p.parseMetricsMathOperand()
+		if err != nil {
+			return left, err
+		}
+
+		for {
+			rightOp, ok := p.peekMetricsMathOp()
+			if !ok || rightOp.Precedence() <= op.Precedence() {
+				break
+			}
+
+			right, err = p.parseMetricsMathExpr(right, op.Precedence()+1)
+			if err != nil {
+				return left, err
+			}
+		}
+
+		left, err = combineMetricsMath(left, op, right, opPos)
+		if err != nil {
+			return left, err
+		}
+	}
+}
+
+// parseMetricsMathOperand parses a single operand of an arithmetic expression.
+func (p *parser) parseMetricsMathOperand() (o mathOperand, _ error) {
+	switch t := p.peek(); t.Type {
+	case lexer.Integer, lexer.Number:
+		scalar, err := p.parseFloat()
+		if err != nil {
+			return o, err
+		}
+		o.scalar = scalar
+		return o, nil
+	case lexer.OpenParen:
+		// Consume "(".
+		p.next()
+
+		// A sub-query must start with a spanset filter, anything else is
+		// a parenthesized arithmetic expression.
+		if p.peek().Type == lexer.OpenBrace {
+			expr, err := p.parseWrappedMetricsPipeline()
+			if err != nil {
+				return o, err
+			}
+			// Past this point the query is certainly an arithmetic expression,
+			// see [parser.tryMetricsMath].
+			p.metricsSubQuery = true
+			o.expr = expr
+		} else {
+			inner, err := p.parseMetricsMathOperand()
+			if err != nil {
+				return o, err
+			}
+			if o, err = p.parseMetricsMathExpr(inner, 0); err != nil {
+				return o, err
+			}
+		}
+
+		if err := p.consume(lexer.CloseParen); err != nil {
+			return o, err
+		}
+		return o, nil
+	default:
+		return o, p.unexpectedToken(t)
+	}
+}
+
+// parseWrappedMetricsPipeline parses a `<spanset pipeline> | <metrics function>`
+// sub-query, with the opening parenthesis already consumed.
+func (p *parser) parseWrappedMetricsPipeline() (MetricsExpr, error) {
+	pipeline, err := p.parsePipeline()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.consume(lexer.Pipe); err != nil {
+		return nil, err
+	}
+	return p.parseMetricsFirstStage(&SpansetPipeline{Pipeline: pipeline})
+}
+
+func combineMetricsMath(left mathOperand, op BinaryOp, right mathOperand, opPos scanner.Position) (o mathOperand, _ error) {
+	for _, e := range []MetricsExpr{left.expr, right.expr} {
+		if e == nil {
+			continue
+		}
+		if err := checkNotCompare(e, opPos); err != nil {
+			return o, err
+		}
+	}
+
+	switch {
+	case left.expr != nil && right.expr != nil:
+		o.expr = &MetricsBinaryExpr{Left: left.expr, Op: op, Right: right.expr}
+	case left.expr != nil:
+		o.expr = appendMetricsStage(left.expr, &MetricsScalarOp{Op: op, Value: right.scalar})
+	case right.expr != nil:
+		o.expr = appendMetricsStage(right.expr, &MetricsScalarOp{Op: op, Value: left.scalar, ScalarLeft: true})
+	default:
+		// Unlike Tempo, constant arithmetic is not folded at parse time.
+		return o, &SyntaxError{
+			Msg: "arithmetic between two constants is not supported",
+			Pos: opPos,
+		}
+	}
+	return o, nil
+}
+
+func appendMetricsStage(e MetricsExpr, stage MetricsStage) *MetricsPipeline {
+	if pipeline, ok := e.(*MetricsPipeline); ok {
+		pipeline.Stages = append(pipeline.Stages, stage)
+		return pipeline
+	}
+	return &MetricsPipeline{Expr: e, Stages: []MetricsStage{stage}}
+}
+
+func (p *parser) peekMetricsMathOp() (op BinaryOp, _ bool) {
+	switch p.peek().Type {
+	case lexer.Add:
+		return OpAdd, true
+	case lexer.Sub:
+		return OpSub, true
+	case lexer.Mul:
+		return OpMul, true
+	case lexer.Div:
+		return OpDiv, true
+	default:
+		return op, false
+	}
+}

--- a/internal/traceql/parser_pipeline.go
+++ b/internal/traceql/parser_pipeline.go
@@ -81,7 +81,7 @@ func (p *parser) parsePipeline() (stages []PipelineStage, rerr error) {
 		p.next()
 		// A metrics aggregation terminates the pipeline instead of being a stage
 		// of it, so leave the pipe to [parser.parseMetricsExpr].
-		if _, ok := metricsOp(p.peek().Type); ok {
+		if isMetricsFirstStage(p.peek().Type) {
 			p.unread()
 			return stages, nil
 		}
@@ -142,35 +142,44 @@ func (p *parser) parseSpansetExpr1() (SpansetExpr, error) {
 		}
 		return expr, nil
 	case lexer.OpenBrace:
-		var filter SpansetFilter
-		if t2 := p.peek(); t2.Type != lexer.CloseBrace {
-			fieldExpr, err := p.parseFieldExpr()
-			if err != nil {
-				return nil, err
-			}
-			switch fieldExpr.ValueType() {
-			case TypeBool, TypeAttribute:
-			default:
-				return nil, &TypeError{
-					Msg: "filter expression must evaluate to boolean",
-					Pos: t2.Pos,
-				}
-			}
-			filter.Expr = fieldExpr
-		} else {
-			s := &Static{}
-			s.SetBool(true)
-			filter.Expr = s
-		}
-
-		if err := p.consume(lexer.CloseBrace); err != nil {
-			return nil, err
-		}
-
-		return &filter, nil
+		p.unread()
+		return p.parseSpansetFilter()
 	default:
 		return nil, p.unexpectedToken(t)
 	}
+}
+
+// parseSpansetFilter parses a `{ ... }` spanset filter.
+func (p *parser) parseSpansetFilter() (*SpansetFilter, error) {
+	if err := p.consume(lexer.OpenBrace); err != nil {
+		return nil, err
+	}
+
+	var filter SpansetFilter
+	if t := p.peek(); t.Type != lexer.CloseBrace {
+		fieldExpr, err := p.parseFieldExpr()
+		if err != nil {
+			return nil, err
+		}
+		switch fieldExpr.ValueType() {
+		case TypeBool, TypeAttribute:
+		default:
+			return nil, &TypeError{
+				Msg: "filter expression must evaluate to boolean",
+				Pos: t.Pos,
+			}
+		}
+		filter.Expr = fieldExpr
+	} else {
+		s := &Static{}
+		s.SetBool(true)
+		filter.Expr = s
+	}
+
+	if err := p.consume(lexer.CloseBrace); err != nil {
+		return nil, err
+	}
+	return &filter, nil
 }
 
 func (p *parser) parseBinarySpansetExpr(left SpansetExpr, minPrecedence int) (SpansetExpr, error) {

--- a/internal/traceql/parser_pipeline.go
+++ b/internal/traceql/parser_pipeline.go
@@ -79,6 +79,12 @@ func (p *parser) parsePipeline() (stages []PipelineStage, rerr error) {
 		}
 		// Consume "|".
 		p.next()
+		// A metrics aggregation terminates the pipeline instead of being a stage
+		// of it, so leave the pipe to [parser.parseMetricsExpr].
+		if _, ok := metricsOp(p.peek().Type); ok {
+			p.unread()
+			return stages, nil
+		}
 		p.first = false
 	}
 }

--- a/internal/traceql/parser_test.go
+++ b/internal/traceql/parser_test.go
@@ -1298,6 +1298,11 @@ func TestParseErrors(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
+	runParseTests(t, tests)
+}
+
+func runParseTests(t *testing.T, tests []TestCase) {
+	t.Helper()
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {
 			defer func() {
@@ -1336,6 +1341,9 @@ func FuzzParse(f *testing.F) {
 	}
 	for _, tt := range spansetOpTests {
 		f.Add(fmt.Sprintf(`{ .a } %s { .b }`, tt.input))
+	}
+	for _, tt := range metricsTests {
+		f.Add(tt.input)
 	}
 	f.Fuzz(func(t *testing.T, input string) {
 		defer func() {

--- a/internal/traceql/preds.go
+++ b/internal/traceql/preds.go
@@ -34,6 +34,8 @@ func (p *predExtractor) walk(expr Expr) {
 		p.Op = SpansetOpUnion
 		p.walk(expr.Left)
 		p.walk(expr.Right)
+	case *MetricsAggregation:
+		p.walk(expr.Spanset)
 	}
 }
 

--- a/internal/traceql/preds.go
+++ b/internal/traceql/preds.go
@@ -36,6 +36,14 @@ func (p *predExtractor) walk(expr Expr) {
 		p.walk(expr.Right)
 	case *MetricsAggregation:
 		p.walk(expr.Spanset)
+	case *CompareOperation:
+		p.walk(expr.Spanset)
+	case *MetricsPipeline:
+		p.walk(expr.Expr)
+	case *MetricsBinaryExpr:
+		p.Op = SpansetOpUnion
+		p.walk(expr.Left)
+		p.walk(expr.Right)
 	}
 }
 

--- a/internal/traceql/type_test.go
+++ b/internal/traceql/type_test.go
@@ -95,6 +95,12 @@ var typeTests = []struct {
 	{`{ .foo =~ .dynamic_regex }`, nil, true},
 	{`{ .foo !~ .dynamic_regex }`, nil, true},
 	{`{ .foo =~ (.dynamic_regex + 10) }`, nil, true},
+
+	// Metrics filter value must be numeric.
+	{`{} | rate() > "10"`, nil, true},
+	{`{} | rate() > nil`, nil, true},
+	{`{} | rate() > true`, nil, true},
+	{`{} | rate() > error`, nil, true},
 }
 
 func TestTypeCheck(t *testing.T) {


### PR DESCRIPTION
Implements the TraceQL metrics query grammar in `internal/traceql`, mirroring Tempo's `pkg/traceql/expr.y`. Parser only — nothing executes yet.

## What parses

**First stage aggregations**, with an optional `by (...)` grouping:

```traceql
{ status = error } | rate() by (resource.service.name)
{} | quantile_over_time(duration, 0.9, 0.99) by (name)
{} | histogram_over_time(duration)
```

`rate`, `count_over_time`, `{min,max,sum,avg,quantile,histogram}_over_time`.

**Second stage operations.** Matching Tempo's asymmetry, `topk()`/`bottomk()` are preceded by a pipe and comparison filters are not, and both chain:

```traceql
{} | rate() > 10 | topk(3) < 100 | bottomk(2)
```

**`compare()`**, with the same validation as Tempo — 0/1/3 arguments, `TopN` within `[1, 1000]`, and `Start`/`End` (Unix nanoseconds) both set with `End > Start`. Per Tempo's docs it supports neither second stages nor arithmetic, and both are rejected.

**Arithmetic** over parenthesized sub-queries with `+ - * /` and standard precedence:

```traceql
({ status = error } | rate()) / ({} | rate())
2 * ({} | rate()) | topk(10)
```

## Notes for review

- A constant operand becomes a `MetricsScalarOp` **stage** rather than a tree node, which is how Tempo models it: it applies pointwise to one series set, unlike the series-matching join of a true binary expression.
- Second stage operations live on a `MetricsPipeline{Expr, Stages}` wrapper rather than on the aggregation, since arithmetic results take them too. `{} | rate()` stays a bare `*MetricsAggregation`; only queries with stages get wrapped.
- Both a metrics sub-query and a spanset query can start with `(` or a constant, and they diverge only at an arbitrarily distant `|`. Tempo defers this with LALR; here the parser tries arithmetic first and restores its state unless a sub-query is reached. It restores at most once and commits as soon as a sub-query parses, so malformed arithmetic still reports its own error. `({a}) && {b}`, `({a} && {b}) | rate()` and `({a}) | rate()` are locked in as test cases.
- The token const block is now append-only: the generated stringer indexes constants by position.

## Known gaps

- **No constant folding.** `> 1 + 1` and `* (2 * 3)` are rejected rather than folded — the int/float/duration arithmetic lives in `traceqlengine`, which `traceql` cannot import. Durations as arithmetic operands are rejected, as in Tempo.
- **Nothing executes.** `traceqlengine.BuildExpr` rejects every metrics node with `unexpected expression %T`. `preds.go`'s pushdown walker does recurse through the new nodes so the extractor stays total over `Expr`.

## Testing

161 subtests across `TestParseMetrics`/`TestTypeCheck`, seeded into `FuzzParse` (60s clean). Full repo build and `go test ./...` pass; `golangci-lint run ./internal/traceql/...` clean.

Generated files (`tokentype_string.go`) are committed separately from the code that produces them.

No issue filed for this work — happy to open one if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)