### PR TITLE
feat(config): expose storage.policy.retention and limits

### DIFF
--- a/cmd/oteldb/storage_backend.go
+++ b/cmd/oteldb/storage_backend.go
@@ -96,6 +96,8 @@ func setupStorageBackend(ctx context.Context, cfg StorageConfig, lg *zap.Logger,
 			zap.Int("precision_tiers", len(cfg.Policy.Precision)),
 			zap.Int("downsample_tiers", len(cfg.Policy.Downsample)),
 			zap.Bool("recompress", cfg.Policy.Recompress != nil),
+			zap.Duration("retention_max_age", retentionMaxAge(cfg.Policy.Retention)),
+			zap.Bool("limits", cfg.Policy.Limits != nil),
 		)
 	}
 

--- a/cmd/oteldb/storage_backend_test.go
+++ b/cmd/oteldb/storage_backend_test.go
@@ -139,6 +139,14 @@ func TestTenancyOption(t *testing.T) {
 				{After: 7 * 24 * time.Hour, Interval: time.Hour}, // Agg defaults to last.
 			},
 			Recompress: &RecompressConfig{After: 14 * 24 * time.Hour, Level: 9},
+			Retention:  &RetentionConfig{MaxAge: 90 * 24 * time.Hour, MaxBytes: 1 << 30},
+			Limits: &LimitsConfig{
+				IngestBytesPerSecond: 10 << 20,
+				MaxInFlightBytes:     64 << 20,
+				MaxSeries:            1_000_000,
+				MaxSeriesSoft:        800_000,
+				MaxPartSize:          32 << 20,
+			},
 		})
 		require.NoError(t, err)
 		o := applyOption(t, opt)
@@ -159,11 +167,54 @@ func TestTenancyOption(t *testing.T) {
 
 		require.Equal(t, 14*24*time.Hour, p.Recompress.After)
 		require.Equal(t, 9, p.Recompress.Level)
+
+		require.Equal(t, 90*24*time.Hour, p.Retention.MaxAge)
+		require.Equal(t, int64(1<<30), p.Retention.MaxBytes)
+
+		require.Equal(t, int64(10<<20), p.Limits.IngestBytesPerSecond)
+		require.Equal(t, int64(64<<20), p.Limits.MaxInFlightBytes)
+		require.Equal(t, int64(1_000_000), p.Limits.MaxSeries)
+		require.Equal(t, int64(800_000), p.Limits.MaxSeriesSoft)
+		require.Equal(t, int64(32<<20), p.Limits.MaxPartSize)
+	})
+
+	t.Run("RetentionOnlyInstallsResolver", func(t *testing.T) {
+		opt, err := tenancyOption(&StoragePolicyConfig{
+			Retention: &RetentionConfig{MaxAge: 14 * 24 * time.Hour},
+		})
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.NotNil(t, o.Tenancy, "a retention-only policy must still install a resolver")
+		require.Equal(t, 14*24*time.Hour, o.Tenancy.Resolve("default").Retention.MaxAge)
+	})
+
+	t.Run("LimitsOnlyInstallsResolver", func(t *testing.T) {
+		opt, err := tenancyOption(&StoragePolicyConfig{
+			Limits: &LimitsConfig{MaxSeries: 1000},
+		})
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.NotNil(t, o.Tenancy)
+		require.Equal(t, int64(1000), o.Tenancy.Resolve("default").Limits.MaxSeries)
 	})
 
 	t.Run("UnknownAggIsAnError", func(t *testing.T) {
 		_, err := tenancyOption(&StoragePolicyConfig{
 			Downsample: []DownsampleTierConfig{{Interval: time.Minute, Agg: "median"}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("NegativeRetentionIsAnError", func(t *testing.T) {
+		_, err := tenancyOption(&StoragePolicyConfig{
+			Retention: &RetentionConfig{MaxAge: -time.Hour},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("SoftSeriesAboveHardIsAnError", func(t *testing.T) {
+		_, err := tenancyOption(&StoragePolicyConfig{
+			Limits: &LimitsConfig{MaxSeries: 100, MaxSeriesSoft: 200},
 		})
 		require.Error(t, err)
 	})
@@ -187,6 +238,13 @@ storage:
     recompress:
       after: 336h
       level: 9
+    retention:
+      max_age: 720h
+      max_bytes: 100GB
+    limits:
+      ingest_bytes_per_second: 10MB
+      max_series: 1000000
+      max_series_soft: 800000
 `
 	f, err := os.CreateTemp("", "oteldb.yml")
 	require.NoError(t, err)
@@ -211,6 +269,11 @@ storage:
 	require.Equal(t, signal.AggAvg, p.Downsample.Tiers[0].Agg)
 	require.Equal(t, 336*time.Hour, p.Recompress.After)
 	require.Equal(t, 9, p.Recompress.Level)
+	require.Equal(t, 720*time.Hour, p.Retention.MaxAge)
+	require.Equal(t, int64(100_000_000_000), p.Retention.MaxBytes)
+	require.Equal(t, int64(10_000_000), p.Limits.IngestBytesPerSecond)
+	require.Equal(t, int64(1_000_000), p.Limits.MaxSeries)
+	require.Equal(t, int64(800_000), p.Limits.MaxSeriesSoft)
 }
 
 func TestS3Backend(t *testing.T) {

--- a/cmd/oteldb/storage_policy.go
+++ b/cmd/oteldb/storage_policy.go
@@ -8,6 +8,8 @@ import (
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/signal"
 	"github.com/oteldb/storage/tenant"
+
+	"github.com/oteldb/oteldb/internal/xbytes"
 )
 
 // StoragePolicyConfig configures the per-tenant storage policy applied to the embedded engine's
@@ -27,6 +29,12 @@ type StoragePolicyConfig struct {
 	// Recompress rewrites fully-cold parts (older than After) with a higher-ratio Zstandard profile
 	// at merge, trading merge CPU for storage. It is decode-transparent. Nil ⇒ disabled.
 	Recompress *RecompressConfig `json:"recompress" yaml:"recompress"`
+	// Retention bounds how long data is kept: parts older than MaxAge are dropped whole at merge.
+	// Nil ⇒ retain forever.
+	Retention *RetentionConfig `json:"retention" yaml:"retention"`
+	// Limits are the operational admission-control limits: over-budget writes are shed and reported
+	// as OTLP partial success rather than buffered. Nil ⇒ unlimited.
+	Limits *LimitsConfig `json:"limits" yaml:"limits"`
 }
 
 // PrecisionTierConfig is one age band of the lossy float-precision policy.
@@ -57,9 +65,53 @@ type RecompressConfig struct {
 	Level int `json:"level" yaml:"level"`
 }
 
+// RetentionConfig configures age-based retention. Enforcement drops whole partitions at merge, so
+// data may outlive MaxAge until the partition containing it is fully expired.
+type RetentionConfig struct {
+	// MaxAge is the maximum age of retained data. Zero ⇒ retain forever.
+	MaxAge time.Duration `json:"max_age" yaml:"max_age"`
+	// MaxBytes is the maximum total retained bytes. Zero ⇒ unlimited.
+	//
+	// Accepted and passed through, but the storage library does not enforce it yet
+	// (oteldb/storage#224): setting it alone bounds nothing. Use MaxAge to bound disk growth.
+	MaxBytes xbytes.Bytes `json:"max_bytes" yaml:"max_bytes"`
+}
+
+// LimitsConfig configures the per-tenant operational limits. They are lossless admission control:
+// over-budget samples are shed and reported via OTLP partial success (RESOURCE_EXHAUSTED), so an
+// overload degrades rather than OOMs. Zero values mean "no limit".
+type LimitsConfig struct {
+	// IngestBytesPerSecond caps the ingest rate (a token bucket bursting to one second of budget).
+	IngestBytesPerSecond xbytes.Bytes `json:"ingest_bytes_per_second" yaml:"ingest_bytes_per_second"`
+	// MaxInFlightBytes caps the unflushed in-flight bytes buffered before backpressure sheds.
+	MaxInFlightBytes xbytes.Bytes `json:"max_in_flight_bytes" yaml:"max_in_flight_bytes"`
+	// MaxSeries is the hard active-series cardinality ceiling: a sample minting a new series past
+	// it is shed (or routed to overflow, see MaxSeriesSoft). Existing series are unaffected.
+	MaxSeries int64 `json:"max_series" yaml:"max_series"`
+	// MaxSeriesSoft, when 0 < MaxSeriesSoft <= MaxSeries, is a soft cardinality budget: past it a
+	// new series' samples go to a synthetic per-metric overflow series instead of being shed, until
+	// MaxSeries is reached. Metrics only.
+	MaxSeriesSoft int64 `json:"max_series_soft" yaml:"max_series_soft"`
+	// MaxPartSize caps an immutable part's approximate uncompressed size; flush and merge split
+	// their output to respect it. It is structural: fixed when the tenant's engine is created.
+	MaxPartSize xbytes.Bytes `json:"max_part_size" yaml:"max_part_size"`
+}
+
+// retentionMaxAge reports the configured retention window, or zero when retention is disabled.
+func retentionMaxAge(cfg *RetentionConfig) time.Duration {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.MaxAge
+}
+
 // empty reports whether the policy configures nothing, in which case no resolver is installed.
 func (cfg *StoragePolicyConfig) empty() bool {
-	return cfg == nil || (len(cfg.Precision) == 0 && len(cfg.Downsample) == 0 && cfg.Recompress == nil)
+	return cfg == nil || (len(cfg.Precision) == 0 &&
+		len(cfg.Downsample) == 0 &&
+		cfg.Recompress == nil &&
+		cfg.Retention == nil &&
+		cfg.Limits == nil)
 }
 
 // tenancyOption builds the storage tenancy option from the policy config, or returns (nil, nil)
@@ -110,6 +162,30 @@ func (cfg *StoragePolicyConfig) policy() (tenant.Policy, error) {
 
 	if r := cfg.Recompress; r != nil {
 		p.Recompress = tenant.Recompress{After: r.After, Level: r.Level}
+	}
+
+	if r := cfg.Retention; r != nil {
+		if r.MaxAge < 0 {
+			return tenant.Policy{}, errors.New("retention: max_age must not be negative")
+		}
+		p.Retention = tenant.Retention{
+			MaxAge:   r.MaxAge,
+			MaxBytes: int64(r.MaxBytes),
+		}
+	}
+
+	if l := cfg.Limits; l != nil {
+		if l.MaxSeriesSoft > 0 && l.MaxSeries > 0 && l.MaxSeriesSoft > l.MaxSeries {
+			return tenant.Policy{}, errors.Errorf("limits: max_series_soft (%d) must not exceed max_series (%d)",
+				l.MaxSeriesSoft, l.MaxSeries)
+		}
+		p.Limits = tenant.Limits{
+			IngestBytesPerSecond: int64(l.IngestBytesPerSecond),
+			MaxInFlightBytes:     int64(l.MaxInFlightBytes),
+			MaxSeries:            l.MaxSeries,
+			MaxSeriesSoft:        l.MaxSeriesSoft,
+			MaxPartSize:          int64(l.MaxPartSize),
+		}
 	}
 
 	return p, nil

--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -92,8 +92,12 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
   compression) through oteldb's per-tenant resolver, alongside Downsample/Recompress.
   **Implemented** in `cmd/oteldb/storage_policy.go` (`tenancyOption` → `storage.WithTenancy`):
   the `storage.policy` config block exposes `precision[]{after,bits}`,
-  `downsample[]{after,interval,agg}`, and `recompress{after,level}`. oteldb runs the embedded
-  engine single-tenant, so a static `tenant.ResolverFunc` returns one policy for every tenant.
+  `downsample[]{after,interval,agg}`, `recompress{after,level}`, `retention{max_age,max_bytes}`
+  and `limits{ingest_bytes_per_second,max_in_flight_bytes,max_series,max_series_soft,max_part_size}`.
+  oteldb runs the embedded engine single-tenant, so a static `tenant.ResolverFunc` returns one
+  policy for every tenant — retention is therefore one global window, not per-tenant.
+  `retention.max_bytes` parses and passes through but the library does not enforce it yet
+  (oteldb/storage#224); `max_age` is the knob that actually bounds disk growth.
 - **Sampling weights:** honour `fetch.Batch.ScaleFactors` in PromQL `sum`/`rate`/`count` for
   sampled tenants. The aggregate sidecar is skipped for sampled parts, so those fall back to a
   weighted raw fold. **Not implemented.** oteldb does not yet expose a `tenant.Sampling` policy,


### PR DESCRIPTION
Fixes #1195.

`StoragePolicyConfig` mapped only `Precision`, `Downsample` and `Recompress` into `tenant.Policy`, so `Retention` was always zero — retain forever, with no supported way to bound disk growth on a storage-backed oteldb. `tenant.Limits` was equally unreachable.

- add `RetentionConfig{max_age, max_bytes}` and `LimitsConfig{ingest_bytes_per_second, max_in_flight_bytes, max_series, max_series_soft, max_part_size}`, mapped in `(*StoragePolicyConfig).policy()`
- byte-valued fields use `xbytes.Bytes`, so `100GB` / `10MB` parse
- `empty()` now accounts for both, so a retention-only block still installs the resolver
- validate negative `max_age` and `max_series_soft > max_series` as startup errors
- log `retention_max_age` and whether limits are set at startup

```yaml
storage:
  policy:
    retention:
      max_age: 336h
```

`retention.max_bytes` parses and passes through but the storage library does not read it yet (oteldb/storage#224) — `max_age` is the knob that actually bounds growth. Noted in the field doc and in `docs/storage-integration.md`.

Since oteldb runs the embedded engine single-tenant, this is one global retention window; per-tenant policy remains #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)