### PR TITLE
fix(chstorage): stop mutating shared series labels in rateSelector

### DIFF
--- a/internal/chstorage/querier_metrics_rate.go
+++ b/internal/chstorage/querier_metrics_rate.go
@@ -276,8 +276,10 @@ func (o *rateSelector) loadSeries(ctx context.Context) error {
 			if !o.filter.Matches(s) {
 				continue
 			}
-			s.labels = extlabels.DropReserved(s.labels, b)
-			o.series = append(o.series, s.labels)
+			// s is a pointer into querySeriesSingleflight's shared, cached result, so it
+			// must not be mutated here: concurrent identical queries hold the same
+			// *series[pointData] and would race on a s.labels write.
+			o.series = append(o.series, extlabels.DropReserved(s.labels, b))
 			o.pointSeries = append(o.pointSeries, s)
 		}
 		numSeries := int64(len(o.series))


### PR DESCRIPTION
## Summary
- Investigated the sporadic CI failure in [run 30506013902 / job 90755817394](https://github.com/oteldb/oteldb/actions/runs/30506013902/job/90755817394) (`unexpected panic: runtime error: slice bounds out of range`) during the PromQL bench step.
- Root cause: `rateSelector.loadSeries` (used for `rate`/`irate`/`increase`/`delta`/`idelta` pushdown) wrote `s.labels = extlabels.DropReserved(s.labels, b)` back onto `*series[pointData]`, a value shared across concurrent identical queries via `querySeriesSingleflight`'s cache. Two concurrent requests for the same query raced on that write, corrupting the stringlabels-encoded `labels.Labels` and panicking inside `labels.Range`/`decodeString`.
- Fix: keep the derived labels local instead of writing back into the shared pointer — the same pattern already used correctly in `vectorSelector.loadSeries` (`querier_metrics_scanners.go`).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/chstorage/...`
- [x] Reproduced locally: spun up `dev/local/ch-bench-read`, replayed the fixed `req.rwq` dataset, then ran `otelbench promql bench --concurrent --jobs 16-24` against the offending query (`sum by(instance) (irate(...)) / on(instance) group_left sum by(instance) (irate(...))`). Panicked within 1-2 rounds before the fix; clean across 9 rounds (up to 24 concurrent workers, 90s each) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)